### PR TITLE
[Drop-In UI] Add support for programmatically changing Info Panel state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+- Introduced `ViewOptionsCustomization.isInfoPanelHideable` that allows control over whether the `NavigationView` Info Panel can hide when it is swiped down. [#6132](https://github.com/mapbox/mapbox-navigation-android/pull/6132)
+- Introduced `ViewOptionsCustomization.infoPanelForcedState` that allows overriding of the `NavigationView` Info Panel (BottomSheetBehaviour) state. [#6132](https://github.com/mapbox/mapbox-navigation-android/pull/6132)
+
 #### Bug fixes and improvements
 
 ## Mapbox Navigation SDK 2.8.0-alpha.1 - 04 August, 2022

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -111,18 +111,24 @@ package com.mapbox.navigation.dropin {
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class ViewOptionsCustomization {
     ctor public ViewOptionsCustomization();
     method public Boolean? getEnableMapLongClickIntercept();
+    method public Integer? getInfoPanelForcedState();
     method public String? getMapStyleUriDay();
     method public String? getMapStyleUriNight();
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions? getRouteArrowOptions();
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions? getRouteLineOptions();
     method public Boolean? getShowInfoPanelInFreeDrive();
+    method public Boolean? isInfoPanelHideable();
     method public void setEnableMapLongClickIntercept(Boolean?);
+    method public void setInfoPanelForcedState(Integer?);
+    method public void setInfoPanelHideable(Boolean?);
     method public void setMapStyleUriDay(String?);
     method public void setMapStyleUriNight(String?);
     method public void setRouteArrowOptions(com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions?);
     method public void setRouteLineOptions(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions?);
     method public void setShowInfoPanelInFreeDrive(Boolean?);
     property public final Boolean? enableMapLongClickIntercept;
+    property public final Integer? infoPanelForcedState;
+    property public final Boolean? isInfoPanelHideable;
     property public final String? mapStyleUriDay;
     property public final String? mapStyleUriNight;
     property public final com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions? routeArrowOptions;

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
@@ -11,6 +11,9 @@ import com.mapbox.navigation.dropin.component.marker.MapMarkerFactory
 import com.mapbox.navigation.dropin.util.BitmapMemoryCache
 import com.mapbox.navigation.dropin.util.BitmapMemoryCache.Companion.MB_IN_BYTES
 import com.mapbox.navigation.ui.app.internal.SharedApp
+import com.mapbox.navigation.ui.app.internal.Store
+import com.mapbox.navigation.ui.utils.internal.Provider
+import com.mapbox.navigation.ui.utils.internal.getValue
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
@@ -26,8 +29,9 @@ internal class NavigationViewContext(
     val context: Context,
     val lifecycleOwner: LifecycleOwner,
     val viewModel: NavigationViewModel,
+    storeProvider: Provider<Store> = Provider { SharedApp.store }
 ) {
-    val store by lazy { SharedApp.store }
+    val store by storeProvider
 
     val mapView = MutableStateFlow<MapView?>(null)
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewOptions.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewOptions.kt
@@ -29,14 +29,19 @@ internal class NavigationViewOptions(context: Context) {
         MutableStateFlow(false)
     private var _enableMapLongClickIntercept: MutableStateFlow<Boolean> =
         MutableStateFlow(true)
+    private var _isInfoPanelHideable: MutableStateFlow<Boolean> =
+        MutableStateFlow(false)
+    private var _infoPanelForcedState: MutableStateFlow<Int> =
+        MutableStateFlow(0)
 
     var mapStyleUriDay: StateFlow<String> = _mapStyleUriDay.asStateFlow()
     var mapStyleUriNight: StateFlow<String> = _mapStyleUriNight.asStateFlow()
     val routeLineOptions: StateFlow<MapboxRouteLineOptions> = _routeLineOptions.asStateFlow()
     val routeArrowOptions: StateFlow<RouteArrowOptions> = _routeArrowOptions.asStateFlow()
     val showInfoPanelInFreeDrive: StateFlow<Boolean> = _showInfoPanelInFreeDrive.asStateFlow()
-    val enableMapLongClickIntercept: StateFlow<Boolean> =
-        _enableMapLongClickIntercept.asStateFlow()
+    val enableMapLongClickIntercept: StateFlow<Boolean> = _enableMapLongClickIntercept.asStateFlow()
+    val isInfoPanelHideable: StateFlow<Boolean> = _isInfoPanelHideable.asStateFlow()
+    val infoPanelForcedState: StateFlow<Int> = _infoPanelForcedState.asStateFlow()
 
     fun applyCustomization(customization: ViewOptionsCustomization) {
         customization.mapStyleUriDay?.also { _mapStyleUriDay.tryEmit(it) }
@@ -44,8 +49,8 @@ internal class NavigationViewOptions(context: Context) {
         customization.routeLineOptions?.also { _routeLineOptions.tryEmit(it) }
         customization.routeArrowOptions?.also { _routeArrowOptions.tryEmit(it) }
         customization.showInfoPanelInFreeDrive?.also { _showInfoPanelInFreeDrive.tryEmit(it) }
-        customization.enableMapLongClickIntercept?.also {
-            _enableMapLongClickIntercept.tryEmit(it)
-        }
+        customization.enableMapLongClickIntercept?.also { _enableMapLongClickIntercept.tryEmit(it) }
+        customization.isInfoPanelHideable?.also { _isInfoPanelHideable.tryEmit(it) }
+        customization.infoPanelForcedState?.also { _infoPanelForcedState.tryEmit(it) }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewOptionsCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewOptionsCustomization.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.dropin
 
 import android.content.Context
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.ui.maps.NavigationStyles
@@ -54,6 +55,21 @@ class ViewOptionsCustomization {
      * Set to `true` as the default behavior.
      */
     var enableMapLongClickIntercept: Boolean? = null
+
+    /**
+     * Sets whether the Info Panel can hide when it is swiped down.
+     * Set to `false` for the default behavior.
+     */
+    var isInfoPanelHideable: Boolean? = null
+
+    /**
+     * Set to override Info Panel BottomSheet state.
+     * Setting this value to one of [BottomSheetBehavior.STATE_COLLAPSED], [BottomSheetBehavior.STATE_EXPANDED],
+     * [BottomSheetBehavior.STATE_HIDDEN] or [BottomSheetBehavior.STATE_HALF_EXPANDED] will disable
+     * default (auto-hiding) behaviour.
+     * Set to `0` to restore the default behavior.
+     */
+    var infoPanelForcedState: Int? = null
 
     companion object {
         /**

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewOptionsTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewOptionsTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.dropin
 import android.content.Context
 import android.graphics.Color
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.maps.Style
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.ui.maps.route.RouteLayerConstants
@@ -40,6 +41,8 @@ internal class NavigationViewOptionsTest {
         assertEquals(c.routeArrowOptions, sut.routeArrowOptions.value)
         assertEquals(c.showInfoPanelInFreeDrive, sut.showInfoPanelInFreeDrive.value)
         assertEquals(c.enableMapLongClickIntercept, sut.enableMapLongClickIntercept.value)
+        assertEquals(c.isInfoPanelHideable, sut.isInfoPanelHideable.value)
+        assertEquals(c.infoPanelForcedState, sut.infoPanelForcedState.value)
     }
 
     private fun customization() =
@@ -58,5 +61,7 @@ internal class NavigationViewOptionsTest {
                 .build()
             showInfoPanelInFreeDrive = true
             enableMapLongClickIntercept = false
+            isInfoPanelHideable = true
+            infoPanelForcedState = BottomSheetBehavior.STATE_EXPANDED
         }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinatorTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinatorTest.kt
@@ -1,0 +1,175 @@
+package com.mapbox.navigation.dropin.coordinator
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.dropin.NavigationViewModel
+import com.mapbox.navigation.dropin.databinding.MapboxNavigationViewLayoutBinding
+import com.mapbox.navigation.dropin.util.TestStore
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLooper
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class InfoPanelCoordinatorTest {
+
+    private lateinit var ctx: Context
+    private lateinit var sut: InfoPanelCoordinator
+    private lateinit var binding: MapboxNavigationViewLayoutBinding
+
+    private lateinit var viewContext: NavigationViewContext
+    private lateinit var testStore: TestStore
+    private lateinit var mapboxNavigation: MapboxNavigation
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+        binding = MapboxNavigationViewLayoutBinding.inflate(
+            LayoutInflater.from(ctx),
+            FrameLayout(ctx)
+        )
+        testStore = TestStore()
+        viewContext = NavigationViewContext(
+            context = ctx,
+            lifecycleOwner = TestLifecycleOwner(),
+            viewModel = NavigationViewModel(),
+            storeProvider = { testStore }
+        )
+        mapboxNavigation = mockk(relaxed = true)
+
+        sut = InfoPanelCoordinator(
+            viewContext,
+            binding.infoPanelLayout,
+            binding.guidelineBottom
+        )
+    }
+
+    @Test
+    fun `init - should hide BottomSheet`() {
+        assertEquals(
+            BottomSheetBehavior.STATE_HIDDEN,
+            BottomSheetBehavior.from(binding.infoPanelLayout).state
+        )
+    }
+
+    @Test
+    fun `should show BottomSheet when NOT in FreeDrive state`() =
+        runBlockingTest {
+            testStore.updateState {
+                it.copy(navigation = NavigationState.RoutePreview)
+            }
+
+            sut.onAttached(mapboxNavigation)
+
+            ShadowLooper.idleMainLooper()
+            assertEquals(BottomSheetBehavior.STATE_COLLAPSED, bottomSheetBehavior().state)
+        }
+
+    @Test
+    fun `should hide BottomSheet when in FreeDrive state`() =
+        runBlockingTest {
+            testStore.updateState {
+                it.copy(navigation = NavigationState.RoutePreview)
+            }
+
+            sut.onAttached(mapboxNavigation)
+            testStore.updateState {
+                it.copy(navigation = NavigationState.FreeDrive)
+            }
+
+            ShadowLooper.idleMainLooper()
+            assertEquals(BottomSheetBehavior.STATE_HIDDEN, bottomSheetBehavior().state)
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `showInfoPanelInFreeDrive customization - should show BottomSheet in FreeDrive when values is true`() =
+        runBlockingTest {
+            viewContext.applyOptionsCustomization {
+                showInfoPanelInFreeDrive = true
+            }
+            testStore.updateState {
+                it.copy(navigation = NavigationState.FreeDrive)
+            }
+
+            sut.onAttached(mapboxNavigation)
+
+            ShadowLooper.idleMainLooper()
+            assertEquals(BottomSheetBehavior.STATE_COLLAPSED, bottomSheetBehavior().state)
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `infoPanelForcedState customization - should update BottomSheet state`() =
+        runBlockingTest {
+            viewContext.applyOptionsCustomization {
+                infoPanelForcedState = BottomSheetBehavior.STATE_EXPANDED
+            }
+            sut.onAttached(mapboxNavigation)
+
+            ShadowLooper.idleMainLooper()
+            assertEquals(BottomSheetBehavior.STATE_EXPANDED, bottomSheetBehavior().state)
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `infoPanelForcedState customization - should not hide BottomSheet when infoPanelForcedState is set`() =
+        runBlockingTest {
+            testStore.updateState {
+                it.copy(navigation = NavigationState.RoutePreview)
+            }
+            viewContext.applyOptionsCustomization {
+                infoPanelForcedState = BottomSheetBehavior.STATE_EXPANDED
+            }
+
+            sut.onAttached(mapboxNavigation)
+            testStore.updateState {
+                it.copy(navigation = NavigationState.FreeDrive)
+            }
+
+            ShadowLooper.idleMainLooper()
+            assertEquals(BottomSheetBehavior.STATE_EXPANDED, bottomSheetBehavior().state)
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `isInfoPanelHideable customization - should enable hiding of BottomSheet`() =
+        runBlockingTest {
+            testStore.updateState {
+                it.copy(navigation = NavigationState.RoutePreview)
+            }
+            sut.onAttached(mapboxNavigation)
+
+            viewContext.applyOptionsCustomization {
+                isInfoPanelHideable = true
+            }
+
+            assertTrue(bottomSheetBehavior().isHideable)
+        }
+
+    private fun bottomSheetBehavior() = BottomSheetBehavior.from(binding.infoPanelLayout)
+
+    private class TestLifecycleOwner : LifecycleOwner {
+        val lifecycleRegistry = LifecycleRegistry(this)
+            .also { it.currentState = Lifecycle.State.INITIALIZED }
+
+        override fun getLifecycle(): Lifecycle = lifecycleRegistry
+    }
+}

--- a/libnavui-util/src/main/java/com/mapbox/navigation/ui/utils/internal/Provider.kt
+++ b/libnavui-util/src/main/java/com/mapbox/navigation/ui/utils/internal/Provider.kt
@@ -1,5 +1,7 @@
 package com.mapbox.navigation.ui.utils.internal
 
+import kotlin.reflect.KProperty
+
 /**
  * An object capable of providing instances of type T.
  */
@@ -10,4 +12,12 @@ fun interface Provider<T> {
     fun get(): T
 }
 
+/**
+ * Shorthand for calling [Provider.get].
+ */
 operator fun <T> Provider<T>.invoke() = get()
+
+/**
+ * Property delegate that exposes [Provider.get] as property getter.
+ */
+operator fun <T> Provider<T>.getValue(thisRef: Any?, property: KProperty<*>): T = get()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -12,4 +12,6 @@ class CustomizedViewModel : ViewModel() {
     val showCustomInfoPanelContent = MutableLiveData(false)
     val showBottomSheetInFreeDrive = MutableLiveData(false)
     val enableOnMapLongClick = MutableLiveData(true)
+    val isInfoPanelHideable = MutableLiveData(false)
+    val infoPanelStateOverride = MutableLiveData("--")
 }

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.LinearLayoutCompat
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -19,102 +18,158 @@
         android:textSize="16sp"
         android:text="NavigationView Customizations" />
 
-    <TableLayout
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:stretchColumns="1"
-        android:padding="10dp">
-        <TableRow android:padding="5dp">
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/toggleViewStyling"
-                android:layout_weight="1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Use custom styling"
-                android:textAllCaps="true" />
-        </TableRow>
-        <TableRow android:padding="5dp">
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/toggleCustomViews"
-                android:layout_weight="1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Use custom views"
-                android:textAllCaps="true" />
-        </TableRow>
-        <TableRow android:padding="5dp">
+        android:layout_height="match_parent">
+
+        <androidx.appcompat.widget.LinearLayoutCompat
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingVertical="10dp"
+            android:paddingHorizontal="15dp">
+
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/toggleReplay"
-                android:layout_weight="1"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
                 android:text="enable replay"
                 android:textAllCaps="true" />
-        </TableRow>
-        <TableRow android:padding="5dp">
+
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/toggleTheme"
-                android:layout_weight="1"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
                 android:text="Dark Theme"
                 android:textAllCaps="true" />
-        </TableRow>
-        <TableRow android:padding="5dp">
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleViewStyling"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="Use custom styling"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleCustomViews"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="Use custom views"
+                android:textAllCaps="true" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textStyle="bold"
+                android:gravity="center"
+                android:layout_marginTop="10dp"
+                android:paddingVertical="10dp"
+                android:text="Map" />
+
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/toggleCustomMap"
-                android:layout_weight="1"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
                 android:text="Use Custom Map"
                 android:textAllCaps="true" />
-        </TableRow>
-        <TableRow android:padding="5dp">
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/toggleCustomInfoPanel"
-                android:layout_weight="1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Custom Info Panel Layout"
-                android:textAllCaps="true" />
-        </TableRow>
-        <TableRow android:padding="5dp">
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/toggleCustomInfoPanelStyles"
-                android:layout_weight="1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Custom Info Panel Styles"
-                android:textAllCaps="true" />
-        </TableRow>
-        <TableRow android:padding="5dp">
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/toggleCustomInfoPanelContent"
-                android:layout_weight="1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Custom Info Panel Content"
-                android:textAllCaps="true" />
-        </TableRow>
-        <TableRow android:padding="5dp">
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/toggleBottomSheetFD"
-                android:layout_weight="1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Show Info Panel IN \nFree Drive"
-                android:textAllCaps="true" />
-        </TableRow>
-        <TableRow android:padding="5dp">
+
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/toggleOnMapLongClick"
                 android:layout_weight="1"
-                android:layout_width="wrap_content"
+                android:paddingVertical="10dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:checked="true"
-                android:text="Enable Map Long Click"
+                android:text="Enable Long Click"
                 android:textAllCaps="true" />
-        </TableRow>
-    </TableLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textStyle="bold"
+                android:gravity="center"
+                android:layout_marginTop="10dp"
+                android:paddingVertical="10dp"
+                android:text="Info Panel" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleBottomSheetFD"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="Show IN Free Drive"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleCustomInfoPanel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="Custom Layout"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleCustomInfoPanelStyles"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="Custom Styles"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleCustomInfoPanelContent"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="Custom Content"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleIsInfoPanelHideable"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="Hideable"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.LinearLayoutCompat
+                android:layout_width="match_parent"
+                android:layout_height="40dp"
+                android:gravity="center_vertical"
+                android:paddingVertical="10dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAllCaps="true"
+                    android:textColor="@color/colorOnSurface"
+                    android:text="STATE OVERRIDE" />
+
+                <androidx.appcompat.widget.AppCompatSpinner
+                    android:id="@+id/spinnerInfoPanelVisibilityOverride"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="5dp"
+                    android:entries="@array/drop_in_info_panel_overrides"
+                    android:spinnerMode="dropdown" />
+            </androidx.appcompat.widget.LinearLayoutCompat>
+
+        </androidx.appcompat.widget.LinearLayoutCompat>
+    </androidx.core.widget.NestedScrollView>
 
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/qa-test-app/src/main/res/values/strings.xml
+++ b/qa-test-app/src/main/res/values/strings.xml
@@ -45,4 +45,12 @@
     <string name="basic_route_line_features_description" translatable="false">Tests basic route line related functionality. \n\nYou should see three route lines on the screen. The blue line is the primary route line. Selecting alternate routes should change the colors such that the line touched turns blue indicating it is the primary route. \n\nOne important use case to observe is: \n\n1. Hide the primary route. \n\n2. Select an alternative route. \n\n3. Notice the route selected becomes the primary route and then disappears, maintaining its state as hidden, while the original primary route line appears colored as an alternative.</string>
 
     <string name="drop_in_buttons_activity_description" translatable="false">Screen for viewing SDK buttons.</string>
+
+    <string-array name="drop_in_info_panel_overrides" translatable="false">
+        <item>--</item>
+        <item>HIDDEN</item>
+        <item>COLLAPSED</item>
+        <item>HALF_EXPANDED</item>
+        <item>EXPANDED</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/6099

### Description

- Added two new options to `NavigationViewOptions`: `.isInfoPanelHideable` and `.infoPanelForcedState` 
- Updated `InfoPanelCoordinator` logic to update BottomSheet state as following:
  ![](https://user-images.githubusercontent.com/2678039/182682314-4d23073a-4638-4b3d-ba44-0d8b2d6adbbb.png)
- Added InfoPanel visibility override examples to qa-test-app.
- Re-gen Metalava API file

### Screenshots or Gifs
_Screen recording of QA Test App captured on Pixel 6_

https://user-images.githubusercontent.com/2678039/183448653-697fa5b9-6695-49a9-b498-b63efb2b1063.mp4


