### PR TITLE
Revert "bump mapbox navigator dependency version to 111.0.1 (#6166)"

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '111.0.1'
+      mapboxNavigatorVersion = '111.0.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 


### PR DESCRIPTION
This reverts commit 5d462cdd83c71035bdf5b4f3cfb7bed0b8f9c34d.