### PR TITLE
keep snapshot name matching latest pre-release name

### DIFF
--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -39,9 +39,19 @@ def getSnapshotVersion(String version) {
         return "0.1.0-SNAPSHOT"
     } else {
         def prefix = project.ext.releaseTagPrefix
-        def matcher = version =~ /$prefix(\d+).(\d+)?.*/
+        def matcher = version =~ /$prefix(\d+)\.(\d+)\.(\d+.*)/
         def major = (matcher[0][1] as Integer)
-        def minor = (matcher[0][2] as Integer) + 1
+        def isPreRelease
+        try {
+            Integer.parseInt(matcher[0][3])
+            isPreRelease = false
+        } catch (NumberFormatException ignored) {
+            isPreRelease = true
+        }
+        def minor = (matcher[0][2] as Integer)
+        if (!isPreRelease) {
+            minor += 1
+        }
         return "${major}.${minor}.0-SNAPSHOT"
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes the snapshot name generator to respect pre-releases and only increment the version name on stable releases.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
