### PR TITLE
optimized cache management when switching between routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Updated `NavigationView` to allow drawing of the info panel behind the translucent navigation bar. [#6145](https://github.com/mapbox/mapbox-navigation-android/pull/6145)
 - Optimized vanishing line updates (`MapboxRouteLineApi#updateTraveledRouteLine`) when going through restrictions and legs aren't styled independently. [#6169](https://github.com/mapbox/mapbox-navigation-android/pull/6169)
+- Optimized cache management when switching between primary and alternative routes to improve the execution time of `MapboxRouteLineApi#setNavigationRoutes`. [#6171](https://github.com/mapbox/mapbox-navigation-android/pull/6171)
 - Added support for _Onboard_ `snapping_include_static_closures` route request parameter (`RouteOptions#snappingIncludeStaticClosures). [#6168](https://github.com/mapbox/mapbox-navigation-android/pull/6168)
 - Fixed a race condition that could cause a hang during `TileStore` clean up. [#6168](https://github.com/mapbox/mapbox-navigation-android/pull/6168)
 - Fixed a crash when the `TileStore` service process is killed by the Android system. [#6168](https://github.com/mapbox/mapbox-navigation-android/pull/6168)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -1429,10 +1429,8 @@ internal object MapboxRouteLineUtils {
         } ?: false
     }
 
-    internal fun resetCache() {
-        synchronized(extractRouteDataCache) {
-            extractRouteDataCache.evictAll()
-        }
+    internal fun trimRouteDataCacheToSize(size: Int) {
+        extractRouteDataCache.trimToSize(size)
     }
 
     internal fun getLayerIdsForPrimaryRoute(

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsRoboTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsRoboTest.kt
@@ -907,18 +907,37 @@ class MapboxRouteLineUtilsRoboTest {
     }
 
     @Test
-    fun resetExtractRouteDataCache() {
+    fun `trim route data cache`() {
         val route1 = mockk<DirectionsRoute> {
+            every { legs() } returns null
+        }
+        val route2 = mockk<DirectionsRoute> {
             every { legs() } returns null
         }
         val trafficCongestionProvider = MapboxRouteLineUtils.getRouteLegTrafficCongestionProvider
         MapboxRouteLineUtils.extractRouteData(route1, trafficCongestionProvider)
         MapboxRouteLineUtils.extractRouteData(route1, trafficCongestionProvider)
+        MapboxRouteLineUtils.extractRouteData(route2, trafficCongestionProvider)
+        MapboxRouteLineUtils.extractRouteData(route2, trafficCongestionProvider)
         verify(exactly = 1) { route1.legs() }
+        verify(exactly = 1) { route2.legs() }
 
-        MapboxRouteLineUtils.resetCache()
+        MapboxRouteLineUtils.trimRouteDataCacheToSize(1) // removes route1
         MapboxRouteLineUtils.extractRouteData(route1, trafficCongestionProvider)
-
+        MapboxRouteLineUtils.extractRouteData(route2, trafficCongestionProvider)
         verify(exactly = 2) { route1.legs() }
+        verify(exactly = 1) { route2.legs() }
+
+        MapboxRouteLineUtils.trimRouteDataCacheToSize(0) // removes both routes
+        MapboxRouteLineUtils.extractRouteData(route1, trafficCongestionProvider)
+        MapboxRouteLineUtils.extractRouteData(route2, trafficCongestionProvider)
+        verify(exactly = 3) { route1.legs() }
+        verify(exactly = 2) { route2.legs() }
+
+        MapboxRouteLineUtils.trimRouteDataCacheToSize(2) // doesn't remove anything
+        MapboxRouteLineUtils.extractRouteData(route1, trafficCongestionProvider)
+        MapboxRouteLineUtils.extractRouteData(route2, trafficCongestionProvider)
+        verify(exactly = 3) { route1.legs() }
+        verify(exactly = 2) { route2.legs() }
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Closes https://github.com/mapbox/mapbox-navigation-android/issues/6138 by trimming the route parsing cache to the size of the new collection of routes, instead of clearing it entirely. This still correctly evicts the route references when they are intentionally cleared while keeping the cache when routes are switched. Additionally, filters out duplicates by `NavigationRoute#id` to not allow them to impact the size of the cache.

For a route from Munich to Madrid, on Samsung S22+, I see the execution time of `MapboxRouteLineApi#setNavigationRoutes` when switching between alternative routes decreasing from ~140ms to ~25ms.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
