### PR TITLE
Bump NN, Maps and Common dependency versions to `112.0.0`, `10.8.0-beta.1` and `23.0.0-beta.1` respectively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Updated `NavigationView` to allow drawing of the info panel behind the translucent navigation bar. [#6145](https://github.com/mapbox/mapbox-navigation-android/pull/6145)
 - Optimized vanishing line updates (`MapboxRouteLineApi#updateTraveledRouteLine`) when going through restrictions and legs aren't styled independently. [#6169](https://github.com/mapbox/mapbox-navigation-android/pull/6169)
+- Added support for _Onboard_ `snapping_include_static_closures` route request parameter (`RouteOptions#snappingIncludeStaticClosures). [#6168](https://github.com/mapbox/mapbox-navigation-android/pull/6168)
+- Fixed a race condition that could cause a hang during `TileStore` clean up. [#6168](https://github.com/mapbox/mapbox-navigation-android/pull/6168)
+- Fixed a crash when the `TileStore` service process is killed by the Android system. [#6168](https://github.com/mapbox/mapbox-navigation-android/pull/6168)
+- Fixed an issue where some callbacks for completed operations would be invoked again if the `TileStore` service process was terminated. [#6168](https://github.com/mapbox/mapbox-navigation-android/pull/6168)
+- Fixed calculation of `AlternativeRouteMetadata` (duration and distance). [#6168](https://github.com/mapbox/mapbox-navigation-android/pull/6168)
 
 ## Mapbox Navigation SDK 2.8.0-alpha.2 - 12 August, 2022
 ### Changelog

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1484,7 +1484,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Navigation uses portions of the Android Support Library compat (The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.).
-URL: [https://developer.android.com/jetpack/androidx/releases/core#1.6.0](https://developer.android.com/jetpack/androidx/releases/core#1.6.0)
+URL: [https://developer.android.com/jetpack/androidx/releases/core#1.7.0](https://developer.android.com/jetpack/androidx/releases/core#1.7.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================
@@ -1597,6 +1597,12 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the AndroidX Futures (Androidx implementation of Guava's ListenableFuture).
+URL: [https://developer.android.com/topic/libraries/architecture/index.html](https://developer.android.com/topic/libraries/architecture/index.html)
+License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the AndroidX Widget ViewPager2.
 URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1604,7 +1610,7 @@ License: [The Apache Software License, Version 2.0](http://www.apache.org/licens
 ===========================================================================
 
 Mapbox Navigation uses portions of the Core Kotlin Extensions (Kotlin extensions for 'core' artifact).
-URL: [https://developer.android.com/jetpack/androidx](https://developer.android.com/jetpack/androidx)
+URL: [https://developer.android.com/jetpack/androidx/releases/core#1.7.0](https://developer.android.com/jetpack/androidx/releases/core#1.7.0)
 License: [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ===========================================================================

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,17 +13,17 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '111.0.0'
+      mapboxNavigatorVersion = '112.0.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 
   version = [
-      mapboxMapSdk              : '10.7.0',
+      mapboxMapSdk              : '10.8.0-beta.1',
       mapboxSdkServices         : '6.8.0-beta.1',
       mapboxEvents              : '8.1.5',
       mapboxCore                : '5.0.2',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
-      mapboxCommonNative        : '22.1.1',
+      mapboxCommonNative        : '23.0.0-beta.1',
       mapboxSearchSdk           : '1.0.0-beta.29',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -241,8 +241,8 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
             alternativesMetadata.navigationRoute.id
         )
         assertNotEquals(alternativesMetadataLegacy, alternativesMetadata)
-        assertEquals(266.0, alternativesMetadataLegacy.infoFromStartOfPrimary.duration, 1.0)
-        assertEquals(275.0, alternativesMetadata.infoFromStartOfPrimary.duration, 1.0)
+        assertEquals(267.9, alternativesMetadataLegacy.infoFromStartOfPrimary.duration, 1.0)
+        assertEquals(277.0, alternativesMetadata.infoFromStartOfPrimary.duration, 1.0)
     }
 
     private fun stayOnInitialPosition() {

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/roadobject/RoadObjectMapperTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/trip/model/roadobject/RoadObjectMapperTest.kt
@@ -381,7 +381,8 @@ class RoadObjectMapperTest {
             location,
             type,
             RoadObjectProvider.MAPBOX,
-            metadata
+            metadata,
+            false,
         )
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -576,7 +576,8 @@ class NavigatorMapperTest {
         MatchedRoadObjectLocation.valueOf(routeAlertLocation),
         com.mapbox.navigator.RoadObjectType.TUNNEL,
         RoadObjectProvider.MAPBOX,
-        RoadObjectMetadata.valueOf(com.mapbox.navigator.TunnelInfo("Ted Williams Tunnel"))
+        RoadObjectMetadata.valueOf(com.mapbox.navigator.TunnelInfo("Ted Williams Tunnel")),
+        false,
     )
 
     private fun RoadObject.toUpcomingRouteAlert(


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
- Bumps NN, Maps and Common dependency versions to `112.0.0`, [`10.8.0-beta.1`](https://github.com/mapbox/mapbox-maps-android/releases/tag/v10.8.0-beta.1) and `23.0.0-beta.1` respectively
