### PR TITLE
[Android Auto] Bumping maps-androidauto to 0.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -28,7 +28,7 @@ ext {
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.8.0',
-      mapboxMapsAndroidAuto     : '0.1.0',
+      mapboxMapsAndroidAuto     : '0.2.0',
       androidXLifecycle         : '2.4.0',
       androidXCoreVersion       : '1.6.0',
       androidXArchCoreVersion   : '2.1.0',


### PR DESCRIPTION
### Description
Since `extension-androidauto` is now on version 0.2.0, we can already consume this one here probably.

https://github.com/mapbox/mapbox-maps-android/releases/tag/extension-androidauto-v0.2.0