### PR TITLE
Do not apply snapping include closure for profiles other than driving traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 #### Bug fixes and improvements
 - Fixed an issue where `NavigationView` switches from Active Guidance to Free Drive state after rotating device when replay is enabled. [#6140](https://github.com/mapbox/mapbox-navigation-android/pull/6140) 
+- Fixed reroute for profiles other than driving/traffic. [#6146](https://github.com/mapbox/mapbox-navigation-android/pull/6146)
 
 ## Mapbox Navigation SDK 2.8.0-alpha.1 - 04 August, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdater.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdater.kt
@@ -100,28 +100,32 @@ class RouteOptionsUpdater {
                                 it.addAll(approachesList.subList(index, coordinatesList.size))
                             }
                         }
-                    )
-                    .snappingIncludeClosuresList(
-                        let snappingClosures@{
-                            val snappingClosures = routeOptions.snappingIncludeClosuresList()
-                            mutableListOf<Boolean?>().apply {
-                                // append true for the origin of the re-route request
-                                add(true)
-                                if (snappingClosures.isNullOrEmpty()) {
-                                    // create `null` value for each upcoming waypoint
-                                    addAll(arrayOfNulls<Boolean>(remainingWaypoints))
-                                } else {
-                                    // get existing values for each upcoming waypoint
-                                    addAll(
-                                        snappingClosures.subList(
-                                            index + 1,
-                                            coordinatesList.size
-                                        )
-                                    )
+                    ).apply {
+                        if (routeOptions.profile() == DirectionsCriteria.PROFILE_DRIVING_TRAFFIC) {
+                            snappingIncludeClosuresList(
+                                let snappingClosures@{
+                                    val snappingClosures =
+                                        routeOptions.snappingIncludeClosuresList()
+                                    mutableListOf<Boolean?>().apply {
+                                        // append true for the origin of the re-route request
+                                        add(true)
+                                        if (snappingClosures.isNullOrEmpty()) {
+                                            // create `null` value for each upcoming waypoint
+                                            addAll(arrayOfNulls<Boolean>(remainingWaypoints))
+                                        } else {
+                                            // get existing values for each upcoming waypoint
+                                            addAll(
+                                                snappingClosures.subList(
+                                                    index + 1,
+                                                    coordinatesList.size
+                                                )
+                                            )
+                                        }
+                                    }
                                 }
-                            }
+                            )
                         }
-                    )
+                    }
                     .waypointNamesList(
                         getUpdatedWaypointsList(
                             routeOptions.waypointNamesList(),

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routeoptions/RouteOptionsUpdaterTest.kt
@@ -513,6 +513,15 @@ class RouteOptionsUpdaterTest {
                     1,
                     2,
                     "true;false"
+                ),
+                arrayOf(
+                    provideRouteOptionsWithCoordinates().toBuilder()
+                        .snappingIncludeClosures(null)
+                        .profile(DirectionsCriteria.PROFILE_CYCLING)
+                        .build(),
+                    1,
+                    2,
+                    null
                 )
             )
         }


### PR DESCRIPTION
### Description
The `snapping_include_closures`[ is supported only by driving traffic profile](https://docs.mapbox.com/api/navigation/directions/#optional-parameters-for-the-mapboxdriving-traffic-profile). When the SDK adds `snapping_include_closures` in cycling profile, route request fails, so reroute doesn't work.
