### PR TITLE
Route preview state

### DIFF
--- a/examples/src/main/res/layout/layout_activity_navigation.xml
+++ b/examples/src/main/res/layout/layout_activity_navigation.xml
@@ -13,6 +13,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/navigate"
+        android:visibility="invisible"
+        android:text="Navigate"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <androidx.cardview.widget.CardView
         android:id="@+id/tripProgressCard"
         android:layout_width="0dp"

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
@@ -98,17 +98,11 @@ class PreviewRoutesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
         val routes = RoutesProvider.dc_short_with_alternative(activity).toNavigationRoutes()
         pushPrimaryRouteOriginAsLocation(routes)
         mapboxNavigation.startTripSession()
-        val previewedRouteDeferred = async {
-            mapboxNavigation.waitForPreviewRoute()
-        }
         mapboxNavigation.previewNavigationRoutes(routes)
-        previewedRouteDeferred.await()
-        val activeGuidanceRouteUpdateDefer = async {
-            mapboxNavigation.waitForNewRoute()
-        }
+        mapboxNavigation.waitForPreviewRoute()
 
         mapboxNavigation.setNavigationRoutes(mapboxNavigation.getPreviewedNavigationRoutes())
-        val activeGuidanceRouteUpdate = activeGuidanceRouteUpdateDefer.await()
+        val activeGuidanceRouteUpdate = mapboxNavigation.waitForNewRoute()
 
         assertEquals(RoutesExtra.ROUTES_UPDATE_REASON_NEW, activeGuidanceRouteUpdate.reason)
         assertEquals(routes, activeGuidanceRouteUpdate.navigationRoutes)

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
@@ -67,15 +67,11 @@ class PreviewRoutesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
         val routes = RoutesProvider.dc_very_short(activity).toNavigationRoutes()
         pushPrimaryRouteOriginAsLocation(routes)
         mapboxNavigation.startTripSession()
-        val previewedRouteDeffer = async {
-            mapboxNavigation.waitForPreviewRoute()
-        }
 
         mapboxNavigation.previewNavigationRoutes(routes)
+        val previewRouteUpdate = mapboxNavigation.waitForPreviewRoute()
 
-        val previewRouteUpdate = previewedRouteDeffer.await()
         assertEquals(routes, previewRouteUpdate.navigationRoutes)
-        assertEquals(RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW, previewRouteUpdate.reason)
         assertEquals(routes, mapboxNavigation.getPreviewedNavigationRoutes())
         assertEquals(emptyList<NavigationRoute>(), mapboxNavigation.getNavigationRoutes())
         assertIs<NavigationSessionState.FreeDrive>(mapboxNavigation.getNavigationSessionState())

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
@@ -63,7 +63,7 @@ class PreviewRoutesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
     }
 
     @Test
-    fun preview_route() = sdkTest {
+    fun preview_route_from_free_drive() = sdkTest {
         val routes = RoutesProvider.dc_very_short(activity).toNavigationRoutes()
         pushPrimaryRouteOriginAsLocation(routes)
         mapboxNavigation.startTripSession()
@@ -79,10 +79,9 @@ class PreviewRoutesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
     }
 
     @Test
-    fun preview_route_with_alternative() = sdkTest {
+    fun preview_route_with_alternative_from_idle() = sdkTest {
         val routes = RoutesProvider.dc_short_with_alternative(activity).toNavigationRoutes()
         pushPrimaryRouteOriginAsLocation(routes)
-        mapboxNavigation.startTripSession()
 
         mapboxNavigation.previewNavigationRoutes(routes)
         val previewRouteUpdate = mapboxNavigation.waitForPreviewRoute()

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
@@ -1,0 +1,141 @@
+package com.mapbox.navigation.instrumentation_tests.core
+
+import android.location.Location
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.directions.session.RoutesExtra
+import com.mapbox.navigation.core.trip.session.NavigationSessionState
+import com.mapbox.navigation.core.trip.session.NavigationSessionStateV2
+import com.mapbox.navigation.instrumentation_tests.activity.EmptyTestActivity
+import com.mapbox.navigation.instrumentation_tests.utils.MapboxNavigationRule
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.sdkTest
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.waitForNewRoute
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.waitForPreviewRoute
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.waitForRoutesCleanUp
+import com.mapbox.navigation.instrumentation_tests.utils.routes.RoutesProvider
+import com.mapbox.navigation.instrumentation_tests.utils.routes.RoutesProvider.toNavigationRoutes
+import com.mapbox.navigation.testing.ui.BaseTest
+import com.mapbox.navigation.testing.ui.utils.getMapboxAccessTokenFromResources
+import com.mapbox.navigation.testing.ui.utils.runOnMainSync
+import kotlinx.coroutines.async
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.Objects
+import kotlin.reflect.typeOf
+
+class PreviewRoutesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.java) {
+
+    override fun setupMockLocation(): Location = mockLocationUpdatesRule.generateLocationUpdate {
+        latitude = 38.894721
+        longitude = -77.031991
+    }
+
+    @get:Rule
+    val mapboxNavigationRule = MapboxNavigationRule()
+    private lateinit var mapboxNavigation: MapboxNavigation
+
+    @Before
+    fun setUp() {
+        runOnMainSync {
+            mapboxNavigation = MapboxNavigationProvider.create(
+                NavigationOptions.Builder(activity)
+                    .accessToken(getMapboxAccessTokenFromResources(activity))
+                    .build()
+            )
+        }
+    }
+
+    @Test
+    fun preview_route() = sdkTest {
+        val routes = RoutesProvider.dc_very_short(activity).toNavigationRoutes()
+        mapboxNavigation.startTripSession()
+        val previewedRouteDeffer = async {
+            mapboxNavigation.waitForPreviewRoute()
+        }
+
+        mapboxNavigation.previewNavigationRoutes(routes)
+
+        val previewRouteUpdate = previewedRouteDeffer.await()
+        assertEquals(routes, previewRouteUpdate.navigationRoutes)
+        assertEquals(RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW, previewRouteUpdate.reason)
+        assertEquals(routes, mapboxNavigation.getPreviewedNavigationRoutes())
+        assertEquals(emptyList<NavigationRoute>(), mapboxNavigation.getNavigationRoutes())
+        assertIs<NavigationSessionState.FreeDrive>(mapboxNavigation.getNavigationSessionState())
+        assertIs<NavigationSessionStateV2.RoutePreview>(mapboxNavigation.getNavigationSessionStateV2())
+    }
+
+    @Test
+    fun preview_route_with_alternative() = sdkTest {
+        val routes = RoutesProvider.dc_short_with_alternative(activity).toNavigationRoutes()
+        mapboxNavigation.startTripSession()
+        val previewedRouteDeffer = async {
+            mapboxNavigation.waitForPreviewRoute()
+        }
+
+        mapboxNavigation.previewNavigationRoutes(routes)
+
+        val previewRouteUpdate = previewedRouteDeffer.await()
+        val previewedRouteMetadata = mapboxNavigation.getAlternativeMetadataFor(
+            previewRouteUpdate.navigationRoutes[1]
+        )
+        assertNotNull(previewedRouteMetadata)
+    }
+
+    @Test
+    fun start_active_guidance_after_preview() = sdkTest {
+        val routes = RoutesProvider.dc_short_with_alternative(activity).toNavigationRoutes()
+        mapboxNavigation.startTripSession()
+        val previewedRouteDeferred = async {
+            mapboxNavigation.waitForPreviewRoute()
+        }
+        mapboxNavigation.previewNavigationRoutes(routes)
+        previewedRouteDeferred.await()
+        val activeGuidanceRouteUpdateDefer = async {
+            mapboxNavigation.waitForNewRoute()
+        }
+
+        mapboxNavigation.setNavigationRoutes(mapboxNavigation.getPreviewedNavigationRoutes())
+
+        val activeGuidanceRouteUpdate = activeGuidanceRouteUpdateDefer.await()
+        assertEquals(RoutesExtra.ROUTES_UPDATE_REASON_NEW, activeGuidanceRouteUpdate.reason)
+        assertEquals(routes, activeGuidanceRouteUpdate.navigationRoutes)
+
+        assertIs<NavigationSessionState.ActiveGuidance>(mapboxNavigation.getNavigationSessionState())
+        assertIs<NavigationSessionStateV2.ActiveGuidance>(mapboxNavigation.getNavigationSessionStateV2())
+    }
+
+    @Test
+    fun switch_to_free_drive_after_preview() = sdkTest {
+        val routes = RoutesProvider.dc_very_short(activity).toNavigationRoutes()
+        mapboxNavigation.startTripSession()
+        val previewedRouteDeffer = async {
+            mapboxNavigation.waitForPreviewRoute()
+        }
+        mapboxNavigation.previewNavigationRoutes(routes)
+        previewedRouteDeffer.await()
+        val freeDriveRoutesUpdateDeferred = async {
+            mapboxNavigation.waitForRoutesCleanUp()
+        }
+
+        mapboxNavigation.clearRoutes()
+
+        val freeDriveRoutesUpdate = freeDriveRoutesUpdateDeferred.await()
+        assertEquals(emptyList<NavigationRoute>(), freeDriveRoutesUpdate.navigationRoutes)
+        assertEquals(emptyList<NavigationRoute>(), mapboxNavigation.getNavigationRoutes())
+        assertIs<NavigationSessionState.FreeDrive>(mapboxNavigation.getNavigationSessionState())
+        assertIs<NavigationSessionStateV2.FreeDrive>(mapboxNavigation.getNavigationSessionStateV2())
+    }
+}
+
+private inline fun <reified T> assertIs(obj: Any) {
+    assertTrue(
+        "expected an instance of ${T::class.java.name}, but it is $obj (${obj.javaClass.name})",
+        obj is T
+    )
+}

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
@@ -104,7 +104,6 @@ class PreviewRoutesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
         mapboxNavigation.setNavigationRoutes(mapboxNavigation.getPreviewedNavigationRoutes())
         val activeGuidanceRouteUpdate = mapboxNavigation.waitForNewRoute()
 
-        assertEquals(RoutesExtra.ROUTES_UPDATE_REASON_NEW, activeGuidanceRouteUpdate.reason)
         assertEquals(routes, activeGuidanceRouteUpdate.navigationRoutes)
         assertIs<NavigationSessionState.ActiveGuidance>(mapboxNavigation.getNavigationSessionState())
         assertIs<NavigationSessionStateV2.ActiveGuidance>(mapboxNavigation.getNavigationSessionStateV2())

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
@@ -83,16 +83,13 @@ class PreviewRoutesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
         val routes = RoutesProvider.dc_short_with_alternative(activity).toNavigationRoutes()
         pushPrimaryRouteOriginAsLocation(routes)
         mapboxNavigation.startTripSession()
-        val previewedRouteDeffer = async {
-            mapboxNavigation.waitForPreviewRoute()
-        }
 
         mapboxNavigation.previewNavigationRoutes(routes)
-
-        val previewRouteUpdate = previewedRouteDeffer.await()
+        val previewRouteUpdate = mapboxNavigation.waitForPreviewRoute()
         val previewedRouteMetadata = mapboxNavigation.getAlternativeMetadataFor(
             previewRouteUpdate.navigationRoutes[1]
         )
+
         assertNotNull(previewedRouteMetadata)
     }
 

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
@@ -131,6 +131,20 @@ class PreviewRoutesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
         assertIs<NavigationSessionState.FreeDrive>(mapboxNavigation.getNavigationSessionState())
         assertIs<NavigationSessionStateV2.FreeDrive>(mapboxNavigation.getNavigationSessionStateV2())
     }
+
+    @Test
+    fun start_preview_after_active_guidance() = sdkTest {
+        val routes = RoutesProvider.dc_short_with_alternative(activity).toNavigationRoutes()
+        mapboxNavigation.startTripSession()
+        mapboxNavigation.setNavigationRoutes(routes)
+        mapboxNavigation.waitForNewRoute()
+
+        mapboxNavigation.previewNavigationRoutes(mapboxNavigation.getNavigationRoutes())
+        mapboxNavigation.waitForPreviewRoute()
+
+        assertIs<NavigationSessionState.FreeDrive>(mapboxNavigation.getNavigationSessionState())
+        assertIs<NavigationSessionStateV2.RoutePreview>(mapboxNavigation.getNavigationSessionStateV2())
+    }
 }
 
 private inline fun <reified T> assertIs(obj: Any) {

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/PreviewRoutesTest.kt
@@ -115,18 +115,12 @@ class PreviewRoutesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.j
         val routes = RoutesProvider.dc_very_short(activity).toNavigationRoutes()
         pushPrimaryRouteOriginAsLocation(routes)
         mapboxNavigation.startTripSession()
-        val previewedRouteDeffer = async {
-            mapboxNavigation.waitForPreviewRoute()
-        }
         mapboxNavigation.previewNavigationRoutes(routes)
-        previewedRouteDeffer.await()
-        val freeDriveRoutesUpdateDeferred = async {
-            mapboxNavigation.waitForRoutesCleanUp()
-        }
+        mapboxNavigation.waitForPreviewRoute()
 
         mapboxNavigation.clearRoutes()
+        val freeDriveRoutesUpdate = mapboxNavigation.waitForRoutesCleanUp()
 
-        val freeDriveRoutesUpdate = freeDriveRoutesUpdateDeferred.await()
         assertEquals(emptyList<NavigationRoute>(), freeDriveRoutesUpdate.navigationRoutes)
         assertEquals(emptyList<NavigationRoute>(), mapboxNavigation.getNavigationRoutes())
         assertIs<NavigationSessionState.FreeDrive>(mapboxNavigation.getNavigationSessionState())

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/TestUtils.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/TestUtils.kt
@@ -100,18 +100,24 @@ suspend fun MapboxNavigation.setNavigationRoutesAndWaitForAlternativesUpdate(
         waitForAlternativeRoute()
     }
 
-suspend fun MapboxNavigation.waitForNewRoute() {
+suspend fun MapboxNavigation.waitForNewRoute(): RoutesUpdatedResult =
     waitForRoutesUpdate(RoutesExtra.ROUTES_UPDATE_REASON_NEW)
-}
+
+suspend fun MapboxNavigation.waitForRoutesCleanUp(): RoutesUpdatedResult =
+    waitForRoutesUpdate(RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP)
 
 suspend fun MapboxNavigation.waitForAlternativeRoute() {
     waitForRoutesUpdate(RoutesExtra.ROUTES_UPDATE_REASON_ALTERNATIVE)
 }
 
+suspend fun MapboxNavigation.waitForPreviewRoute(): RoutesUpdatedResult {
+    return waitForRoutesUpdate(RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW)
+}
+
 private suspend fun MapboxNavigation.waitForRoutesUpdate(
     @RoutesExtra.RoutesUpdateReason reason: String
-) {
-    routesUpdates()
+): RoutesUpdatedResult {
+    return routesUpdates()
         .filter { it.reason == reason }
         .first()
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -1726,7 +1726,9 @@ class MapboxNavigation @VisibleForTesting internal constructor(
     private fun createInternalRoutesObserver() = RoutesObserver { result ->
         latestLegIndex = null
         currentIndicesProvider.clear()
-        if (result.navigationRoutes.isNotEmpty()) {
+        if (result.navigationRoutes.isNotEmpty()
+            && result.reason != RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW
+        ) {
             routeScope.launch {
                 val refreshed = routeRefreshController.refresh(
                     result.navigationRoutes

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -657,6 +657,14 @@ class MapboxNavigation @VisibleForTesting internal constructor(
      * @see [registerNavigationSessionStateObserver]
      */
     fun getNavigationSessionState(): NavigationSessionState = navigationSession.state
+
+    /**
+     * Provides the current navigation session state.
+     * Replacement of [MapboxNavigation.getNavigationSessionState] which to be depricated.
+     *
+     * @return current [NavigationSessionStateV2]
+     */
+    @ExperimentalPreviewMapboxNavigationAPI
     fun getNavigationSessionStateV2(): NavigationSessionStateV2 = navigationSession.stateV2
 
     /**
@@ -1012,6 +1020,13 @@ class MapboxNavigation @VisibleForTesting internal constructor(
      */
     fun getNavigationRoutes(): List<NavigationRoute> = directionsSession.routes
 
+    /**
+     * Get a list of previewed routes.
+     *
+     * If the list is not empty, the route at index 0 is the one treated as the primary route.
+     *
+     * @return a list of [NavigationRoute]s
+     */
     fun getPreviewedNavigationRoutes(): List<NavigationRoute> = directionsSession.previewedRoutes
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -852,7 +852,8 @@ class MapboxNavigation @VisibleForTesting internal constructor(
     ) {
         internalSetNavigationRoutes(
             emptyList(),
-            BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP, 0)
+            BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP, 0),
+            updateRoutesInDirectionSession = false
         )
         threadController.getMainScopeAndRootJob().scope.launch(Dispatchers.Main.immediate) {
             routeUpdateMutex.withLock {
@@ -909,6 +910,7 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         routes: List<NavigationRoute>,
         setRoutesInfo: SetRoutesInfo,
         callback: RoutesSetCallback? = null,
+        updateRoutesInDirectionSession: Boolean = true
     ) {
         rerouteController?.interrupt()
         restartRouteScope()
@@ -925,7 +927,9 @@ class MapboxNavigation @VisibleForTesting internal constructor(
                                     processedRoute.route.routeId == passedRoute.id
                                 }
                             }
-                        directionsSession.setRoutes(processedRoutes.routes, setRoutesInfo)
+                        if (updateRoutesInDirectionSession) {
+                            directionsSession.setRoutes(processedRoutes.routes, setRoutesInfo)
+                        }
                         routesSetResult = ExpectedFactory.createValue(
                             RoutesSetSuccess(
                                 ignoredAlternatives.associate {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -850,6 +850,10 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         routes: List<NavigationRoute>,
         initialLegIndex: Int = 0,
     ) {
+        internalSetNavigationRoutes(
+            emptyList(),
+            BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP, 0)
+        )
         threadController.getMainScopeAndRootJob().scope.launch(Dispatchers.Main.immediate) {
             routeUpdateMutex.withLock {
                 val alternatives = routes.drop(1)
@@ -861,7 +865,10 @@ class MapboxNavigation @VisibleForTesting internal constructor(
                     routes,
                     routesData.alternativeRoutes()
                 )
-                directionsSession.setRoutes(routes, BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW, initialLegIndex))
+                directionsSession.setRoutes(
+                    routes,
+                    BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW, initialLegIndex)
+                )
             }
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/DirectionsSession.kt
@@ -16,6 +16,8 @@ internal interface DirectionsSession : RouteRefresh {
      */
     val routes: List<NavigationRoute>
 
+    val previewedRoutes: List<NavigationRoute>
+
     val initialLegIndex: Int
 
     fun setRoutes(

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -37,6 +37,8 @@ internal class MapboxDirectionsSession(
             routesInitialized = true
         }
 
+    override var previewedRoutes: List<NavigationRoute> = emptyList()
+
     private var routesInitialized = false
 
     @RoutesExtra.RoutesUpdateReason
@@ -50,11 +52,21 @@ internal class MapboxDirectionsSession(
         setRoutesInfo: SetRoutesInfo,
     ) {
         this.initialLegIndex = setRoutesInfo.legIndex
-        if (routesInitialized && this.routes.isEmpty() && routes.isEmpty()) {
+        if (
+            routesInitialized
+            && this.routes.isEmpty() && this.previewedRoutes.isEmpty()
+            && routes.isEmpty()
+        ) {
             return
         }
         RouteCompatibilityCache.setDirectionsSessionResult(routes)
-        this.routes = routes
+        if (setRoutesInfo.reason == RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW) {
+            this.previewedRoutes = routes
+            this.routes = emptyList()
+        } else {
+            this.routes = routes
+            this.previewedRoutes = emptyList()
+        }
         this.routesUpdateReason = setRoutesInfo.reason
         routesObservers.forEach {
             it.onRoutesChanged(

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSession.kt
@@ -140,6 +140,9 @@ internal class MapboxDirectionsSession(
     override fun registerRoutesObserver(routesObserver: RoutesObserver) {
         routesObservers.add(routesObserver)
         if (routesInitialized) {
+            val routes = if (routesUpdateReason == RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW) {
+                previewedRoutes
+            } else routes
             routesObserver.onRoutesChanged(RoutesUpdatedResult(routes, routesUpdateReason))
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesExtra.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesExtra.kt
@@ -19,6 +19,9 @@ object RoutesExtra {
      */
     const val ROUTES_UPDATE_REASON_NEW = "ROUTES_UPDATE_REASON_NEW"
 
+
+    const val ROUTES_UPDATE_REASON_PREVIEW = "ROUTES_UPDATE_REASON_PREVIEW"
+
     /**
      * Routes update reason is **alternative routes**.
      * @see [RoutesObserver]
@@ -48,6 +51,7 @@ object RoutesExtra {
         ROUTES_UPDATE_REASON_ALTERNATIVE,
         ROUTES_UPDATE_REASON_REROUTE,
         ROUTES_UPDATE_REASON_REFRESH,
+        ROUTES_UPDATE_REASON_PREVIEW,
     )
     annotation class RoutesUpdateReason
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSession.kt
@@ -188,6 +188,9 @@ sealed class NavigationSessionStateV2 {
         override val sessionId: String
     ) : NavigationSessionStateV2()
 
+    /**
+     * Route preview state
+     */
     data class RoutePreview internal constructor(
         override val sessionId: String
     ) : NavigationSessionStateV2()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSession.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.trip.session
 
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.directions.session.RoutesExtra
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesUpdatedResult
 import com.mapbox.navigation.core.history.MapboxHistoryRecorder
@@ -12,6 +13,7 @@ import java.util.concurrent.CopyOnWriteArraySet
 internal class NavigationSession : RoutesObserver, TripSessionStateObserver {
 
     private val stateObservers = CopyOnWriteArraySet<NavigationSessionStateObserver>()
+    private val stateObserversV2 = CopyOnWriteArraySet<NavigationSessionStateObserverV2>()
 
     internal var state: NavigationSessionState = Idle
         set(value) {
@@ -23,13 +25,17 @@ internal class NavigationSession : RoutesObserver, TripSessionStateObserver {
             stateObservers.forEach { it.onNavigationSessionStateChanged(value) }
         }
 
-    private var hasRoutes = false
+    internal var stateV2: NavigationSessionStateV2 = NavigationSessionStateV2.Idle
         set(value) {
-            if (field != value) {
-                field = value
-                updateState()
+            if (field == value) {
+                return
             }
+            field = value
+
+            stateObserversV2.forEach { it.onNavigationSessionStateChanged(value) }
         }
+
+    private var hasRoutes = false
 
     private var isDriving = false
         set(value) {
@@ -39,11 +45,16 @@ internal class NavigationSession : RoutesObserver, TripSessionStateObserver {
             }
         }
 
+    private var isPreview = false
+
     private fun updateState() {
-        state = NavigationSessionUtils.getNewNavigationSessionState(
-            isDriving = isDriving,
-            hasRoutes = hasRoutes
-        )
+        stateV2 = NavigationSessionUtils.getNewStateV2(isDriving, hasRoutes, isPreview)
+        state = when (stateV2) {
+            is NavigationSessionStateV2.ActiveGuidance -> ActiveGuidance(stateV2.sessionId)
+            is NavigationSessionStateV2.FreeDrive -> FreeDrive(stateV2.sessionId)
+            NavigationSessionStateV2.Idle -> Idle
+            is NavigationSessionStateV2.RoutePreview -> FreeDrive(stateV2.sessionId)
+        }
     }
 
     internal fun registerNavigationSessionStateObserver(
@@ -59,12 +70,31 @@ internal class NavigationSession : RoutesObserver, TripSessionStateObserver {
         stateObservers.remove(navigationSessionStateObserver)
     }
 
+    internal fun registerNavigationSessionStateObserverV2(
+        navigationSessionStateObserver: NavigationSessionStateObserverV2
+    ) {
+        stateObserversV2.add(navigationSessionStateObserver)
+        navigationSessionStateObserver.onNavigationSessionStateChanged(stateV2)
+    }
+
+    internal fun unregisterNavigationSessionStateObserverV2(
+        navigationSessionStateObserver: NavigationSessionStateObserverV2
+    ) {
+        stateObserversV2.remove(navigationSessionStateObserver)
+    }
+
     internal fun unregisterAllNavigationSessionStateObservers() {
         stateObservers.clear()
     }
 
     override fun onRoutesChanged(result: RoutesUpdatedResult) {
-        hasRoutes = result.navigationRoutes.isNotEmpty()
+        val newIsPreview = result.reason == RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW
+        val newNasRoutes = result.navigationRoutes.isNotEmpty()
+        if (newIsPreview != isPreview || newNasRoutes != hasRoutes) {
+            isPreview = newIsPreview
+            hasRoutes = newNasRoutes
+            updateState()
+        }
     }
 
     override fun onSessionStateChanged(tripSessionState: TripSessionState) {
@@ -122,4 +152,43 @@ sealed class NavigationSessionState {
     data class ActiveGuidance internal constructor(
         override val sessionId: String
     ) : NavigationSessionState()
+}
+
+sealed class NavigationSessionStateV2 {
+
+    /**
+     * Random session UUID.
+     * This is generated internally based on the current state within a trip session.
+     * I.e. will change when transitioning across states of a trip session. Empty when [Idle].
+     *
+     * Useful to use it in combination with the [MapboxHistoryRecorder].
+     *
+     * @see [TripSessionState]
+     */
+    abstract val sessionId: String
+
+    /**
+     * Idle state
+     */
+    object Idle : NavigationSessionStateV2() {
+        override val sessionId = ""
+    }
+
+    /**
+     * Free Drive state
+     */
+    data class FreeDrive internal constructor(
+        override val sessionId: String
+    ) : NavigationSessionStateV2()
+
+    /**
+     * Active Guidance state
+     */
+    data class ActiveGuidance internal constructor(
+        override val sessionId: String
+    ) : NavigationSessionStateV2()
+
+    data class RoutePreview internal constructor(
+        override val sessionId: String
+    ) : NavigationSessionStateV2()
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSessionStateObserverV2.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSessionStateObserverV2.kt
@@ -1,0 +1,15 @@
+package com.mapbox.navigation.core.trip.session
+
+/**
+ * Callback that provides the various session states that can happen within a navigation session
+ *
+ * @see NavigationSessionState
+ */
+fun interface NavigationSessionStateObserverV2 {
+    /**
+     * Called whenever the navigation session state has changed
+     *
+     * @param navigationSession [NavigationSessionStateV2]
+     */
+    fun onNavigationSessionStateChanged(navigationSession: NavigationSessionStateV2)
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSessionStateObserverV2.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSessionStateObserverV2.kt
@@ -3,7 +3,7 @@ package com.mapbox.navigation.core.trip.session
 /**
  * Callback that provides the various session states that can happen within a navigation session
  *
- * @see NavigationSessionState
+ * @see NavigationSessionStateV2
  */
 fun interface NavigationSessionStateObserverV2 {
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSessionUtils.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NavigationSessionUtils.kt
@@ -49,4 +49,23 @@ internal object NavigationSessionUtils {
             idleProvider()
         }
     }
+
+    fun getNewStateV2(
+        isDriving: Boolean,
+        hasRoutes: Boolean,
+        routePreview: Boolean
+    ): NavigationSessionStateV2 = when {
+        hasRoutes && routePreview -> {
+            NavigationSessionStateV2.RoutePreview(navObtainUniversalSessionId())
+        }
+        hasRoutes && isDriving -> {
+            NavigationSessionStateV2.ActiveGuidance(navObtainUniversalSessionId())
+        }
+        isDriving -> {
+            NavigationSessionStateV2.FreeDrive(navObtainUniversalSessionId())
+        }
+        else -> {
+            NavigationSessionStateV2.Idle
+        }
+    }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/directions/session/MapboxDirectionsSessionTest.kt
@@ -412,6 +412,26 @@ class MapboxDirectionsSessionTest {
     }
 
     @Test
+    fun `register route observer during preview state`() {
+        val testRoutes = createNavigationRoutes()
+        session.setRoutes(
+            testRoutes,
+            BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW, 0)
+        )
+
+        session.registerRoutesObserver(observer)
+
+        verify {
+            observer.onRoutesChanged(
+                match {
+                    it.navigationRoutes == testRoutes
+                        && it.reason == RoutesExtra.ROUTES_UPDATE_REASON_PREVIEW
+                }
+            )
+        }
+    }
+
+    @Test
     fun `clean set previewed route`() {
         session.setRoutes(
             createNavigationRoutes(),

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/NavigationSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/NavigationSessionTest.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.core.trip.session
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.core.directions.session.RoutesExtra
 import com.mapbox.navigation.core.directions.session.RoutesUpdatedResult
-import com.mapbox.navigation.core.trip.session.NavigationSessionState
 import com.mapbox.navigation.testing.factories.createNavigationRoutes
 import io.mockk.clearMocks
 import io.mockk.every


### PR DESCRIPTION
This PR introduces a preview state in `MapboxNavigation`. `MapboxNavigation` will be a single source of truth for different clients: mobile app, Drop-In UI, android auto. We wan't charge users for route preview, but if trip session is started, the users will be charged if they are in free drive. 

The preview state doesn't mean that you can't implement route preview without it. You still can draw a route using route line without `MapboxNavigation`. But the route preview state will be the default approach for this as it automatically syncs the state with android auto. 

## States before this PR

![image](https://user-images.githubusercontent.com/6190346/188157861-0a721703-5f08-45c7-8e8e-6a2c9d685c47.png)


## New preview state

![image](https://user-images.githubusercontent.com/6190346/188157971-f6c468dd-8367-4807-827d-31a236d3f466.png)


## Is the PR ready for review?

Yes. It's still requires some polishing(documentation, code style, more tests) but it works. If some aspect doesn't work for you, please report it in comments 🙂 

I recommend you checking `PreviewRoutesTest` and `MapboxNavigationActivity` to see the preview API in action.

https://user-images.githubusercontent.com/6190346/181538028-134c5c38-fc04-4c4e-af80-9abb371a9ade.mp4

## TODO in followup PRs:

- [ ] record set route preview into history file 
- [ ] add telemetry event to measure if it's used
- [ ] integrate preview with copilot 

## Next steps after "route preview" feature 

The introduced route preview state doesn't cover the case when an app developers want to show route preview during active guidance. They can manually draw a route using route line, but `AlternativesMetadata` isn't available there. The next logical step I see, is to introduce a data structure which replaces `List<NavigationRoute>` everywhere(`setNavigaitonRoutes`, `previewNavigationRoutes`, etc). 

```koltin
class NavigationRoutes {
   val navigationRoutes: List<NavigationRoutes>
   val primaryRouteIndex: Int
   val primaryRoute: NavigationRoute
   val alternativeRoutes: List<AlternativeRoute>
   internal val routesData: RoutesData
}

class AlternativeRoute {
  val alternativeRoute: NavigationRoute
  val metadata: AlternativeMetadata
}
```

This data structure will solve the problems this PR doesn't address:

* route preview UI can display a list of routes, their order shouldn't change when a user switches between routes
* NN expect `RoutesData` on set route, which will be carried by `NavigationRoutes`
* an app developers will be able to access alternative metadata without `MapboxNavigation`, which will let preview a route even during active navigation 

This next step will need to be discussed. I described it ahead because I assume that you ask me about those unsolved problems. 

