### PR TITLE
do not crash process on unexpected requests

### DIFF
--- a/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/http/MockWebServerRule.kt
+++ b/libtesting-ui/src/main/java/com/mapbox/navigation/testing/ui/http/MockWebServerRule.kt
@@ -43,15 +43,14 @@ class MockWebServerRule : TestWatcher() {
                 requestHandlers.forEach {
                     formattedHandlersBuilder.append("$it\n|")
                 }
-                throw Error(
-                    """Request url:
+                return MockResponse().setResponseCode(500)
+                    .setBody("""Request url:
                       |${request.path}
                       |is not handled.
                       |
                       |Available handlers:
                       |$formattedHandlersBuilder
-                    """.trimMargin()
-                )
+                    """.trimMargin())
             }
         }
     }


### PR DESCRIPTION
### Description
If the SDK makes an unexpected http request, test process crashes and we have very little information of what went wrong because history file isn't saved. 