### PR TITLE
Refactor SpeedLimit and Maneuver component by moving them outside Drop-In UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Introduced `NavigationViewOptions.enableMapLongClickIntercept` that would allow users to disable `NavigationView` from handling `OnMapLongClick` events. [#6116](https://github.com/mapbox/mapbox-navigation-android/pull/6116)
 - Introduced `MapViewObserver#onAttached` and `MapViewObserver#onDetached` to get access to `MapView` instance used by `NavigationView`. [#6116](https://github.com/mapbox/mapbox-navigation-android/pull/6116)
 - Removed `NavigationViewListener.onMapStyleChanged`. [#6116](https://github.com/mapbox/mapbox-navigation-android/pull/6116)
+- Added `ComponentInstaller` to `Maneuver` and `SpeedLimit` that offer simplified integration of maneuvers and speed limits APIs. [#6117](https://github.com/mapbox/mapbox-navigation-android/pull/6117)
 - Fixed bearing calculation error during tunnel dead reckoning. [#6118](https://github.com/mapbox/mapbox-navigation-android/pull/6118)
 
 ### Mapbox dependencies

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverViewBinder.kt
@@ -10,7 +10,10 @@ import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxManeuverGuidanceLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.reloadOnChange
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
+import com.mapbox.navigation.ui.maneuver.internal.ManeuverComponent
 import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
+import com.mapbox.navigation.ui.maps.internal.extensions.getStyleId
+import com.mapbox.navigation.ui.maps.internal.extensions.getUserId
 import kotlinx.coroutines.flow.StateFlow
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
@@ -34,7 +37,8 @@ internal class ManeuverViewBinder(
             if (mapStyle != null) {
                 ManeuverComponent(
                     maneuverView = binding.maneuverView,
-                    mapStyle = mapStyle,
+                    userId = mapStyle.getUserId(),
+                    styleId = mapStyle.getStyleId(),
                     options = options
                 )
             } else {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/speedlimit/SpeedLimitViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/speedlimit/SpeedLimitViewBinder.kt
@@ -11,6 +11,7 @@ import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxSpeedLimitLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.reloadOnChange
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
+import com.mapbox.navigation.ui.speedlimit.internal.SpeedLimitComponent
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal class SpeedLimitViewBinder(

--- a/libnavui-maneuver/api/current.txt
+++ b/libnavui-maneuver/api/current.txt
@@ -1,4 +1,24 @@
 // Signature format: 3.0
+package com.mapbox.navigation.ui.maneuver {
+
+  public final class ComponentInstallerKt {
+    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public static com.mapbox.navigation.ui.base.installer.Installation maneuver(com.mapbox.navigation.ui.base.installer.ComponentInstaller, com.mapbox.navigation.ui.maneuver.view.MapboxManeuverView maneuverView, kotlin.jvm.functions.Function1<? super com.mapbox.navigation.ui.maneuver.ManeuverConfig,kotlin.Unit> config = {});
+  }
+
+  @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class ManeuverConfig {
+    method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions getOptions();
+    method public String? getStyleId();
+    method public String? getUserId();
+    method public void setOptions(com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions);
+    method public void setStyleId(String?);
+    method public void setUserId(String?);
+    property public final com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions options;
+    property public final String? styleId;
+    property public final String? userId;
+  }
+
+}
+
 package com.mapbox.navigation.ui.maneuver.api {
 
   public final class MapboxLaneIconsApi {

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/ComponentInstaller.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/ComponentInstaller.kt
@@ -1,0 +1,99 @@
+package com.mapbox.navigation.ui.maneuver
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.ui.base.installer.ComponentInstaller
+import com.mapbox.navigation.ui.base.installer.Installation
+import com.mapbox.navigation.ui.maneuver.internal.ManeuverComponent
+import com.mapbox.navigation.ui.maneuver.model.ManeuverExitOptions
+import com.mapbox.navigation.ui.maneuver.model.ManeuverPrimaryOptions
+import com.mapbox.navigation.ui.maneuver.model.ManeuverSecondaryOptions
+import com.mapbox.navigation.ui.maneuver.model.ManeuverSubOptions
+import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
+import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverView
+
+/**
+ * Install components that render [MapboxManeuverView].
+ *
+ * @param maneuverView
+ * @param userId
+ * @param styleId
+ * @param config options that can be used to configure [ManeuverViewOptions]
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+fun ComponentInstaller.maneuver(
+    maneuverView: MapboxManeuverView,
+    config: ManeuverConfig.() -> Unit = {}
+): Installation {
+    val componentConfig = ManeuverConfig().apply(config)
+    return component(
+        ManeuverComponent(
+            maneuverView = maneuverView,
+            userId = componentConfig.userId,
+            styleId = componentConfig.styleId,
+            componentConfig.options
+        )
+    )
+}
+
+/**
+ * Maneuver view component configuration class.
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+class ManeuverConfig internal constructor() {
+    /**
+     * [userId]
+     */
+    var userId: String? = null
+
+    /**
+     * [styleId] used by maps style.
+     */
+    var styleId: String? = null
+
+    /**
+     * Options used to create [MapboxManeuverView] instance.
+     */
+    var options = ManeuverViewOptions.Builder()
+        .maneuverBackgroundColor(R.color.colorPrimary)
+        .subManeuverBackgroundColor(R.color.colorPrimaryVariant)
+        .turnIconManeuver(R.style.MapboxStyleTurnIconManeuver)
+        .laneGuidanceTurnIconManeuver(R.style.MapboxStyleTurnIconManeuver)
+        .stepDistanceTextAppearance(R.style.MapboxStyleStepDistance)
+        .primaryManeuverOptions(
+            ManeuverPrimaryOptions
+                .Builder()
+                .textAppearance(R.style.MapboxStylePrimaryManeuver)
+                .exitOptions(
+                    ManeuverExitOptions
+                        .Builder()
+                        .textAppearance(R.style.MapboxStyleExitTextForPrimary)
+                        .build()
+                )
+                .build()
+        )
+        .secondaryManeuverOptions(
+            ManeuverSecondaryOptions
+                .Builder()
+                .textAppearance(R.style.MapboxStyleSecondaryManeuver)
+                .exitOptions(
+                    ManeuverExitOptions
+                        .Builder()
+                        .textAppearance(R.style.MapboxStyleExitTextForSecondary)
+                        .build()
+                )
+                .build()
+        )
+        .subManeuverOptions(
+            ManeuverSubOptions
+                .Builder()
+                .textAppearance(R.style.MapboxStyleSubManeuver)
+                .exitOptions(
+                    ManeuverExitOptions
+                        .Builder()
+                        .textAppearance(R.style.MapboxStyleExitTextForSub)
+                        .build()
+                )
+                .build()
+        )
+        .build()
+}

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponent.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponent.kt
@@ -1,6 +1,5 @@
-package com.mapbox.navigation.dropin.component.maneuver
+package com.mapbox.navigation.ui.maneuver.internal
 
-import com.mapbox.maps.Style
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.core.MapboxNavigation
@@ -13,16 +12,15 @@ import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import com.mapbox.navigation.ui.maneuver.api.MapboxManeuverApi
 import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
 import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverView
-import com.mapbox.navigation.ui.maps.internal.extensions.getStyleId
-import com.mapbox.navigation.ui.maps.internal.extensions.getUserId
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal class ManeuverComponent(
+class ManeuverComponent(
     val maneuverView: MapboxManeuverView,
-    val mapStyle: Style,
+    val userId: String?,
+    val styleId: String?,
     val options: ManeuverViewOptions,
     val maneuverApi: MapboxManeuverApi = MapboxManeuverApi(
         MapboxDistanceFormatter(
@@ -49,8 +47,8 @@ internal class ManeuverComponent(
 
                     value.onValue { maneuvers ->
                         maneuverApi.getRoadShields(
-                            mapStyle.getUserId(),
-                            mapStyle.getStyleId(),
+                            userId,
+                            styleId,
                             mapboxNavigation.navigationOptions.accessToken,
                             maneuvers
                         ) { result ->

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponentTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponentTest.kt
@@ -1,9 +1,8 @@
-package com.mapbox.navigation.dropin.component.maneuver
+package com.mapbox.navigation.ui.maneuver.internal
 
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
-import com.mapbox.maps.Style
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -19,7 +18,6 @@ import com.mapbox.navigation.ui.maneuver.model.Maneuver
 import com.mapbox.navigation.ui.maneuver.model.ManeuverError
 import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
 import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverView
-import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.shield.model.RouteShieldCallback
 import com.mapbox.navigation.ui.shield.model.RouteShieldError
 import com.mapbox.navigation.ui.shield.model.RouteShieldResult
@@ -43,17 +41,12 @@ class ManeuverComponentTest {
     @get:Rule
     var coroutineRule = MainCoroutineRule()
 
-    lateinit var style: Style
-
     private val maneuverViewOptions = ManeuverViewOptions.Builder().build()
 
     @Before
     fun setUp() {
         mockkStatic("com.mapbox.navigation.core.internal.extensions.MapboxNavigationEx")
         every { mockNavigation.flowRouteProgress() } returns flowOf(routeProgress)
-        style = mockk {
-            every { styleURI } returns NavigationStyles.NAVIGATION_DAY_STYLE
-        }
     }
 
     @After
@@ -70,7 +63,7 @@ class ManeuverComponentTest {
         every {
             getRoadShields(
                 DirectionsCriteria.PROFILE_DEFAULT_USER,
-                NavigationStyles.NAVIGATION_DAY_STYLE_ID,
+                "navigation-day-v1",
                 "token",
                 maneuvers,
                 capture(callbackSlot)
@@ -78,7 +71,7 @@ class ManeuverComponentTest {
         } returns Unit
     }
     private val maneuverView: MapboxManeuverView = mockk(relaxed = true)
-    private val mockNavigation = mockk<MapboxNavigation>() {
+    private val mockNavigation = mockk<MapboxNavigation> {
         every { navigationOptions } returns mockk {
             every { accessToken } returns "token"
         }
@@ -108,7 +101,13 @@ class ManeuverComponentTest {
                 firstArg<TripSessionStateObserver>().onSessionStateChanged(TripSessionState.STARTED)
             }
             val maneuverComponent =
-                ManeuverComponent(maneuverView, style, maneuverViewOptions, mockManeuverApi)
+                ManeuverComponent(
+                    maneuverView = maneuverView,
+                    userId = DirectionsCriteria.PROFILE_DEFAULT_USER,
+                    styleId = "navigation-day-v1",
+                    options = maneuverViewOptions,
+                    maneuverApi = mockManeuverApi
+                )
 
             maneuverComponent.onAttached(mockNavigation)
 
@@ -139,7 +138,13 @@ class ManeuverComponentTest {
             }
             val expectedList: List<Expected<RouteShieldError, RouteShieldResult>> = listOf()
             val maneuverComponent =
-                ManeuverComponent(maneuverView, style, maneuverViewOptions, mockManeuverApi)
+                ManeuverComponent(
+                    maneuverView = maneuverView,
+                    userId = DirectionsCriteria.PROFILE_DEFAULT_USER,
+                    styleId = "navigation-day-v1",
+                    options = maneuverViewOptions,
+                    maneuverApi = mockManeuverApi
+                )
 
             maneuverComponent.onAttached(mockNavigation).also {
                 callbackSlot.captured.onRoadShields(expectedList)
@@ -172,7 +177,13 @@ class ManeuverComponentTest {
             }
 
             val maneuverComponent =
-                ManeuverComponent(maneuverView, style, maneuverViewOptions, mockManeuverApi)
+                ManeuverComponent(
+                    maneuverView = maneuverView,
+                    userId = DirectionsCriteria.PROFILE_DEFAULT_USER,
+                    styleId = "navigation-day-v1",
+                    options = maneuverViewOptions,
+                    maneuverApi = mockManeuverApi
+                )
 
             maneuverComponent.onAttached(mockNavigation)
 
@@ -201,7 +212,13 @@ class ManeuverComponentTest {
             }
 
             val maneuverComponent =
-                ManeuverComponent(maneuverView, style, maneuverViewOptions, mockManeuverApi)
+                ManeuverComponent(
+                    maneuverView = maneuverView,
+                    userId = DirectionsCriteria.PROFILE_DEFAULT_USER,
+                    styleId = "navigation-day-v1",
+                    options = maneuverViewOptions,
+                    maneuverApi = mockManeuverApi
+                )
 
             maneuverComponent.onAttached(mockNavigation)
 

--- a/libnavui-speedlimit/api/current.txt
+++ b/libnavui-speedlimit/api/current.txt
@@ -1,4 +1,21 @@
 // Signature format: 3.0
+package com.mapbox.navigation.ui.speedlimit {
+
+  public final class ComponentInstallerKt {
+    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public static com.mapbox.navigation.ui.base.installer.Installation speedLimit(com.mapbox.navigation.ui.base.installer.ComponentInstaller, com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView speedLimitView, kotlin.jvm.functions.Function1<? super com.mapbox.navigation.ui.speedlimit.SpeedLimitConfig,kotlin.Unit> config = {});
+  }
+
+  public final class SpeedLimitConfig {
+    method public int getStyle();
+    method public int getTextAppearance();
+    method public void setStyle(int);
+    method public void setTextAppearance(int);
+    property public final int style;
+    property public final int textAppearance;
+  }
+
+}
+
 package com.mapbox.navigation.ui.speedlimit.api {
 
   public final class MapboxSpeedLimitApi {

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/ComponentInstaller.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/ComponentInstaller.kt
@@ -1,0 +1,44 @@
+package com.mapbox.navigation.ui.speedlimit
+
+import androidx.annotation.StyleRes
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.ui.base.installer.ComponentInstaller
+import com.mapbox.navigation.ui.base.installer.Installation
+import com.mapbox.navigation.ui.speedlimit.internal.SpeedLimitComponent
+import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView
+
+/**
+ * Install components that render [MapboxSpeedLimitView].
+ *
+ * @param style definition for [MapboxSpeedLimitView]
+ * @param textAppearance for [MapboxSpeedLimitView]
+ * @param speedLimitView [MapboxSpeedLimitView]
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+fun ComponentInstaller.speedLimit(
+    speedLimitView: MapboxSpeedLimitView,
+    config: SpeedLimitConfig.() -> Unit = {}
+): Installation {
+    val componentConfig = SpeedLimitConfig().apply(config)
+    return component(
+        SpeedLimitComponent(
+            style = componentConfig.style,
+            textAppearance = componentConfig.textAppearance,
+            speedLimitView = speedLimitView
+        )
+    )
+}
+
+/**
+ * Speed limit view component configuration class.
+ */
+class SpeedLimitConfig internal constructor() {
+    /**
+     * [style] to be set to [MapboxSpeedLimitView].
+     */
+    @StyleRes var style: Int = R.style.MapboxStyleSpeedLimit
+    /**
+     * [textAppearance] to be set to [MapboxSpeedLimitView].
+     */
+    @StyleRes var textAppearance: Int = 0
+}

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedLimitComponent.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedLimitComponent.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.dropin.component.speedlimit
+package com.mapbox.navigation.ui.speedlimit.internal
 
 import androidx.annotation.StyleRes
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
@@ -12,18 +12,20 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal class SpeedLimitComponent(
+class SpeedLimitComponent(
     @StyleRes val style: Int,
     @StyleRes val textAppearance: Int,
-    val speedLimitView: MapboxSpeedLimitView
+    val speedLimitView: MapboxSpeedLimitView,
+    val speedLimitApi: MapboxSpeedLimitApi = MapboxSpeedLimitApi(
+        SpeedLimitFormatter(speedLimitView.context)
+    )
 ) : UIComponent() {
+
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
         speedLimitView.updateStyle(style)
         // setTextAppearance is not deprecated in AppCompatTextView
         speedLimitView.setTextAppearance(speedLimitView.context, textAppearance)
-        val speedLimitFormatter = SpeedLimitFormatter(speedLimitView.context)
-        val speedLimitApi = MapboxSpeedLimitApi(speedLimitFormatter)
 
         coroutineScope.launch {
             mapboxNavigation.flowLocationMatcherResult().collect {

--- a/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedLimitComponentTest.kt
+++ b/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedLimitComponentTest.kt
@@ -1,0 +1,121 @@
+package com.mapbox.navigation.ui.speedlimit.internal
+
+import com.mapbox.bindgen.ExpectedFactory
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.speed.model.SpeedLimit
+import com.mapbox.navigation.base.speed.model.SpeedLimitSign
+import com.mapbox.navigation.base.speed.model.SpeedLimitUnit
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.extensions.flowLocationMatcherResult
+import com.mapbox.navigation.core.trip.session.LocationMatcherResult
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.speedlimit.api.MapboxSpeedLimitApi
+import com.mapbox.navigation.ui.speedlimit.model.UpdateSpeedLimitError
+import com.mapbox.navigation.ui.speedlimit.model.UpdateSpeedLimitValue
+import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+@ExperimentalPreviewMapboxNavigationAPI
+class SpeedLimitComponentTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    private val speedLimitView = mockk<MapboxSpeedLimitView>(relaxed = true)
+    private val mockNavigation = mockk<MapboxNavigation> {
+        every { navigationOptions } returns mockk {
+            every { accessToken } returns "token"
+        }
+    }
+
+    @Before
+    fun setUp() {
+        mockkStatic("com.mapbox.navigation.core.internal.extensions.MapboxNavigationEx")
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic("com.mapbox.navigation.core.internal.extensions.MapboxNavigationEx")
+    }
+
+    @Test
+    fun `speed limit is rendered when location matcher results are available`() =
+        coroutineRule.runBlockingTest {
+            val locationMatcher = mockk<LocationMatcherResult> {
+                every { speedLimit } returns SpeedLimit(
+                    speedKmph = 120,
+                    speedLimitUnit = SpeedLimitUnit.MILES_PER_HOUR,
+                    speedLimitSign = SpeedLimitSign.MUTCD
+                )
+            }
+            every { mockNavigation.flowLocationMatcherResult() } returns flowOf(locationMatcher)
+            every {
+                mockNavigation.registerLocationObserver(any())
+            } answers {
+                firstArg<LocationObserver>().onNewLocationMatcherResult(locationMatcher)
+            }
+            val expected = ExpectedFactory
+                .createValue<UpdateSpeedLimitError, UpdateSpeedLimitValue>(
+                    UpdateSpeedLimitValue(
+                        locationMatcher.speedLimit?.speedKmph!!,
+                        locationMatcher.speedLimit?.speedLimitUnit!!,
+                        locationMatcher.speedLimit?.speedLimitSign!!,
+                        mockk()
+                    )
+                )
+            val speedLimitApi = mockk<MapboxSpeedLimitApi>(relaxed = true) {
+                every { updateSpeedLimit(locationMatcher.speedLimit) } returns expected
+            }
+            val speedLimitComponent = SpeedLimitComponent(
+                style = 1,
+                textAppearance = 1,
+                speedLimitView = speedLimitView,
+                speedLimitApi = speedLimitApi
+            )
+            speedLimitComponent.onAttached(mockNavigation)
+
+            verify { speedLimitView.render(expected) }
+        }
+
+    @Test
+    fun `speed limit is not rendered when speed is not available`() =
+        coroutineRule.runBlockingTest {
+            val locationMatcher = mockk<LocationMatcherResult> {
+                every { speedLimit } returns null
+            }
+            every { mockNavigation.flowLocationMatcherResult() } returns flowOf(locationMatcher)
+            every {
+                mockNavigation.registerLocationObserver(any())
+            } answers {
+                firstArg<LocationObserver>().onNewLocationMatcherResult(locationMatcher)
+            }
+            val expected = ExpectedFactory
+                .createError<UpdateSpeedLimitError, UpdateSpeedLimitValue>(
+                    UpdateSpeedLimitError("Speed Limit data not available", null)
+                )
+            val speedLimitApi = mockk<MapboxSpeedLimitApi>(relaxed = true) {
+                every { updateSpeedLimit(locationMatcher.speedLimit) } returns expected
+            }
+            val speedLimitComponent = SpeedLimitComponent(
+                style = 1,
+                textAppearance = 1,
+                speedLimitView = speedLimitView,
+                speedLimitApi = speedLimitApi
+            )
+            speedLimitComponent.onAttached(mockNavigation)
+
+            verify { speedLimitView.render(expected) }
+        }
+}

--- a/qa-test-app/src/main/AndroidManifest.xml
+++ b/qa-test-app/src/main/AndroidManifest.xml
@@ -25,8 +25,14 @@
             </intent-filter>
         </activity>
 
-        <activity android:name=".view.ComponentsActivity" />
-        <activity android:name=".view.ComponentsAltActivity" />
+        <activity
+            android:name=".view.ComponentsActivity"
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            />
+        <activity
+            android:name=".view.ComponentsAltActivity"
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            />
         <activity android:name=".view.AppLifecycleActivity" />
         <activity android:name=".view.AlternativeRouteActivity" />
         <activity android:name=".view.MapboxRouteLineActivity" />

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RetainedActiveGuidanceFragment.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RetainedActiveGuidanceFragment.kt
@@ -16,7 +16,10 @@ import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.qa_test_app.databinding.FragmentActiveGuidanceBinding
 import com.mapbox.navigation.qa_test_app.lifecycle.bottomsheet.DropInTripProgress
-import com.mapbox.navigation.qa_test_app.lifecycle.topbanner.DropInManeuver
+import com.mapbox.navigation.ui.base.installer.installComponents
+import com.mapbox.navigation.ui.maneuver.maneuver
+import com.mapbox.navigation.ui.maps.NavigationStyles
+import com.mapbox.navigation.ui.speedlimit.speedLimit
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.onStart
@@ -25,7 +28,6 @@ import kotlinx.coroutines.flow.onStart
 class RetainedActiveGuidanceFragment : Fragment() {
 
     private var dropInTripProgress: DropInTripProgress? = null
-    private var dropInManeuver: DropInManeuver? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -59,6 +61,19 @@ class RetainedActiveGuidanceFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentActiveGuidanceBinding.bind(view)
 
+        MapboxNavigationApp.installComponents(this) {
+            maneuver(
+                binding.maneuverView,
+                config = {
+                    userId = NavigationStyles.NAVIGATION_DAY_STYLE_USER_ID
+                    styleId = NavigationStyles.NAVIGATION_DAY_STYLE_ID
+                }
+            )
+            speedLimit(
+                binding.speedLimitView
+            )
+        }
+
         attachStarted(object : MapboxNavigationObserver {
             override fun onAttached(mapboxNavigation: MapboxNavigation) {
                 mapboxNavigation.flowActiveGuidanceStarted().asLiveData()
@@ -79,9 +94,6 @@ class RetainedActiveGuidanceFragment : Fragment() {
             stopView = binding.stop,
             tripProgressView = binding.tripProgressView
         ).also { MapboxNavigationApp.registerObserver(it) }
-        dropInManeuver = DropInManeuver(
-            maneuverView = binding.maneuverView,
-        ).also { MapboxNavigationApp.registerObserver(it) }
     }
 
     override fun onDestroyView() {
@@ -89,8 +101,6 @@ class RetainedActiveGuidanceFragment : Fragment() {
         // be created within the Fragment lifecycle.
         dropInTripProgress?.let { MapboxNavigationApp.unregisterObserver(it) }
         dropInTripProgress = null
-        dropInManeuver?.let { MapboxNavigationApp.unregisterObserver(it) }
-        dropInManeuver = null
 
         super.onDestroyView()
     }

--- a/qa-test-app/src/main/res/layout/fragment_active_guidance.xml
+++ b/qa-test-app/src/main/res/layout/fragment_active_guidance.xml
@@ -40,4 +40,12 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView
+        android:id="@+id/speedLimitView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        app:layout_constraintTop_toBottomOf="@id/maneuverView"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
As a part of moving components, the PR moves `ManeuverComponent` and `SpeedLimitComponent` outside Drop-In UI.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
