### PR TITLE
[Drop-In UI] Fixed: Drop-In UI goes back to Free drive state when the device is rotated in active guidance with replay enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Introduced `ViewOptionsCustomization.infoPanelForcedState` that allows overriding of the `NavigationView` Info Panel (BottomSheetBehaviour) state. [#6132](https://github.com/mapbox/mapbox-navigation-android/pull/6132)
 
 #### Bug fixes and improvements
+- Fixed an issue where `NavigationView` switches from Active Guidance to Free Drive state after rotating device when replay is enabled. [#6140](https://github.com/mapbox/mapbox-navigation-android/pull/6140) 
 
 ## Mapbox Navigation SDK 2.8.0-alpha.1 - 04 August, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionState.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionState.kt
@@ -3,7 +3,7 @@ package com.mapbox.navigation.core.trip.session
 /**
  * Describes the [TripSession]'s state.
  */
-enum class TripSessionState {
+enum class  TripSessionState {
     /**
      * State when the session is active, running a foreground service and requesting and returning location updates.
      */

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionState.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionState.kt
@@ -3,7 +3,7 @@ package com.mapbox.navigation.core.trip.session
 /**
  * Describes the [TripSession]'s state.
  */
-enum class  TripSessionState {
+enum class TripSessionState {
     /**
      * State when the session is active, running a foreground service and requesting and returning location updates.
      */

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/StateResetController.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/StateResetController.kt
@@ -2,36 +2,42 @@ package com.mapbox.navigation.ui.app.internal.controller
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.core.internal.extensions.flowTripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionState
+import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.endNavigation
 import com.mapbox.navigation.ui.app.internal.extension.dispatch
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.debounce
+import java.util.concurrent.atomic.AtomicBoolean
 
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, FlowPreview::class)
-internal class StateResetController(private val store: Store) : UIComponent() {
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal class StateResetController(
+    private val store: Store,
+    private val ignoreTripSessionUpdates: AtomicBoolean
+) : UIComponent() {
+
+    private var prevState: TripSessionState? = null
+
+    private val tripSessionStateObserver = TripSessionStateObserver { newState ->
+        // we only reset Store state when TripSessionState switches from STARTED to STOPPED.
+        if (!ignoreTripSessionUpdates.get() &&
+            prevState == TripSessionState.STARTED &&
+            newState == TripSessionState.STOPPED
+        ) {
+            store.dispatch(endNavigation())
+        }
+        prevState = newState
+    }
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
-
-        // TripSessionState is triggered rapidly when enabling and disabling replay by
-        // calling `startTripSession, `stopTripSession`, `startReplayTripSession`
-        // Debouncing it by 100 ms ensures we skip transient values.
-        var prevState = mapboxNavigation.getTripSessionState()
-        mapboxNavigation.flowTripSessionState().debounce(100).observe { newState ->
-            if (prevState == TripSessionState.STARTED && newState == TripSessionState.STOPPED) {
-                // we only reset Store state when TripSessionState switches from STARTED to STOPPED.
-                store.dispatch(endNavigation())
-            }
-            prevState = newState
-        }
+        prevState = mapboxNavigation.getTripSessionState()
+        mapboxNavigation.registerTripSessionStateObserver(tripSessionStateObserver)
     }
 
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
         super.onDetached(mapboxNavigation)
+        mapboxNavigation.unregisterTripSessionStateObserver(tripSessionStateObserver)
 
         // we reset Store state every time MapboxNavigation gets destroyed
         store.reset()

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/StateResetControllerTest.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/StateResetControllerTest.kt
@@ -4,7 +4,6 @@ import com.mapbox.geojson.Point
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
-import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.app.internal.State
 import com.mapbox.navigation.ui.app.internal.destination.Destination
 import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
@@ -18,21 +17,17 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
+import java.util.concurrent.atomic.AtomicBoolean
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class StateResetControllerTest {
-
-    @get:Rule
-    var coroutineRule = MainCoroutineRule()
 
     private lateinit var mapboxNavigation: MapboxNavigation
     private lateinit var store: TestStore
     private lateinit var sut: StateResetController
+    private lateinit var ignoreTripSessionUpdates: AtomicBoolean
 
     @Before
     fun setUp() {
@@ -46,39 +41,55 @@ internal class StateResetControllerTest {
                 navigation = NavigationState.ActiveNavigation
             )
         )
-        sut = StateResetController(store)
+        ignoreTripSessionUpdates = AtomicBoolean(false)
+        sut = StateResetController(store, ignoreTripSessionUpdates)
     }
 
     @Test
     @Suppress("MaxLineLength")
-    fun `onAttached, should dispatch actions that end navigation only when TripSessionState transitions from STARTED to STOPPED`() =
-        coroutineRule.runBlockingTest {
-            val observer = slot<TripSessionStateObserver>()
-            every {
-                mapboxNavigation.registerTripSessionStateObserver(capture(observer))
-            } returns Unit
-            sut.onAttached(mapboxNavigation)
+    fun `onAttached, should dispatch actions that end navigation only when TripSessionState transitions from STARTED to STOPPED`() {
+        val observer = slot<TripSessionStateObserver>()
+        every {
+            mapboxNavigation.registerTripSessionStateObserver(capture(observer))
+        } returns Unit
+        sut.onAttached(mapboxNavigation)
 
-            // STOPPED -> STOPPED
-            observer.captured.onSessionStateChanged(TripSessionState.STOPPED)
-            coroutineRule.testDispatcher.advanceTimeBy(200)
-            verify(exactly = 0) { store.dispatch(any()) }
+        // STOPPED -> STOPPED
+        observer.captured.onSessionStateChanged(TripSessionState.STOPPED)
+        verify(exactly = 0) { store.dispatch(any()) }
 
-            // STOPPED -> STARTED
-            observer.captured.onSessionStateChanged(TripSessionState.STARTED)
-            coroutineRule.testDispatcher.advanceTimeBy(200)
-            verify(exactly = 0) { store.dispatch(any()) }
+        // STOPPED -> STARTED
+        observer.captured.onSessionStateChanged(TripSessionState.STARTED)
+        verify(exactly = 0) { store.dispatch(any()) }
 
-            // STARTED -> STOPPED
-            observer.captured.onSessionStateChanged(TripSessionState.STOPPED)
-            coroutineRule.testDispatcher.advanceTimeBy(200)
-            verify(exactly = 1) {
-                store.dispatch(RoutesAction.SetRoutes(emptyList()))
-                store.dispatch(RoutePreviewAction.Ready(emptyList()))
-                store.dispatch(DestinationAction.SetDestination(null))
-                store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
-            }
+        // STARTED -> STOPPED
+        observer.captured.onSessionStateChanged(TripSessionState.STOPPED)
+        verify(exactly = 1) {
+            store.dispatch(RoutesAction.SetRoutes(emptyList()))
+            store.dispatch(RoutePreviewAction.Ready(emptyList()))
+            store.dispatch(DestinationAction.SetDestination(null))
+            store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
         }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `onAttached, should NOT dispatch end navigation action when ignoreTripSessionUpdates is true`() {
+        ignoreTripSessionUpdates.set(true)
+        val observer = slot<TripSessionStateObserver>()
+        every { mapboxNavigation.registerTripSessionStateObserver(capture(observer)) } returns Unit
+        every { mapboxNavigation.getTripSessionState() } returns TripSessionState.STARTED
+        sut.onAttached(mapboxNavigation)
+
+        // STARTED -> STOPPED
+        observer.captured.onSessionStateChanged(TripSessionState.STOPPED)
+        verify(exactly = 0) {
+            store.dispatch(RoutesAction.SetRoutes(emptyList()))
+            store.dispatch(RoutePreviewAction.Ready(emptyList()))
+            store.dispatch(DestinationAction.SetDestination(null))
+            store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
+        }
+    }
 
     @Test
     fun `onDetached should reset Store state`() {


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/6103

### Description

- Introduced `SharedApp.tripSessionTransaction { }` block that temporarily disables `StateResetController` to avoid cleanup logic execution when `TripSession` state changes.
- Updated `StateResetController` to register/unregister `TripSessionStateObserver` instead of collect Flowable. This ensures observer logic gets immediately called when TripSession changes.

### Screenshots or Gifs

_Screen recording of QA Test App captured on Pixel 6_

https://user-images.githubusercontent.com/2678039/183727218-a8b1a34f-6490-41eb-b218-ca7637c79356.mp4


