### PR TITLE
[Drop-In UI] Added support for drawing info panel behind the navigation bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Updated `NavigationView` to allow drawing of the info panel behind the translucent navigation bar. [#6145](https://github.com/mapbox/mapbox-navigation-android/pull/6145)
 
 ## Mapbox Navigation SDK 2.8.0-alpha.2 - 12 August, 2022
 ### Changelog

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -224,6 +224,7 @@ package com.mapbox.navigation.dropin.binder.infopanel {
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class InfoPanelBinder implements com.mapbox.navigation.ui.base.lifecycle.UIBinder {
     ctor public InfoPanelBinder();
+    method public void applySystemBarsInsets(android.view.ViewGroup layout, androidx.core.graphics.Insets insets);
     method public com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver bind(android.view.ViewGroup viewGroup);
     method public abstract android.view.ViewGroup? getContentLayout(android.view.ViewGroup layout);
     method public abstract android.view.ViewGroup? getHeaderLayout(android.view.ViewGroup layout);

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
@@ -35,7 +35,7 @@ internal class NavigationViewContext(
 
     val mapView = MutableStateFlow<MapView?>(null)
 
-    val systemBarsInsets = MutableStateFlow<Insets?>(null)
+    val systemBarsInsets = MutableStateFlow(Insets.NONE)
 
     val uiBinders = ViewBinder()
     val styles = NavigationViewStyles(context)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/infopanel/InfoPanelBinder.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.dropin.binder.infopanel
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.graphics.Insets
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
@@ -53,6 +54,17 @@ abstract class InfoPanelBinder : UIBinder {
      */
     abstract fun getContentLayout(layout: ViewGroup): ViewGroup?
 
+    /**
+     * Called when the Info Panel layout should apply system bar insets.
+     *
+     * This method should be overridden by a subclass to apply a policy different from the default behavior.
+     * The default behavior applies insets with a value of [Insets.NONE].
+     *
+     * @param layout ViewGroup returned by [onCreateLayout]
+     * @param insets system bars insets
+     */
+    open fun applySystemBarsInsets(layout: ViewGroup, insets: Insets) = Unit
+
     internal fun setBinders(headerBinder: UIBinder?, contentBinder: UIBinder?) {
         this.headerBinder = headerBinder
         this.contentBinder = contentBinder
@@ -81,6 +93,11 @@ abstract class InfoPanelBinder : UIBinder {
         ifNonNull(contentBinder, getContentLayout(layout)) { binder, contentLayout ->
             binders.add(binder.bind(contentLayout))
         }
+
+        context?.apply {
+            applySystemBarsInsets(layout, systemBarsInsets.value)
+        }
+
         return navigationListOf(*binders.toTypedArray())
     }
 
@@ -105,6 +122,15 @@ internal class MapboxInfoPanelBinder : InfoPanelBinder() {
 
     override fun getContentLayout(layout: ViewGroup): ViewGroup? =
         layout.findViewById(R.id.infoPanelContent)
+
+    override fun applySystemBarsInsets(layout: ViewGroup, insets: Insets) {
+        layout.setPadding(
+            layout.paddingLeft,
+            layout.paddingTop,
+            layout.paddingRight,
+            insets.bottom
+        )
+    }
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
         val observer = super.bind(viewGroup)

--- a/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
@@ -20,13 +20,13 @@
     -->
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:id="@+id/coordinatorLayout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="true">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/container"
@@ -122,17 +122,18 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <FrameLayout
-                android:id="@+id/infoPanelLayout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
-                app:behavior_hideable="true"
-                app:behavior_fitToContents="true"
-                tools:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight"
-                tools:background="@drawable/mapbox_bg_info_panel"
-                tools:minHeight="@dimen/mapbox_infoPanel_peekHeight" />
-
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+        <FrameLayout
+            android:id="@+id/infoPanelLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+            app:behavior_hideable="true"
+            app:behavior_fitToContents="true"
+            tools:behavior_peekHeight="@dimen/mapbox_infoPanel_peekHeight"
+            tools:background="@drawable/mapbox_bg_info_panel"
+            tools:minHeight="@dimen/mapbox_infoPanel_peekHeight" />
+
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </merge>

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/infopanel/MapboxInfoPanelBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/infopanel/MapboxInfoPanelBinderTest.kt
@@ -2,13 +2,16 @@ package com.mapbox.navigation.dropin.binder.infopanel
 
 import android.content.Context
 import android.widget.FrameLayout
+import androidx.core.graphics.Insets
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.internal.extensions.MapboxNavigationObserverChain
 import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.dropin.component.infopanel.InfoPanelComponent
 import io.mockk.MockKAnnotations
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -31,6 +34,8 @@ internal class MapboxInfoPanelBinderTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
         ctx = ApplicationProvider.getApplicationContext()
+
+        every { mockNavContext.systemBarsInsets } returns MutableStateFlow(Insets.NONE)
 
         sut = MapboxInfoPanelBinder()
     }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinatorTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/coordinator/InfoPanelCoordinatorTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.dropin.coordinator
 import android.content.Context
 import android.view.LayoutInflater
 import android.widget.FrameLayout
+import androidx.core.graphics.Insets
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -15,8 +16,12 @@ import com.mapbox.navigation.dropin.NavigationViewModel
 import com.mapbox.navigation.dropin.databinding.MapboxNavigationViewLayoutBinding
 import com.mapbox.navigation.dropin.util.TestStore
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
+import com.mapbox.navigation.ui.base.lifecycle.UIBinder
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -163,6 +168,21 @@ class InfoPanelCoordinatorTest {
 
             assertTrue(bottomSheetBehavior().isHideable)
         }
+
+    @Test
+    fun `should reload binders when systemInsets change`() = runBlockingTest {
+        val binders = mutableListOf<UIBinder>()
+        val job = launch {
+            sut.apply {
+                mapboxNavigation.flowViewBinders().take(2).toList(binders)
+            }
+        }
+
+        viewContext.systemBarsInsets.value = Insets.of(0, 0, 0, 10)
+        job.join()
+
+        assertEquals(2, binders.size)
+    }
 
     private fun bottomSheetBehavior() = BottomSheetBehavior.from(binding.infoPanelLayout)
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomInfoPanelBinder.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomInfoPanelBinder.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.qa_test_app.view.customnavview
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.graphics.Insets
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.binder.infopanel.InfoPanelBinder
 import com.mapbox.navigation.qa_test_app.R
@@ -20,4 +21,10 @@ class CustomInfoPanelBinder : InfoPanelBinder() {
 
     override fun getContentLayout(layout: ViewGroup): ViewGroup? =
         layout.findViewById(R.id.infoPanelContent)
+
+    override fun applySystemBarsInsets(layout: ViewGroup, insets: Insets) {
+        layout.layoutParams = (layout.layoutParams as ViewGroup.MarginLayoutParams).apply {
+            setMargins(leftMargin, topMargin, rightMargin, 10.dp + insets.bottom)
+        }
+    }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -14,4 +14,5 @@ class CustomizedViewModel : ViewModel() {
     val enableOnMapLongClick = MutableLiveData(true)
     val isInfoPanelHideable = MutableLiveData(false)
     val infoPanelStateOverride = MutableLiveData("--")
+    val fullScreen = MutableLiveData(false)
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -14,6 +14,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.appcompat.widget.SwitchCompat
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.MutableLiveData
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.geojson.Point
@@ -106,8 +107,19 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
         return menuBinding.root
     }
 
+    private fun updateTheme() {
+        if (viewModel.fullScreen.value == true) {
+            setTheme(R.style.Theme_Fullscreen)
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+        } else {
+            setTheme(R.style.Theme_AppCompat_NoActionBar)
+            WindowCompat.setDecorFitsSystemWindows(window, true)
+        }
+    }
+
     @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        updateTheme()
         super.onCreate(savedInstanceState)
 
         binding.navigationView.addListener(freeDriveInfoPanelInstaller)
@@ -134,6 +146,15 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             menuBinding.toggleCustomMap,
             viewModel.showCustomMapView,
             ::customizeMap
+        )
+
+        bindSwitch(
+            menuBinding.toggleFullscreen,
+            getValue = { viewModel.fullScreen.value == true },
+            setValue = {
+                viewModel.fullScreen.value = it
+                recreate()
+            }
         )
 
         bindSwitch(

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -48,6 +48,15 @@
                 android:textAllCaps="true" />
 
             <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleFullscreen"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="Fullscreen"
+                android:textAllCaps="true" />
+
+            <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/toggleViewStyling"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-navigation-android/issues/6073

### Description

- Updated `NavigationView` layout to allow Info Panel drawing in the same bounds as the map.
- Introduced `InfoPanelBinder.applySystemBarsInsets` method that should be overridden by subclasses to apply insets to custom info panel layouts.
- Updated `MapboxInfoPanelBinder` to adjust the default info panel layout using system bars insets.

### Screenshots or Gifs

_Screen recording of the QA Test App captured on Pixel 2 running Android 11._

https://user-images.githubusercontent.com/2678039/183988001-eea7baa6-4e2c-42ff-8dfa-34a73a98f6fb.mp4


