### PR TITLE
add an option to override route options used by android auto

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Bumped maps extension version to fix AAOS issue when changing screens. [#6139](https://github.com/mapbox/mapbox-navigation-android/pull/6139)
 - Added an option to override items displayed in the feedback screen. [#6144](https://github.com/mapbox/mapbox-navigation-android/pull/6144)
 - Fixed an issue with alternative route line not vanishing. [#6153](https://github.com/mapbox/mapbox-navigation-android/pull/6153)
+- Added an option to override route options used for route requests. [#6153](https://github.com/mapbox/mapbox-navigation-android/pull/6153)
 
 ## androidauto-v0.6.0 - Jul 29, 2022
 ### Changelog

--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Added metalava api tracking. Removed `AndroidAutoLog` and `RendererUtils` from public api. [#6130](https://github.com/mapbox/mapbox-navigation-android/pull/6130)
 - Bumped maps extension version to fix AAOS issue when changing screens. [#6139](https://github.com/mapbox/mapbox-navigation-android/pull/6139)
 - Added an option to override items displayed in the feedback screen. [#6144](https://github.com/mapbox/mapbox-navigation-android/pull/6144)
+- Fixed an issue with alternative route line not vanishing. [#6153](https://github.com/mapbox/mapbox-navigation-android/pull/6153)
 
 ## androidauto-v0.6.0 - Jul 29, 2022
 ### Changelog

--- a/libnavui-androidauto/api/current.txt
+++ b/libnavui-androidauto/api/current.txt
@@ -49,7 +49,10 @@ package com.mapbox.androidauto.car {
   }
 
   public final class MainCarContext {
-    ctor public MainCarContext(androidx.car.app.CarContext carContext, com.mapbox.maps.extension.androidauto.MapboxCarMap mapboxCarMap, com.mapbox.search.SearchEngine searchEngine, com.mapbox.androidauto.car.feedback.core.CarFeedbackPollProvider feedbackPollProvider = com.mapbox.androidauto.car.feedback.core.CarFeedbackPollProvider());
+    ctor public MainCarContext(androidx.car.app.CarContext carContext, com.mapbox.maps.extension.androidauto.MapboxCarMap mapboxCarMap, com.mapbox.search.SearchEngine searchEngine, com.mapbox.androidauto.car.feedback.core.CarFeedbackPollProvider feedbackPollProvider = com.mapbox.androidauto.car.feedback.core.CarFeedbackPollProvider(), com.mapbox.androidauto.car.preview.CarRouteOptionsInterceptor routeOptionsInterceptor = CarRouteOptionsInterceptor({ var it: com.mapbox.api.directions.v5.models.RouteOptions.Builder ->
+
+    return it
+}));
     method public androidx.car.app.CarContext getCarContext();
     method public com.mapbox.androidauto.car.settings.CarSettingsStorage getCarSettingsStorage();
     method public com.mapbox.navigation.base.formatter.DistanceFormatter getDistanceFormatter();
@@ -58,7 +61,7 @@ package com.mapbox.androidauto.car {
     method public com.mapbox.navigation.ui.maneuver.api.MapboxManeuverApi getManeuverApi();
     method public com.mapbox.maps.extension.androidauto.MapboxCarMap getMapboxCarMap();
     method public com.mapbox.navigation.core.MapboxNavigation getMapboxNavigation();
-    method public kotlinx.coroutines.flow.MutableStateFlow<java.lang.Boolean> getRouteAlternativesEnabled();
+    method public com.mapbox.androidauto.car.preview.CarRouteOptionsInterceptor getRouteOptionsInterceptor();
     method public com.mapbox.search.SearchEngine getSearchEngine();
     property public final androidx.car.app.CarContext carContext;
     property public final com.mapbox.androidauto.car.settings.CarSettingsStorage carSettingsStorage;
@@ -67,7 +70,7 @@ package com.mapbox.androidauto.car {
     property public final com.mapbox.navigation.ui.maneuver.api.MapboxManeuverApi maneuverApi;
     property public final com.mapbox.maps.extension.androidauto.MapboxCarMap mapboxCarMap;
     property public final com.mapbox.navigation.core.MapboxNavigation mapboxNavigation;
-    property public final kotlinx.coroutines.flow.MutableStateFlow<java.lang.Boolean> routeAlternativesEnabled;
+    property public final com.mapbox.androidauto.car.preview.CarRouteOptionsInterceptor routeOptionsInterceptor;
     property public final com.mapbox.search.SearchEngine searchEngine;
   }
 
@@ -620,6 +623,10 @@ package com.mapbox.androidauto.car.preview {
     property public final com.mapbox.androidauto.car.MainCarContext mainCarContext;
   }
 
+  public fun interface CarRouteOptionsInterceptor {
+    method public com.mapbox.api.directions.v5.models.RouteOptions.Builder intercept(com.mapbox.api.directions.v5.models.RouteOptions.Builder builder);
+  }
+
   @com.mapbox.maps.MapboxExperimental public final class CarRoutePreviewScreen extends androidx.car.app.Screen {
     ctor public CarRoutePreviewScreen(com.mapbox.androidauto.car.preview.RoutePreviewCarContext routePreviewCarContext, com.mapbox.androidauto.car.search.PlaceRecord placeRecord, java.util.List<com.mapbox.navigation.base.route.NavigationRoute> navigationRoutes, com.mapbox.androidauto.car.placeslistonmap.PlacesListOnMapLayerUtil placesLayerUtil = com.mapbox.androidauto.car.placeslistonmap.PlacesListOnMapLayerUtil());
     method public com.mapbox.androidauto.car.location.CarLocationRenderer getCarLocationRenderer();
@@ -637,7 +644,7 @@ package com.mapbox.androidauto.car.preview {
   }
 
   public final class CarRouteRequest {
-    ctor public CarRouteRequest(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation, com.mapbox.navigation.ui.maps.location.NavigationLocationProvider navigationLocationProvider);
+    ctor public CarRouteRequest(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation, com.mapbox.androidauto.car.preview.CarRouteOptionsInterceptor routeOptionsInterceptor, com.mapbox.navigation.ui.maps.location.NavigationLocationProvider navigationLocationProvider);
     method public void cancelRequest();
     method public com.mapbox.navigation.core.MapboxNavigation getMapboxNavigation();
     method public void request(com.mapbox.androidauto.car.search.PlaceRecord placeRecord, com.mapbox.androidauto.car.preview.CarRouteRequestCallback callback);

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarContext.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarContext.kt
@@ -2,6 +2,7 @@ package com.mapbox.androidauto.car
 
 import androidx.car.app.CarContext
 import com.mapbox.androidauto.car.feedback.core.CarFeedbackPollProvider
+import com.mapbox.androidauto.car.preview.CarRouteOptionsInterceptor
 import com.mapbox.androidauto.car.settings.CarSettingsStorage
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMap
@@ -15,7 +16,6 @@ import com.mapbox.search.SearchEngine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
 
 @OptIn(MapboxExperimental::class)
 class MainCarContext(
@@ -23,6 +23,7 @@ class MainCarContext(
     val mapboxCarMap: MapboxCarMap,
     val searchEngine: SearchEngine,
     val feedbackPollProvider: CarFeedbackPollProvider = CarFeedbackPollProvider(),
+    val routeOptionsInterceptor: CarRouteOptionsInterceptor = CarRouteOptionsInterceptor { it },
 ) {
     val carSettingsStorage = CarSettingsStorage(carContext)
 
@@ -39,8 +40,6 @@ class MainCarContext(
     val maneuverApi: MapboxManeuverApi by lazy {
         MapboxManeuverApi(distanceFormatter)
     }
-
-    val routeAlternativesEnabled = MutableStateFlow(value = true)
 
     fun getJobControl(): JobControl {
         val supervisorJob = SupervisorJob()

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteLine.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteLine.kt
@@ -23,7 +23,6 @@ import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
-import com.mapbox.navigation.ui.maps.route.line.model.NavigationRouteLine
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
 import kotlinx.coroutines.CoroutineScope
@@ -73,8 +72,9 @@ class CarRouteLine internal constructor(
         logAndroidAuto("CarRouteLine onRoutesChanged ${routes.size}")
         mainCarContext.mapboxCarMap.carMapSurface?.getStyle()?.let { style ->
             if (routes.isNotEmpty()) {
-                val routeLines = routes.map { NavigationRouteLine(it, identifier = null) }
-                routeLineApi.setNavigationRouteLines(routeLines) { value ->
+                val routesMetadata =
+                    mainCarContext.mapboxNavigation.getAlternativeMetadataFor(routes)
+                routeLineApi.setNavigationRoutes(routes, routesMetadata) { value ->
                     routeLineView.renderRouteDrawData(style, value)
                 }
             } else {

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteOptionsInterceptor.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteOptionsInterceptor.kt
@@ -1,0 +1,16 @@
+package com.mapbox.androidauto.car.preview
+
+import com.mapbox.api.directions.v5.models.RouteOptions
+
+/**
+ * This allows you to change the route options used by Android Auto for requesting a route.
+ */
+fun interface CarRouteOptionsInterceptor {
+
+    /**
+     * Called before the route is requested.
+     *
+     * @param builder with initial route options
+     */
+    fun intercept(builder: RouteOptions.Builder): RouteOptions.Builder
+}

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteRequest.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteRequest.kt
@@ -34,6 +34,7 @@ interface CarRouteRequestCallback {
  */
 class CarRouteRequest(
     val mapboxNavigation: MapboxNavigation,
+    private val routeOptionsInterceptor: CarRouteOptionsInterceptor,
     private val navigationLocationProvider: NavigationLocationProvider,
 ) {
     internal var currentRequestId: Long? = null
@@ -119,6 +120,7 @@ class CarRouteRequest(
         .coordinatesList(listOf(origin, destination))
         .layersList(listOf(mapboxNavigation.getZLevel(), null))
         .metadata(true)
+        .let { routeOptionsInterceptor.intercept(it) }
         .build()
 
     /**

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/SearchCarContext.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/SearchCarContext.kt
@@ -22,6 +22,7 @@ class SearchCarContext(
     )
     val carRouteRequest = CarRouteRequest(
         mainCarContext.mapboxNavigation,
+        mainCarContext.routeOptionsInterceptor,
         MapboxCarApp.carAppLocationService().navigationLocationProvider
     )
 }


### PR DESCRIPTION
### Description
Removed `routeAlternativesEnabled` flow in `MainCarContext` in favor of a more flexible `CarRouteOptionsInterceptor` that allows you to override any route options. This can be used to enable/disable alternatives. Also fixed an issue with alternative route line not vanishing. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
