### PR TITLE
Add new feature flag to allow users to handle their own map long click events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Mapbox welcomes participation and contributions from everyone.
 - Introduced `NavigationViewListener#onInfoPanelHidden` to inform user when `InfoPanel` hides. [#6113](https://github.com/mapbox/mapbox-navigation-android/pull/6113)
 - Introduced `NavigationViewListener#onInfoPanelExpanded` to inform user when `InfoPanel` expands. [#6113](https://github.com/mapbox/mapbox-navigation-android/pull/6113)
 - Introduced `NavigationViewListener#onInfoPanelCollapsed` to inform user when `InfoPanel` collapses. [#6113](https://github.com/mapbox/mapbox-navigation-android/pull/6113)
+- Introduced `NavigationViewOptions.enableMapLongClickIntercept` that would allow users to disable `NavigationView` from handling `OnMapLongClick` events. [#6116](https://github.com/mapbox/mapbox-navigation-android/pull/6116)
+- Introduced `MapViewObserver#onAttached` and `MapViewObserver#onDetached` to get access to `MapView` instance used by `NavigationView`. [#6116](https://github.com/mapbox/mapbox-navigation-android/pull/6116)
+- Removed `NavigationViewListener.onMapStyleChanged`. [#6116](https://github.com/mapbox/mapbox-navigation-android/pull/6116)
 - Fixed bearing calculation error during tunnel dead reckoning. [#6118](https://github.com/mapbox/mapbox-navigation-android/pull/6118)
 
 ## Mapbox Navigation SDK 2.7.0-beta.3 - 29 July, 2022

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -14,6 +14,12 @@ package com.mapbox.navigation.dropin {
     enum_constant public static final com.mapbox.navigation.dropin.ActionButtonDescription.Position START;
   }
 
+  @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class MapViewObserver {
+    ctor public MapViewObserver();
+    method public void onAttached(com.mapbox.maps.MapView mapView);
+    method public void onDetached(com.mapbox.maps.MapView mapView);
+  }
+
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class NavigationView extends android.widget.FrameLayout implements androidx.lifecycle.LifecycleOwner {
     ctor public NavigationView(android.content.Context context, android.util.AttributeSet? attrs = null, String accessToken = attrs.navigationViewAccessToken(context), androidx.lifecycle.ViewModelStoreOwner viewModelStoreOwner = context.toViewModelStoreOwner());
     ctor public NavigationView(android.content.Context context, android.util.AttributeSet? attrs = null, String accessToken = attrs.navigationViewAccessToken(context));
@@ -26,7 +32,9 @@ package com.mapbox.navigation.dropin {
     method public void customizeViewStyles(kotlin.jvm.functions.Function1<? super com.mapbox.navigation.dropin.ViewStyleCustomization,kotlin.Unit> action);
     method public com.mapbox.navigation.dropin.NavigationViewApi getApi();
     method public androidx.lifecycle.Lifecycle getLifecycle();
+    method public void registerMapObserver(com.mapbox.navigation.dropin.MapViewObserver observer);
     method public void removeListener(com.mapbox.navigation.dropin.NavigationViewListener listener);
+    method public void unregisterMapObserver(com.mapbox.navigation.dropin.MapViewObserver observer);
     property public final com.mapbox.navigation.dropin.NavigationViewApi api;
   }
 
@@ -55,7 +63,6 @@ package com.mapbox.navigation.dropin {
     method public void onInfoPanelCollapsed();
     method public void onInfoPanelExpanded();
     method public void onInfoPanelHidden();
-    method public void onMapStyleChanged(com.mapbox.maps.Style style);
     method public void onOverviewCameraMode();
     method public void onRouteFetchCanceled(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
     method public void onRouteFetchFailed(java.util.List<com.mapbox.navigation.base.route.RouterFailure> reasons, com.mapbox.api.directions.v5.models.RouteOptions routeOptions);
@@ -103,16 +110,19 @@ package com.mapbox.navigation.dropin {
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class ViewOptionsCustomization {
     ctor public ViewOptionsCustomization();
+    method public Boolean? getEnableMapLongClickIntercept();
     method public String? getMapStyleUriDay();
     method public String? getMapStyleUriNight();
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions? getRouteArrowOptions();
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions? getRouteLineOptions();
     method public Boolean? getShowInfoPanelInFreeDrive();
+    method public void setEnableMapLongClickIntercept(Boolean?);
     method public void setMapStyleUriDay(String?);
     method public void setMapStyleUriNight(String?);
     method public void setRouteArrowOptions(com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions?);
     method public void setRouteLineOptions(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions?);
     method public void setShowInfoPanelInFreeDrive(Boolean?);
+    property public final Boolean? enableMapLongClickIntercept;
     property public final String? mapStyleUriDay;
     property public final String? mapStyleUriNight;
     property public final com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions? routeArrowOptions;

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/MapViewObserver.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/MapViewObserver.kt
@@ -1,0 +1,23 @@
+package com.mapbox.navigation.dropin
+
+import com.mapbox.maps.MapView
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+
+/**
+ * Defines an object that needs to interact with or observe [MapView].
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+abstract class MapViewObserver {
+
+    /**
+     * Signals that [mapView] is ready to be used. Use this function to register [mapView] observers
+     * or perform operations.
+     */
+    open fun onAttached(mapView: MapView) = Unit
+
+    /**
+     * Signals that [mapView] instance is being detached. Use this function to unregister [mapView]
+     * observers that were registered in [onAttached]
+     */
+    open fun onDetached(mapView: MapView) = Unit
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/MapViewOwner.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/MapViewOwner.kt
@@ -1,0 +1,42 @@
+package com.mapbox.navigation.dropin
+
+import com.mapbox.maps.MapView
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import java.util.concurrent.CopyOnWriteArraySet
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal class MapViewOwner {
+
+    private var mapView: MapView? = null
+    private val listeners = CopyOnWriteArraySet<MapViewObserver>()
+
+    fun registerObserver(observer: MapViewObserver) {
+        if (listeners.add(observer)) {
+            mapView?.let {
+                observer.onAttached(it)
+            }
+        }
+    }
+
+    fun unregisterObserver(observer: MapViewObserver) {
+        if (listeners.remove(observer)) {
+            mapView?.let {
+                observer.onDetached(it)
+            }
+        }
+    }
+
+    fun updateMapView(mapView: MapView?) {
+        this.mapView?.let {
+            listeners.forEach { listener ->
+                listener.onDetached(it)
+            }
+        }
+        this.mapView = mapView
+        mapView?.let {
+            listeners.forEach { listener ->
+                listener.onAttached(it)
+            }
+        }
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -199,6 +199,20 @@ class NavigationView @JvmOverloads constructor(
         navigationContext.listenerRegistry.unregisterListener(listener)
     }
 
+    /**
+     * Registers [MapViewObserver].
+     */
+    fun registerMapObserver(observer: MapViewObserver) {
+        navigationContext.mapViewOwner.registerObserver(observer)
+    }
+
+    /**
+     * Unregisters [MapViewObserver].
+     */
+    fun unregisterMapObserver(observer: MapViewObserver) {
+        navigationContext.mapViewOwner.unregisterObserver(observer)
+    }
+
     private inline fun <reified T : ViewModel> lazyViewModel(): Lazy<T> = lazy {
         viewModelProvider[T::class.java]
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
@@ -37,11 +37,11 @@ internal class NavigationViewContext(
     val styles = NavigationViewStyles(context)
     val options = NavigationViewOptions(context)
     val infoPanelBehavior = InfoPanelBehavior()
+    val mapViewOwner = MapViewOwner()
     val mapStyleLoader = MapStyleLoader(context, options)
     val listenerRegistry by lazy {
         NavigationViewListenerRegistry(
             store,
-            mapStyleLoader,
             infoPanelBehavior,
             lifecycleOwner.lifecycleScope
         )

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.dropin
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.Style
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.Router
@@ -46,14 +45,6 @@ abstract class NavigationViewListener {
      * Called when NavigationView enters Arrival state.
      */
     open fun onArrival() = Unit
-
-    /**
-     * Called when Map [Style] has changed. Invoked once the new style has been fully loaded,
-     * including the style specified sprite and sources.
-     *
-     * @param style Fully loaded style.
-     */
-    open fun onMapStyleChanged(style: Style) = Unit
 
     /**
      * Called when camera mode has changed to Idle.

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.launch
 @ExperimentalPreviewMapboxNavigationAPI
 internal class NavigationViewListenerRegistry(
     private val store: Store,
-    private val mapStyleLoader: MapStyleLoader,
     private val infoPanelSubscriber: InfoPanelBehavior,
     private val coroutineScope: CoroutineScope
 ) {
@@ -71,11 +70,6 @@ internal class NavigationViewListenerRegistry(
                 }
             }
             launch {
-                mapStyleLoader.loadedMapStyle.filterNotNull().collect {
-                    listener.onMapStyleChanged(it)
-                }
-            }
-            launch {
                 store.select { it.camera.cameraMode }.collect {
                     listener.onCameraModeChanged(it)
                 }
@@ -90,7 +84,6 @@ internal class NavigationViewListenerRegistry(
                     listener.onAudioGuidanceStateChanged(it)
                 }
             }
-
             launch {
                 infoPanelSubscriber
                     .infoPanelBehavior

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewOptions.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewOptions.kt
@@ -27,12 +27,16 @@ internal class NavigationViewOptions(context: Context) {
         MutableStateFlow(defaultRouteArrowOptions(context))
     private var _showInfoPanelInFreeDrive: MutableStateFlow<Boolean> =
         MutableStateFlow(false)
+    private var _enableMapLongClickIntercept: MutableStateFlow<Boolean> =
+        MutableStateFlow(true)
 
     var mapStyleUriDay: StateFlow<String> = _mapStyleUriDay.asStateFlow()
     var mapStyleUriNight: StateFlow<String> = _mapStyleUriNight.asStateFlow()
     val routeLineOptions: StateFlow<MapboxRouteLineOptions> = _routeLineOptions.asStateFlow()
     val routeArrowOptions: StateFlow<RouteArrowOptions> = _routeArrowOptions.asStateFlow()
     val showInfoPanelInFreeDrive: StateFlow<Boolean> = _showInfoPanelInFreeDrive.asStateFlow()
+    val enableMapLongClickIntercept: StateFlow<Boolean> =
+        _enableMapLongClickIntercept.asStateFlow()
 
     fun applyCustomization(customization: ViewOptionsCustomization) {
         customization.mapStyleUriDay?.also { _mapStyleUriDay.tryEmit(it) }
@@ -40,5 +44,8 @@ internal class NavigationViewOptions(context: Context) {
         customization.routeLineOptions?.also { _routeLineOptions.tryEmit(it) }
         customization.routeArrowOptions?.also { _routeArrowOptions.tryEmit(it) }
         customization.showInfoPanelInFreeDrive?.also { _showInfoPanelInFreeDrive.tryEmit(it) }
+        customization.enableMapLongClickIntercept?.also {
+            _enableMapLongClickIntercept.tryEmit(it)
+        }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewOptionsCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewOptionsCustomization.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.dropin
 
 import android.content.Context
+import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants
@@ -47,6 +48,12 @@ class ViewOptionsCustomization {
      * Set to `false` for the default behavior.
      */
     var showInfoPanelInFreeDrive: Boolean? = null
+
+    /**
+     * Set to false if you don't want [NavigationView] to intercept [OnMapLongClickListener] events.
+     * Set to `true` as the default behavior.
+     */
+    var enableMapLongClickIntercept: Boolean? = null
 
     companion object {
         /**

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
@@ -94,9 +94,9 @@ internal class MapBinder(
         when (navigationState) {
             NavigationState.FreeDrive,
             NavigationState.DestinationPreview ->
-                FreeDriveLongPressMapComponent(store, mapView)
+                FreeDriveLongPressMapComponent(store, mapView, context)
             NavigationState.RoutePreview ->
-                RoutePreviewLongPressMapComponent(store, mapView)
+                RoutePreviewLongPressMapComponent(store, mapView, context)
             NavigationState.ActiveNavigation,
             NavigationState.Arrival ->
                 null

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/FreeDriveLongPressMapComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/FreeDriveLongPressMapComponent.kt
@@ -5,6 +5,7 @@ import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.dropin.util.HapticFeedback
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.destination.Destination
@@ -17,6 +18,7 @@ import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 internal class FreeDriveLongPressMapComponent(
     private val store: Store,
     private val mapView: MapView,
+    private val context: NavigationViewContext,
 ) : UIComponent() {
 
     private var hapticFeedback: HapticFeedback? = null
@@ -35,9 +37,11 @@ internal class FreeDriveLongPressMapComponent(
     }
 
     private val longClickListener = OnMapLongClickListener { point ->
-        store.dispatch(DestinationAction.SetDestination(Destination(point)))
-        store.dispatch(NavigationStateAction.Update(NavigationState.DestinationPreview))
-        hapticFeedback?.tick()
+        if (context.options.enableMapLongClickIntercept.value) {
+            store.dispatch(DestinationAction.SetDestination(Destination(point)))
+            store.dispatch(NavigationStateAction.Update(NavigationState.DestinationPreview))
+            hapticFeedback?.tick()
+        }
         false
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/RoutePreviewLongPressMapComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/RoutePreviewLongPressMapComponent.kt
@@ -5,6 +5,7 @@ import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.dropin.util.HapticFeedback
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.destination.Destination
@@ -18,6 +19,7 @@ import com.mapbox.navigation.utils.internal.toPoint
 internal class RoutePreviewLongPressMapComponent(
     private val store: Store,
     private val mapView: MapView,
+    private val context: NavigationViewContext
 ) : UIComponent() {
 
     private var hapticFeedback: HapticFeedback? = null
@@ -36,12 +38,14 @@ internal class RoutePreviewLongPressMapComponent(
     }
 
     private val longClickListener = OnMapLongClickListener { point ->
-        val location = store.state.value.location?.enhancedLocation
-        location?.toPoint()?.also { lastPoint ->
-            store.dispatch(DestinationAction.SetDestination(Destination(point)))
-            store.dispatch(RoutePreviewAction.FetchPoints(listOf(lastPoint, point)))
-            hapticFeedback?.tick()
-        } ?: logW(TAG, "Current location is unknown so map long press does nothing")
+        if (context.options.enableMapLongClickIntercept.value) {
+            val location = store.state.value.location?.enhancedLocation
+            location?.toPoint()?.also { lastPoint ->
+                store.dispatch(DestinationAction.SetDestination(Destination(point)))
+                store.dispatch(RoutePreviewAction.FetchPoints(listOf(lastPoint, point)))
+                hapticFeedback?.tick()
+            } ?: logW(TAG, "Current location is unknown so map long press does nothing")
+        }
         false
     }
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/MapLayoutCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/MapLayoutCoordinator.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.dropin.databinding.MapboxMapviewLayoutBinding
 import com.mapbox.navigation.dropin.databinding.MapboxNavigationViewLayoutBinding
 import com.mapbox.navigation.ui.base.lifecycle.Binder
 import com.mapbox.navigation.ui.base.lifecycle.UICoordinator
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -21,6 +22,7 @@ import kotlinx.coroutines.launch
 /**
  * Coordinator for inflating [MapView].
  */
+@OptIn(FlowPreview::class)
 @ExperimentalPreviewMapboxNavigationAPI
 internal class MapLayoutCoordinator(
     private val navigationViewContext: NavigationViewContext,
@@ -28,6 +30,7 @@ internal class MapLayoutCoordinator(
 ) : UICoordinator<ViewGroup>(binding.mapViewLayout) {
 
     private val viewGroup = binding.mapViewLayout
+    private val mapViewOwner = navigationViewContext.mapViewOwner
     private val mapStyleLoader = navigationViewContext.mapStyleLoader
     private var reloadStyleJob: Job? = null
 
@@ -48,11 +51,13 @@ internal class MapLayoutCoordinator(
 
                     val binding = MapboxMapviewLayoutBinding.bind(viewGroup)
                     initDefaultMap(binding.mapView.getMapboxMap())
+                    mapViewOwner.updateMapView(binding.mapView)
                     binding.mapView
                 } else {
                     initCustomMap(mapViewOverride.getMapboxMap())
                     viewGroup.removeAllViews()
                     viewGroup.addView(mapViewOverride)
+                    mapViewOwner.updateMapView(mapViewOverride)
                     mapViewOverride
                 }
             }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/MapViewOwnerTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/MapViewOwnerTest.kt
@@ -1,0 +1,130 @@
+package com.mapbox.navigation.dropin
+
+import com.mapbox.maps.MapView
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Test
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal class MapViewOwnerTest {
+
+    @Test
+    fun `when map view is null onAttached not called upon calling register`() {
+        val sut = MapViewOwner()
+        val observer = spyk<TestMapViewObserver>()
+
+        sut.registerObserver(observer)
+
+        verify(exactly = 0) {
+            observer.onAttached(any())
+        }
+    }
+
+    @Test
+    fun `when map view exists onAttached is called upon calling register`() {
+        val sut = MapViewOwner()
+        val mapView = mockk<MapView>()
+        val observer = spyk<TestMapViewObserver>()
+        sut.updateMapView(mapView)
+
+        sut.registerObserver(observer)
+
+        verify { observer.onAttached(mapView) }
+    }
+
+    @Test
+    fun `when map view is null onDetached not called upon calling unregister`() {
+        val sut = MapViewOwner()
+        val observer = spyk<TestMapViewObserver>()
+
+        sut.unregisterObserver(observer)
+
+        verify(exactly = 0) {
+            observer.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `when map view exists onDetached is called upon calling unregister`() {
+        val sut = MapViewOwner()
+        val mapView = mockk<MapView>()
+        val observer = spyk<TestMapViewObserver>()
+        sut.updateMapView(mapView)
+
+        sut.registerObserver(observer)
+        sut.unregisterObserver(observer)
+
+        verify { observer.onDetached(mapView) }
+    }
+
+    @Test
+    fun `multiple register calls should only call onAttached once`() {
+        val sut = MapViewOwner()
+        val mapView = mockk<MapView>()
+        val observer = spyk<TestMapViewObserver>()
+        sut.updateMapView(mapView)
+
+        sut.registerObserver(observer)
+        sut.registerObserver(observer)
+
+        verify(exactly = 1) { observer.onAttached(mapView) }
+    }
+
+    @Test
+    fun `multiple unregister calls should only call onDetached once`() {
+        val sut = MapViewOwner()
+        val mapView = mockk<MapView>()
+        val observer = spyk<TestMapViewObserver>()
+        sut.updateMapView(mapView)
+
+        sut.registerObserver(observer)
+        sut.unregisterObserver(observer)
+        sut.unregisterObserver(observer)
+
+        verify(exactly = 1) { observer.onDetached(mapView) }
+    }
+
+    @Test
+    fun `when already registered and mapView is updated onAttached is called`() {
+        val sut = MapViewOwner()
+        val mapView = mockk<MapView>()
+        val observer = spyk<TestMapViewObserver>()
+        sut.registerObserver(observer)
+
+        sut.updateMapView(mapView)
+
+        verify(exactly = 1) { observer.onAttached(mapView) }
+    }
+
+    @Test
+    fun `when update old mapView onDetach and onAttach should be called`() {
+        val sut = MapViewOwner()
+        val mapView1 = mockk<MapView>()
+        val mapView2 = mockk<MapView>()
+        val observer = spyk<TestMapViewObserver>()
+        sut.registerObserver(observer)
+
+        sut.updateMapView(mapView1)
+        verify(exactly = 0) { observer.onDetached(any()) }
+        verify(exactly = 1) { observer.onAttached(mapView1) }
+
+        sut.updateMapView(mapView2)
+        verify(exactly = 1) { observer.onDetached(mapView1) }
+        verify(exactly = 1) { observer.onAttached(mapView2) }
+    }
+}
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal open class TestMapViewObserver : MapViewObserver() {
+    private var attachedTo: MapView? = null
+
+    override fun onAttached(mapView: MapView) {
+        attachedTo = mapView
+    }
+
+    override fun onDetached(mapView: MapView) {
+        attachedTo = null
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistryTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistryTest.kt
@@ -4,7 +4,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.Style
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterFailure
@@ -38,26 +37,20 @@ class NavigationViewListenerRegistryTest {
 
     private lateinit var sut: NavigationViewListenerRegistry
     private lateinit var testStore: TestStore
-    private lateinit var loadedMapStyleFlow: MutableStateFlow<Style?>
     private lateinit var infoPanelBehaviorFlow: MutableStateFlow<Int?>
     private lateinit var testListener: NavigationViewListener
 
     @Before
     fun setUp() {
         testStore = TestStore()
-        loadedMapStyleFlow = MutableStateFlow(null)
         infoPanelBehaviorFlow = MutableStateFlow(null)
         val mockInfoPanelBehavior = mockk<InfoPanelBehavior> {
             every { infoPanelBehavior } returns infoPanelBehaviorFlow.asStateFlow()
-        }
-        val mockStyleLoader = mockk<MapStyleLoader> {
-            every { loadedMapStyle } returns loadedMapStyleFlow.asStateFlow()
         }
         testListener = spyk(object : NavigationViewListener() {})
 
         sut = NavigationViewListenerRegistry(
             testStore,
-            mockStyleLoader,
             mockInfoPanelBehavior,
             coroutineRule.coroutineScope
         )
@@ -125,16 +118,6 @@ class NavigationViewListenerRegistryTest {
         testStore.setState(State(navigation = navigationState))
 
         verify { testListener.onArrival() }
-    }
-
-    @Test
-    fun onMapStyleChanged() {
-        sut.registerListener(testListener)
-
-        val style = mockk<Style>()
-        loadedMapStyleFlow.value = style
-
-        verify { testListener.onMapStyleChanged(style) }
     }
 
     @Test

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewOptionsTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewOptionsTest.kt
@@ -39,6 +39,7 @@ internal class NavigationViewOptionsTest {
         assertEquals(c.routeLineOptions, sut.routeLineOptions.value)
         assertEquals(c.routeArrowOptions, sut.routeArrowOptions.value)
         assertEquals(c.showInfoPanelInFreeDrive, sut.showInfoPanelInFreeDrive.value)
+        assertEquals(c.enableMapLongClickIntercept, sut.enableMapLongClickIntercept.value)
     }
 
     private fun customization() =
@@ -56,5 +57,6 @@ internal class NavigationViewOptionsTest {
                 .withArrowColor(Color.YELLOW)
                 .build()
             showInfoPanelInFreeDrive = true
+            enableMapLongClickIntercept = false
         }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -11,4 +11,5 @@ class CustomizedViewModel : ViewModel() {
     val useCustomInfoPanelStyles = MutableLiveData(false)
     val showCustomInfoPanelContent = MutableLiveData(false)
     val showBottomSheetInFreeDrive = MutableLiveData(false)
+    val enableOnMapLongClick = MutableLiveData(true)
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/LoggingNavigationViewListener.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/LoggingNavigationViewListener.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.qa_test_app.view.customnavview
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.maps.EdgeInsets
-import com.mapbox.maps.Style
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterFailure
@@ -50,10 +49,6 @@ class LoggingNavigationViewListener(
 
     override fun onFollowingCameraMode() {
         log("listener onFollowingCameraMode")
-    }
-
-    override fun onMapStyleChanged(style: Style) {
-        log("listener onMapStyleChange = ${style.styleURI}")
     }
 
     override fun onCameraPaddingChanged(padding: EdgeInsets) {

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -105,6 +105,16 @@
                 android:text="Show Info Panel IN \nFree Drive"
                 android:textAllCaps="true" />
         </TableRow>
+        <TableRow android:padding="5dp">
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleOnMapLongClick"
+                android:layout_weight="1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="Enable Map Long Click"
+                android:textAllCaps="true" />
+        </TableRow>
     </TableLayout>
 
 </androidx.appcompat.widget.LinearLayoutCompat>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/6104
Fixes #6014 

> - [ ] Drop-In UI has 2 components `FreeDriveLongPressComponent` and `RoutePreviewLongPressComponent` which registers with map long press events. Based on long press these components set destinations and draw route lines. However, a customer should be allowed to intercept the long press event and handle it themselves. When long press event is intercepted, Drop-In UI should not perform the actions it would do otherwise. 
**Example use case:** _As a user, I would want to intercept long press on the map, and invoke `navigationViewApi.setRoute(routeOptions)` with appropriate `routeOptions`. This is currently not possible with Drop-In UI._

Thinking it through and revisiting this [discussion](https://github.com/mapbox/mapbox-navigation-android/pull/5922#discussion_r897909137), the implementation becomes simple by exposing `mapView` instance. Since, we already decided to expose `mapView`, in case users want to handle `OnMapLongClick` events themselves, they would have access to `mapView` and can add a `onLongClick` listener to it. Only thing they would have to do is inform `Drop-In` to disable handling `OnMapLongClick` events. Hence exposed a new feature flag `NavigationViewOptions.enableMapLongClickIntercept`  which is `true` by default, allowing `Drop-In UI` to handle long click events. Similarly, if users inject their own `mapView` instance, they would already have access to it and can add a `OnMapLongClick` listener to it. 

> - [ ] Drop-In UI makes use of `OnMapClick` event in `RouteLineComponent` to select alternative routes. A user, should be able to intercept `OnMapClick` events and handle it themselves. When intercepted, Drop-In UI should not perform the actions it would do otherwise. In this case if the event in intercepted, `RouteLineComponent` should not select alternative route and customer would be responsible to implement that piece of code.
**Example use case:** _As a user, I want to hide the info panel every time I click on the Map to make more of the map visible._

Rethinking this requirement, I don't think we should allow users to disable `OnMapClick` events and ask them to write their own logic to select alternative routes. With exposure to `mapView`, users can add their own `OnMapClick` listeners to `mapView`. The only difference here would be since there is no option to disable `OnMapClick` events on `Drop-In UI`, if an end user taps on map, both `Drop-In UI` and `app` would execute their piece of logic accordingly.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
