### PR TITLE
[DropInUi] Remove replayer speed up

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/tripsession/ReplayRouteTripSession.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/tripsession/ReplayRouteTripSession.kt
@@ -31,7 +31,6 @@ internal class ReplayRouteTripSession {
             .also { mapboxNavigation.registerRouteProgressObserver(it) }
 
         mapboxReplayer.pushRealLocation(context, 0.0)
-        mapboxReplayer.playbackSpeed(1.5)
         mapboxReplayer.play()
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves: https://github.com/mapbox/mobile-metrics/issues/850

The benchmarks created by drop-in-ui are being completed in less time because the replayer has this "fast-forward" setting.

My theory is this is creating inaccurate battery metrics.
