### PR TITLE
optimize vanishing line updates when going through restrictions and legs aren't styled independently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 #### Bug fixes and improvements
 - Updated `NavigationView` to allow drawing of the info panel behind the translucent navigation bar. [#6145](https://github.com/mapbox/mapbox-navigation-android/pull/6145)
+- Optimized vanishing line updates (`MapboxRouteLineApi#updateTraveledRouteLine`) when going through restrictions and legs aren't styled independently. [#6169](https://github.com/mapbox/mapbox-navigation-android/pull/6169)
 
 ## Mapbox Navigation SDK 2.8.0-alpha.2 - 12 August, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -447,34 +447,31 @@ class MapboxRouteLineApi(
             )
         }
 
-        val workingRouteLineExpressionData =
-            if (routeLineOptions.styleInactiveRouteLegsIndependently) {
-                alternativelyStyleSegmentsNotInLeg(activeLegIndex, routeLineExpressionData)
-            } else {
-                routeLineExpressionData
-            }
-
         val stopGap: Double = ifNonNull(primaryRoute?.directionsRoute) { route ->
             RouteLayerConstants.SOFT_GRADIENT_STOP_GAP_METERS / route.distance()
         } ?: .00000000001 // an arbitrarily small value so Expression values are in ascending order
 
-        val restrictedExpressionData: List<ExtractedRouteData>? =
-            ifNonNull(primaryRoute?.directionsRoute) { route ->
-                if (routeLineOptions.displayRestrictedRoadSections && routeHasRestrictions) {
-                    MapboxRouteLineUtils.extractRouteData(
-                        route,
-                        MapboxRouteLineUtils.getTrafficCongestionAnnotationProvider(
-                            route,
-                            routeLineOptions.resourceProvider.routeLineColorResources
-                        )
-                    )
-                } else {
-                    null
-                }
-            }
-
         val routeLineExpressionProviders =
             if (routeLineOptions.styleInactiveRouteLegsIndependently) {
+                val workingRouteLineExpressionData =
+                    alternativelyStyleSegmentsNotInLeg(activeLegIndex, routeLineExpressionData)
+
+                val restrictedExpressionData: List<ExtractedRouteData>? =
+                    ifNonNull(primaryRoute?.directionsRoute) { route ->
+                        if (routeLineOptions.displayRestrictedRoadSections &&
+                            routeHasRestrictions
+                        ) {
+                            MapboxRouteLineUtils.extractRouteData(
+                                route,
+                                MapboxRouteLineUtils.getTrafficCongestionAnnotationProvider(
+                                    route,
+                                    routeLineOptions.resourceProvider.routeLineColorResources
+                                )
+                            )
+                        } else {
+                            null
+                        }
+                    }
                 routeLineOptions.vanishingRouteLine?.getTraveledRouteLineExpressions(
                     point,
                     workingRouteLineExpressionData,

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
@@ -26,6 +26,7 @@ import kotlin.math.abs
  * @param styleInactiveRouteLegsIndependently enabling this feature will change the color of the route
  * legs that aren't currently being navigated. See [RouteLineColorResources] to specify the color
  * used.
+ * **Enabling this feature when [vanishingRouteLine] is enabled can have negative performance implications, especially for long routes.**
  * @param displaySoftGradientForTraffic determines if the color transition between traffic congestion
  * changes should use a soft gradient appearance or abrupt color change. This is false by default.
  * @param softGradientTransition influences the length of the color transition when the displaySoftGradientForTraffic

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/AlternativeRouteActivity.kt
@@ -103,6 +103,7 @@ class AlternativeRouteActivity : AppCompatActivity(), OnMapLongClickListener {
             .withRouteLineResources(routeLineResources)
             .withRouteLineBelowLayerId("road-label-navigation")
             .withVanishingRouteLineEnabled(true)
+            .displayRestrictedRoadSections(true)
             .build()
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
https://github.com/mapbox/mapbox-navigation-android/issues/6167 describes an issue of using the full extracted route data LRU cache, which key is based on the full hash of the `DirectionsRoute`. The cache lookup is actually only needed when the legs are styled independently, since we can't use the `trim-offset` expression for that scenario. This PR addresses the issue for a scenario where independently styled route legs _are not_ used.

There's a huge performance improvement for a route from Munich to Madrid going through restrictions:
_before_
 
![Screenshot from 2022-08-15 12-47-47](https://user-images.githubusercontent.com/16925074/184626437-709a708d-961f-48bb-8c4f-b1ae7fc432b4.png)

_after_
![Screenshot from 2022-08-15 12-50-34](https://user-images.githubusercontent.com/16925074/184626449-62359fdc-a606-4187-8e1d-6d8ee28858aa.png)

We can see a main thread usage by the `MapboxRouteLineApi#updateTraveledRouteLine` **dropping from over 20% to less than 1%** on a Samsung S22+.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
