### PR TITLE
[Drop-In UI] Expose public APIs via NavigationViewApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Updated `NavigationViewApi`. Introduced `startFreeDrive`, `startDestinationPreview`, `startRoutePreview`, `startActiveGuidance`, `startArrival`. Removed `fetchRoutes`, `setPreviewRoutes`, `setRoutes`, `setDestination`. Replaced `enableTripSession` and `enableReplaySession` with `routeReplayEnabled(enabled: Boolean)`. [#6174](https://github.com/mapbox/mapbox-navigation-android/pull/6174)
 
 ## Mapbox Navigation SDK 2.8.0-alpha.3 - 17 August, 2022
 ### Changelog

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -40,24 +40,16 @@ package com.mapbox.navigation.dropin {
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class NavigationViewApi {
     ctor public NavigationViewApi();
-    method public abstract void enableReplaySession();
-    method public abstract void enableTripSession();
-    method public abstract void endNavigation();
-    method public abstract void fetchRoutes(com.mapbox.api.directions.v5.models.RouteOptions options);
-    method public abstract void fetchRoutes(java.util.List<com.mapbox.geojson.Point> points);
     method public abstract boolean isReplayEnabled();
-    method public abstract void setDestination(com.mapbox.geojson.Point point);
-    method public abstract void setPreviewRoutes(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
-    method public abstract void setRoutes(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
-    method public abstract void startArrival();
+    method public abstract void routeReplayEnabled(boolean enabled);
+    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startArrival();
+    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startArrival(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    method public abstract void startDestinationPreview(com.mapbox.geojson.Point point);
     method public abstract void startFreeDrive();
-    method @kotlin.jvm.Throws(exceptionClasses=IllegalStateException::class) public abstract void startNavigation() throws java.lang.IllegalStateException;
-    method @kotlin.jvm.Throws(exceptionClasses=IllegalStateException::class) public abstract void startRoutePreview() throws java.lang.IllegalStateException;
-  }
-
-  public final class NavigationViewApiKt {
-    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI @kotlin.jvm.Throws(exceptionClasses=IllegalArgumentException::class) public static void startNavigation(com.mapbox.navigation.dropin.NavigationViewApi, com.mapbox.geojson.Point destination, java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes) throws java.lang.IllegalArgumentException;
-    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI @kotlin.jvm.Throws(exceptionClasses=IllegalArgumentException::class) public static void startRoutePreview(com.mapbox.navigation.dropin.NavigationViewApi, com.mapbox.geojson.Point destination, java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes) throws java.lang.IllegalArgumentException;
+    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startNavigation();
+    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startNavigation(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startRoutePreview();
+    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startRoutePreview(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
   }
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class NavigationViewListener {

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -38,15 +38,26 @@ package com.mapbox.navigation.dropin {
     property public final com.mapbox.navigation.dropin.NavigationViewApi api;
   }
 
-  @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class NavigationViewApi {
-    method public void enableReplaySession();
-    method public void enableTripSession();
-    method public void fetchRoutes(com.mapbox.api.directions.v5.models.RouteOptions options);
-    method public void fetchRoutes(java.util.List<com.mapbox.geojson.Point> points);
-    method public boolean isReplayEnabled();
-    method public void setDestination(com.mapbox.geojson.Point point);
-    method public void setPreviewRoutes(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
-    method public void setRoutes(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+  @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class NavigationViewApi {
+    ctor public NavigationViewApi();
+    method public abstract void enableReplaySession();
+    method public abstract void enableTripSession();
+    method public abstract void endNavigation();
+    method public abstract void fetchRoutes(com.mapbox.api.directions.v5.models.RouteOptions options);
+    method public abstract void fetchRoutes(java.util.List<com.mapbox.geojson.Point> points);
+    method public abstract boolean isReplayEnabled();
+    method public abstract void setDestination(com.mapbox.geojson.Point point);
+    method public abstract void setPreviewRoutes(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    method public abstract void setRoutes(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    method public abstract void startArrival();
+    method public abstract void startFreeDrive();
+    method @kotlin.jvm.Throws(exceptionClasses=IllegalStateException::class) public abstract void startNavigation() throws java.lang.IllegalStateException;
+    method @kotlin.jvm.Throws(exceptionClasses=IllegalStateException::class) public abstract void startRoutePreview() throws java.lang.IllegalStateException;
+  }
+
+  public final class NavigationViewApiKt {
+    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI @kotlin.jvm.Throws(exceptionClasses=IllegalArgumentException::class) public static void startNavigation(com.mapbox.navigation.dropin.NavigationViewApi, com.mapbox.geojson.Point destination, java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes) throws java.lang.IllegalArgumentException;
+    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI @kotlin.jvm.Throws(exceptionClasses=IllegalArgumentException::class) public static void startRoutePreview(com.mapbox.navigation.dropin.NavigationViewApi, com.mapbox.geojson.Point destination, java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes) throws java.lang.IllegalArgumentException;
   }
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class NavigationViewListener {

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -42,14 +42,37 @@ package com.mapbox.navigation.dropin {
     ctor public NavigationViewApi();
     method public abstract boolean isReplayEnabled();
     method public abstract void routeReplayEnabled(boolean enabled);
-    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startArrival();
-    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startArrival(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startActiveGuidance();
+    method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startActiveGuidance(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startArrival();
+    method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startArrival(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
     method public abstract void startDestinationPreview(com.mapbox.geojson.Point point);
     method public abstract void startFreeDrive();
-    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startNavigation();
-    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startNavigation(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
-    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startRoutePreview();
-    method public abstract com.mapbox.bindgen.Expected<java.lang.Throwable,kotlin.Unit> startRoutePreview(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startRoutePreview();
+    method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startRoutePreview(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+  }
+
+  public abstract sealed class NavigationViewApiError extends java.lang.Throwable {
+  }
+
+  public static final class NavigationViewApiError.IncompleteRoutesInfo extends com.mapbox.navigation.dropin.NavigationViewApiError {
+    field public static final com.mapbox.navigation.dropin.NavigationViewApiError.IncompleteRoutesInfo INSTANCE;
+  }
+
+  public static final class NavigationViewApiError.InvalidRoutesInfo extends com.mapbox.navigation.dropin.NavigationViewApiError {
+    field public static final com.mapbox.navigation.dropin.NavigationViewApiError.InvalidRoutesInfo INSTANCE;
+  }
+
+  public static final class NavigationViewApiError.MissingDestinationInfo extends com.mapbox.navigation.dropin.NavigationViewApiError {
+    field public static final com.mapbox.navigation.dropin.NavigationViewApiError.MissingDestinationInfo INSTANCE;
+  }
+
+  public static final class NavigationViewApiError.MissingPreviewRoutesInfo extends com.mapbox.navigation.dropin.NavigationViewApiError {
+    field public static final com.mapbox.navigation.dropin.NavigationViewApiError.MissingPreviewRoutesInfo INSTANCE;
+  }
+
+  public static final class NavigationViewApiError.MissingRoutesInfo extends com.mapbox.navigation.dropin.NavigationViewApiError {
+    field public static final com.mapbox.navigation.dropin.NavigationViewApiError.MissingRoutesInfo INSTANCE;
   }
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class NavigationViewListener {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -35,6 +35,7 @@ import com.mapbox.navigation.dropin.coordinator.RightFrameCoordinator
 import com.mapbox.navigation.dropin.coordinator.RoadNameLabelCoordinator
 import com.mapbox.navigation.dropin.coordinator.SpeedLimitCoordinator
 import com.mapbox.navigation.dropin.databinding.MapboxNavigationViewLayoutBinding
+import com.mapbox.navigation.dropin.internal.MapboxNavigationViewApi
 import com.mapbox.navigation.dropin.internal.extensions.navigationViewAccessToken
 import com.mapbox.navigation.dropin.internal.extensions.toComponentActivityRef
 import com.mapbox.navigation.dropin.internal.extensions.toViewModelStoreOwner
@@ -155,7 +156,7 @@ class NavigationView @JvmOverloads constructor(
     /**
      * Api for changing navigation state.
      */
-    val api: NavigationViewApi = NavigationViewApi(navigationContext.store)
+    val api: NavigationViewApi = MapboxNavigationViewApi(navigationContext.store)
 
     /**
      * Customize the views by implementing your own [UIBinder] components.

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewApi.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewApi.kt
@@ -39,7 +39,7 @@ abstract class NavigationViewApi {
      *
      * Fails with an error when either Destination or Preview Routes has not been set.
      */
-    abstract fun startRoutePreview(): Expected<Throwable, Unit>
+    abstract fun startRoutePreview(): Expected<NavigationViewApiError, Unit>
 
     /**
      * Sets a preview [routes] and request Request [NavigationView] to enter Route Preview state.
@@ -51,7 +51,9 @@ abstract class NavigationViewApi {
      *
      * Fails with an error when [routes] is an empty list.
      */
-    abstract fun startRoutePreview(routes: List<NavigationRoute>): Expected<Throwable, Unit>
+    abstract fun startRoutePreview(
+        routes: List<NavigationRoute>
+    ): Expected<NavigationViewApiError, Unit>
 
     /**
      * Request [NavigationView] to enter Active Navigation state.
@@ -61,7 +63,7 @@ abstract class NavigationViewApi {
      *
      * Fails with an error when either Destination or Preview Routes has not been set.
      */
-    abstract fun startNavigation(): Expected<Throwable, Unit>
+    abstract fun startActiveGuidance(): Expected<NavigationViewApiError, Unit>
 
     /**
      * Sets [routes] and request [NavigationView] to enter Active Navigation state.
@@ -73,7 +75,9 @@ abstract class NavigationViewApi {
      *
      * Fails with an error when [routes] is an empty list.
      */
-    abstract fun startNavigation(routes: List<NavigationRoute>): Expected<Throwable, Unit>
+    abstract fun startActiveGuidance(
+        routes: List<NavigationRoute>
+    ): Expected<NavigationViewApiError, Unit>
 
     /**
      * Request [NavigationView] to enter Arrival state.
@@ -83,7 +87,7 @@ abstract class NavigationViewApi {
      *
      * Fails with an error when either Destination or Routes has not been set.
      */
-    abstract fun startArrival(): Expected<Throwable, Unit>
+    abstract fun startArrival(): Expected<NavigationViewApiError, Unit>
 
     /**
      * Sets [routes] and request [NavigationView] to enter Arrival state.
@@ -95,7 +99,7 @@ abstract class NavigationViewApi {
      *
      * Fails with an error when [routes] is an empty list.
      */
-    abstract fun startArrival(routes: List<NavigationRoute>): Expected<Throwable, Unit>
+    abstract fun startArrival(routes: List<NavigationRoute>): Expected<NavigationViewApiError, Unit>
 
     /**
      * Checks if the current trip is being simulated.
@@ -106,4 +110,36 @@ abstract class NavigationViewApi {
      * Enable/Disable replay trip session based on simulated locations.
      */
     abstract fun routeReplayEnabled(enabled: Boolean)
+}
+
+/**
+ * Errors returned by the NavigationApi.
+ */
+sealed class NavigationViewApiError(message: String) : Throwable(message) {
+    /**
+     * Error returned when the Destination hasn't been set yet.
+     */
+    object MissingDestinationInfo : NavigationViewApiError("Destination cannot be empty.")
+
+    /**
+     * Error returned when the Preview Routes list hasn't been set yet.
+     */
+    object MissingPreviewRoutesInfo : NavigationViewApiError("Preview Routes cannot be empty.")
+
+    /**
+     * Error returned when the Routes list hasn't been set yet.
+     */
+    object MissingRoutesInfo : NavigationViewApiError("Routes cannot be empty.")
+
+    /**
+     * Error returned when given PreviewRoute or Route list is empty.
+     */
+    object InvalidRoutesInfo : NavigationViewApiError("Routes cannot be empty.")
+
+    /**
+     * Error returned when given PreviewRoute or Route list is missing [DirectionsWaypoint]
+     * information that is needed to determine Destination coordinates.
+     */
+    object IncompleteRoutesInfo :
+        NavigationViewApiError("Missing destination info in a given route.")
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApi.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApi.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.dropin.internal
 
-import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.bindgen.Expected
+import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
@@ -8,6 +9,7 @@ import com.mapbox.navigation.dropin.NavigationViewApi
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.destination.Destination
 import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
+import com.mapbox.navigation.ui.app.internal.endNavigation
 import com.mapbox.navigation.ui.app.internal.extension.dispatch
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
@@ -15,82 +17,99 @@ import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutesAction
 import com.mapbox.navigation.ui.app.internal.tripsession.TripSessionStarterAction
-import com.mapbox.navigation.ui.app.internal.endNavigation as endNavigationAction
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal class MapboxNavigationViewApi(
     private val store: Store
 ) : NavigationViewApi() {
 
-    override fun fetchRoutes(options: RouteOptions) {
-        store.dispatch(RoutePreviewAction.FetchOptions(options))
+    override fun startFreeDrive() {
+        store.dispatch(endNavigation())
     }
 
-    override fun fetchRoutes(points: List<Point>) {
-        store.dispatch(RoutePreviewAction.FetchPoints(points))
-    }
-
-    override fun setPreviewRoutes(routes: List<NavigationRoute>) {
-        store.dispatch(RoutePreviewAction.Ready(routes))
-    }
-
-    override fun setRoutes(routes: List<NavigationRoute>) {
-        store.dispatch(RoutesAction.SetRoutes(routes))
-    }
-
-    override fun setDestination(point: Point) {
+    override fun startDestinationPreview(point: Point) {
         store.dispatch(DestinationAction.SetDestination(Destination(point)))
+        store.dispatch(NavigationStateAction.Update(NavigationState.DestinationPreview))
     }
 
-    override fun enableTripSession() {
-        store.dispatch(TripSessionStarterAction.EnableTripSession)
-    }
+    override fun startRoutePreview(): Expected<Throwable, Unit> =
+        runCatchingExpected {
+            checkDestination()
+            checkPreviewRoutes()
 
-    override fun enableReplaySession() {
-        store.dispatch(TripSessionStarterAction.EnableReplayTripSession)
-    }
+            store.dispatch(NavigationStateAction.Update(NavigationState.RoutePreview))
+        }
+
+    override fun startRoutePreview(routes: List<NavigationRoute>): Expected<Throwable, Unit> =
+        runCatchingExpected {
+            require(routes.isNotEmpty()) { "routes cannot be empty" }
+            val point = checkNotNull(routes.first().getDestination()) {
+                "destination not found in a given route"
+            }
+
+            setDestination(point)
+            setPreviewRoutes(routes)
+            startRoutePreview()
+        }
+
+    override fun startNavigation(): Expected<Throwable, Unit> =
+        runCatchingExpected {
+            checkDestination()
+            checkPreviewRoutes()
+
+            val routes = (store.state.value.previewRoutes as RoutePreviewState.Ready).routes
+            setRoutes(routes)
+            store.dispatch(NavigationStateAction.Update(NavigationState.ActiveNavigation))
+        }
+
+    override fun startNavigation(routes: List<NavigationRoute>): Expected<Throwable, Unit> =
+        runCatchingExpected {
+            require(routes.isNotEmpty()) { "routes cannot be empty" }
+            val point = checkNotNull(routes.first().getDestination()) {
+                "destination not found in a given route"
+            }
+
+            setDestination(point)
+            setPreviewRoutes(routes)
+            startNavigation()
+        }
+
+    override fun startArrival(): Expected<Throwable, Unit> =
+        runCatchingExpected {
+            checkDestination()
+            checkRoutes()
+
+            store.dispatch(NavigationStateAction.Update(NavigationState.Arrival))
+        }
+
+    override fun startArrival(routes: List<NavigationRoute>): Expected<Throwable, Unit> =
+        runCatchingExpected {
+            require(routes.isNotEmpty()) { "routes cannot be empty" }
+            val point = checkNotNull(routes.first().getDestination()) {
+                "destination not found in a given route"
+            }
+
+            setDestination(point)
+            setPreviewRoutes(routes)
+            setRoutes(routes)
+            startArrival()
+        }
 
     override fun isReplayEnabled(): Boolean {
         return store.state.value.tripSession.isReplayEnabled
     }
 
-    override fun startFreeDrive() {
-        store.dispatch(RoutesAction.SetRoutes(emptyList()))
-        store.dispatch(RoutePreviewAction.Ready(emptyList()))
-        store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
-    }
-
-    @Throws(IllegalStateException::class)
-    override fun startRoutePreview() {
-        checkDestination()
-        checkPreviewRoutes()
-
-        store.dispatch(NavigationStateAction.Update(NavigationState.RoutePreview))
-    }
-
-    @Throws(IllegalStateException::class)
-    override fun startNavigation() {
-        checkDestination()
-        checkPreviewRoutes()
-
-        val routes = (store.state.value.previewRoutes as RoutePreviewState.Ready).routes
-        store.dispatch(RoutesAction.SetRoutes(routes))
-        store.dispatch(NavigationStateAction.Update(NavigationState.ActiveNavigation))
-    }
-
-    override fun startArrival() {
-        store.dispatch(NavigationStateAction.Update(NavigationState.Arrival))
-    }
-
-    override fun endNavigation() {
-        store.dispatch(endNavigationAction())
+    override fun routeReplayEnabled(enabled: Boolean) {
+        if (enabled) {
+            store.dispatch(TripSessionStarterAction.EnableReplayTripSession)
+        } else {
+            store.dispatch(TripSessionStarterAction.EnableTripSession)
+        }
     }
 
     @Throws(IllegalStateException::class)
     private fun checkDestination() {
-        checkNotNull(store.state.value.destination) {
-            "Destination not set. Use setDestination(point) to set Destination."
-        }
+        checkNotNull(store.state.value.destination) { "Destination not set." }
     }
 
     @Throws(IllegalStateException::class)
@@ -99,7 +118,40 @@ internal class MapboxNavigationViewApi(
         check(
             previewState is RoutePreviewState.Ready && previewState.routes.isNotEmpty()
         ) {
-            "Preview Routes not set. Use setPreviewRoutes(routes) to set Preview Routes."
+            "Preview Routes not set."
         }
+    }
+
+    @Throws(IllegalStateException::class)
+    private fun checkRoutes() {
+        check(store.state.value.routes.isNotEmpty()) { "Routes not set." }
+    }
+
+    private fun setDestination(point: Point) {
+        store.dispatch(DestinationAction.SetDestination(Destination(point)))
+    }
+
+    private fun setPreviewRoutes(routes: List<NavigationRoute>) {
+        store.dispatch(RoutePreviewAction.Ready(routes))
+    }
+
+    private fun setRoutes(routes: List<NavigationRoute>) {
+        store.dispatch(RoutesAction.SetRoutes(routes))
+    }
+
+    private fun NavigationRoute.getDestination(): Point? {
+        return directionsResponse.waypoints()?.lastOrNull()?.location()
+    }
+}
+
+/**
+ * Calls the specified function [block] and returns its encapsulated result if invocation was successful,
+ * catching any [Throwable] exception that was thrown from the [block] function execution and encapsulating it as a failure.
+ */
+private inline fun <R : Any> runCatchingExpected(block: () -> R): Expected<Throwable, R> {
+    return try {
+        ExpectedFactory.createValue(block())
+    } catch (e: Throwable) {
+        ExpectedFactory.createError(e)
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApi.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApi.kt
@@ -1,0 +1,105 @@
+package com.mapbox.navigation.dropin.internal
+
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.dropin.NavigationViewApi
+import com.mapbox.navigation.ui.app.internal.Store
+import com.mapbox.navigation.ui.app.internal.destination.Destination
+import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
+import com.mapbox.navigation.ui.app.internal.extension.dispatch
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutesAction
+import com.mapbox.navigation.ui.app.internal.tripsession.TripSessionStarterAction
+import com.mapbox.navigation.ui.app.internal.endNavigation as endNavigationAction
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class MapboxNavigationViewApi(
+    private val store: Store
+) : NavigationViewApi() {
+
+    override fun fetchRoutes(options: RouteOptions) {
+        store.dispatch(RoutePreviewAction.FetchOptions(options))
+    }
+
+    override fun fetchRoutes(points: List<Point>) {
+        store.dispatch(RoutePreviewAction.FetchPoints(points))
+    }
+
+    override fun setPreviewRoutes(routes: List<NavigationRoute>) {
+        store.dispatch(RoutePreviewAction.Ready(routes))
+    }
+
+    override fun setRoutes(routes: List<NavigationRoute>) {
+        store.dispatch(RoutesAction.SetRoutes(routes))
+    }
+
+    override fun setDestination(point: Point) {
+        store.dispatch(DestinationAction.SetDestination(Destination(point)))
+    }
+
+    override fun enableTripSession() {
+        store.dispatch(TripSessionStarterAction.EnableTripSession)
+    }
+
+    override fun enableReplaySession() {
+        store.dispatch(TripSessionStarterAction.EnableReplayTripSession)
+    }
+
+    override fun isReplayEnabled(): Boolean {
+        return store.state.value.tripSession.isReplayEnabled
+    }
+
+    override fun startFreeDrive() {
+        store.dispatch(RoutesAction.SetRoutes(emptyList()))
+        store.dispatch(RoutePreviewAction.Ready(emptyList()))
+        store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
+    }
+
+    @Throws(IllegalStateException::class)
+    override fun startRoutePreview() {
+        checkDestination()
+        checkPreviewRoutes()
+
+        store.dispatch(NavigationStateAction.Update(NavigationState.RoutePreview))
+    }
+
+    @Throws(IllegalStateException::class)
+    override fun startNavigation() {
+        checkDestination()
+        checkPreviewRoutes()
+
+        val routes = (store.state.value.previewRoutes as RoutePreviewState.Ready).routes
+        store.dispatch(RoutesAction.SetRoutes(routes))
+        store.dispatch(NavigationStateAction.Update(NavigationState.ActiveNavigation))
+    }
+
+    override fun startArrival() {
+        store.dispatch(NavigationStateAction.Update(NavigationState.Arrival))
+    }
+
+    override fun endNavigation() {
+        store.dispatch(endNavigationAction())
+    }
+
+    @Throws(IllegalStateException::class)
+    private fun checkDestination() {
+        checkNotNull(store.state.value.destination) {
+            "Destination not set. Use setDestination(point) to set Destination."
+        }
+    }
+
+    @Throws(IllegalStateException::class)
+    private fun checkPreviewRoutes() {
+        val previewState = store.state.value.previewRoutes
+        check(
+            previewState is RoutePreviewState.Ready && previewState.routes.isNotEmpty()
+        ) {
+            "Preview Routes not set. Use setPreviewRoutes(routes) to set Preview Routes."
+        }
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApiTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApiTest.kt
@@ -4,6 +4,7 @@ import com.mapbox.api.directions.v5.models.DirectionsWaypoint
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.dropin.NavigationViewApiError
 import com.mapbox.navigation.dropin.util.TestStore
 import com.mapbox.navigation.ui.app.internal.Reducer
 import com.mapbox.navigation.ui.app.internal.destination.Destination
@@ -90,7 +91,8 @@ class MapboxNavigationViewApiTest {
     }
 
     @Test
-    fun `startRoutePreview should return an Error if destination has not been set`() {
+    @Suppress("MaxLineLength")
+    fun `startRoutePreview should return an MissingDestinationInfo error if destination has not been set`() {
         testStore.updateState {
             it.copy(
                 destination = null,
@@ -100,11 +102,12 @@ class MapboxNavigationViewApiTest {
 
         val error = sut.startRoutePreview().error
 
-        assertTrue(error is IllegalStateException)
+        assertTrue(error is NavigationViewApiError.MissingDestinationInfo)
     }
 
     @Test
-    fun `startRoutePreview should fail with IllegalStateException if preview routes are empty`() {
+    @Suppress("MaxLineLength")
+    fun `startRoutePreview should fail with MissingPreviewRoutesInfo error if preview routes are empty`() {
         testStore.updateState {
             it.copy(
                 destination = Destination(Point.fromLngLat(1.0, 2.0)),
@@ -114,7 +117,7 @@ class MapboxNavigationViewApiTest {
 
         val result = sut.startRoutePreview()
 
-        assertTrue(result.error is IllegalStateException)
+        assertTrue(result.error is NavigationViewApiError.MissingPreviewRoutesInfo)
     }
 
     @Test
@@ -139,15 +142,23 @@ class MapboxNavigationViewApiTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `startRoutePreview should fail with IllegalArgumentException if preview routes are empty`() {
+    fun `startRoutePreview should fail with InvalidRoutesInfo error if preview routes are empty`() {
         val result = sut.startRoutePreview(emptyList())
 
-        assertTrue(result.error is IllegalArgumentException)
+        assertTrue(result.error is NavigationViewApiError.InvalidRoutesInfo)
     }
 
     @Test
     @Suppress("MaxLineLength")
-    fun `startNavigation should set preview routes as routes and set ActiveNavigation NavigationState`() {
+    fun `startRoutePreview should fail with IncompleteRoutesInfo error if preview routes is missing waypoints data`() {
+        val result = sut.startRoutePreview(listOf(navigationRoute()))
+
+        assertTrue(result.error is NavigationViewApiError.IncompleteRoutesInfo)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `startActiveGuidance should set preview routes as routes and set ActiveNavigation NavigationState`() {
         val routes = listOf<NavigationRoute>(mockk())
         testStore.updateState {
             it.copy(
@@ -156,7 +167,7 @@ class MapboxNavigationViewApiTest {
             )
         }
 
-        val result = sut.startNavigation()
+        val result = sut.startActiveGuidance()
 
         verify { testStore.dispatch(RoutesAction.SetRoutes(routes)) }
         verify {
@@ -167,7 +178,7 @@ class MapboxNavigationViewApiTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `startNavigation should fail with IllegalStateException if destination has not been set`() {
+    fun `startActiveGuidance should fail with MissingDestinationInfo error if destination has not been set`() {
         testStore.updateState {
             it.copy(
                 destination = null,
@@ -175,13 +186,13 @@ class MapboxNavigationViewApiTest {
             )
         }
 
-        val result = sut.startNavigation()
+        val result = sut.startActiveGuidance()
 
-        assertTrue(result.error is IllegalStateException)
+        assertTrue(result.error is NavigationViewApiError.MissingDestinationInfo)
     }
 
     @Test
-    fun `startNavigation should fail with IllegalStateException if preview routes are empty`() {
+    fun `startActiveGuidance should fail with MissingPreviewRoutesInfo error if preview routes are empty`() {
         testStore.updateState {
             it.copy(
                 destination = Destination(Point.fromLngLat(1.0, 2.0)),
@@ -189,14 +200,14 @@ class MapboxNavigationViewApiTest {
             )
         }
 
-        val result = sut.startNavigation()
+        val result = sut.startActiveGuidance()
 
-        assertTrue(result.error is IllegalStateException)
+        assertTrue(result.error is NavigationViewApiError.MissingPreviewRoutesInfo)
     }
 
     @Test
     @Suppress("MaxLineLength")
-    fun `startNavigation should set destination, preview routes and set RoutePreview NavigationState `() {
+    fun `startActiveGuidance should set destination, preview routes and set RoutePreview NavigationState `() {
         val point = Point.fromLngLat(11.0, 22.0)
         val routes = listOf(
             navigationRoute(
@@ -206,7 +217,7 @@ class MapboxNavigationViewApiTest {
             )
         )
 
-        val result = sut.startNavigation(routes)
+        val result = sut.startActiveGuidance(routes)
 
         verify { testStore.dispatch(DestinationAction.SetDestination(Destination(point))) }
         verify { testStore.dispatch(RoutePreviewAction.Ready(routes)) }
@@ -217,10 +228,11 @@ class MapboxNavigationViewApiTest {
     }
 
     @Test
-    fun `startNavigation should fail with IllegalArgumentException if preview routes are empty`() {
-        val result = sut.startNavigation(emptyList())
+    @Suppress("MaxLineLength")
+    fun `startActiveGuidance should fail with InvalidRoutesInfo error if preview routes are empty`() {
+        val result = sut.startActiveGuidance(emptyList())
 
-        assertTrue(result.error is IllegalArgumentException)
+        assertTrue(result.error is NavigationViewApiError.InvalidRoutesInfo)
     }
 
     @Test
@@ -239,7 +251,8 @@ class MapboxNavigationViewApiTest {
     }
 
     @Test
-    fun `startArrival should fail with IllegalStateException if destination has not been set`() {
+    @Suppress("MaxLineLength")
+    fun `startArrival should fail with MissingDestinationInfo error if destination has not been set`() {
         testStore.updateState {
             it.copy(
                 destination = null,
@@ -249,21 +262,22 @@ class MapboxNavigationViewApiTest {
 
         val result = sut.startArrival()
 
-        assertTrue(result.error is IllegalStateException)
+        assertTrue(result.error is NavigationViewApiError.MissingDestinationInfo)
     }
 
     @Test
-    fun `startArrival should fail with IllegalStateException if preview routes are empty`() {
+    @Suppress("MaxLineLength")
+    fun `startArrival should fail with MissingRoutesInfo error if routes are empty`() {
         testStore.updateState {
             it.copy(
-                destination = null,
+                destination = Destination(Point.fromLngLat(1.0, 2.0)),
                 routes = emptyList()
             )
         }
 
         val result = sut.startArrival()
 
-        assertTrue(result.error is IllegalStateException)
+        assertTrue(result.error is NavigationViewApiError.MissingRoutesInfo)
     }
 
     @Test
@@ -290,10 +304,11 @@ class MapboxNavigationViewApiTest {
     }
 
     @Test
-    fun `startArrival should fail with IllegalArgumentException if preview routes are empty`() {
+    @Suppress("MaxLineLength")
+    fun `startArrival should fail with InvalidRoutesInfo error if preview routes are empty`() {
         val result = sut.startArrival(emptyList())
 
-        assertTrue(result.error is IllegalArgumentException)
+        assertTrue(result.error is NavigationViewApiError.InvalidRoutesInfo)
     }
 
     @Test

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApiTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApiTest.kt
@@ -1,0 +1,224 @@
+package com.mapbox.navigation.dropin.internal
+
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.dropin.startNavigation
+import com.mapbox.navigation.dropin.startRoutePreview
+import com.mapbox.navigation.dropin.util.TestStore
+import com.mapbox.navigation.ui.app.internal.Reducer
+import com.mapbox.navigation.ui.app.internal.destination.Destination
+import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutesAction
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import junit.framework.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class MapboxNavigationViewApiTest {
+
+    private lateinit var sut: MapboxNavigationViewApi
+
+    private lateinit var testStore: TestStore
+
+    @Before
+    fun setUp() {
+        testStore = spyk(TestStore())
+        // registering simple reducer that copies Destination and RoutePreviewState values
+        testStore.register(
+            Reducer { state, action ->
+                when (action) {
+                    is DestinationAction.SetDestination ->
+                        state.copy(destination = action.destination)
+                    is RoutePreviewAction.Ready ->
+                        state.copy(previewRoutes = RoutePreviewState.Ready(action.routes))
+                    else -> state
+                }
+            }
+        )
+        sut = MapboxNavigationViewApi(testStore)
+    }
+
+    @Test
+    fun `startFreeDrive should clear routes and preview routes and set FreeDrive NavigationState`() {
+        sut.startFreeDrive()
+
+        verify { testStore.dispatch(RoutesAction.SetRoutes(emptyList())) }
+        verify { testStore.dispatch(RoutePreviewAction.Ready(emptyList())) }
+        verify { testStore.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive)) }
+    }
+
+    @Test
+    fun `startRoutePreview should set RoutePreview NavigationState`() {
+        testStore.updateState {
+            it.copy(
+                destination = Destination(Point.fromLngLat(1.0, 2.0)),
+                previewRoutes = RoutePreviewState.Ready(listOf(mockk()))
+            )
+        }
+
+        sut.startRoutePreview()
+
+        verify { testStore.dispatch(NavigationStateAction.Update(NavigationState.RoutePreview)) }
+    }
+
+    @Test
+    fun `startRoutePreview should throw IllegalStateException if destination has not been set`() {
+        testStore.updateState {
+            it.copy(
+                destination = null,
+                previewRoutes = RoutePreviewState.Ready(listOf(mockk()))
+            )
+        }
+
+        try {
+            sut.startRoutePreview()
+            fail("expected IllegalStateException to be thrown")
+        } catch (e: IllegalStateException) {
+            // pass
+        }
+    }
+
+    @Test
+    fun `startRoutePreview should throw IllegalStateException if preview routes are empty`() {
+        testStore.updateState {
+            it.copy(
+                destination = Destination(Point.fromLngLat(1.0, 2.0)),
+                previewRoutes = RoutePreviewState.Ready(emptyList())
+            )
+        }
+        try {
+            sut.startRoutePreview()
+            fail("expected IllegalStateException to be thrown")
+        } catch (e: IllegalStateException) {
+            // pass
+        }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `startRoutePreview should set destination, preview routes and set RoutePreview NavigationState `() {
+        val point = Point.fromLngLat(11.0, 22.0)
+        val previewRoutes = listOf<NavigationRoute>(mockk())
+
+        sut.startRoutePreview(point, previewRoutes)
+
+        verify { testStore.dispatch(DestinationAction.SetDestination(Destination(point))) }
+        verify { testStore.dispatch(RoutePreviewAction.Ready(previewRoutes)) }
+        verify { testStore.dispatch(NavigationStateAction.Update(NavigationState.RoutePreview)) }
+    }
+
+    @Test
+    fun `startRoutePreview should throw IllegalArgumentException if preview routes are empty`() {
+        val point = Point.fromLngLat(11.0, 22.0)
+        try {
+            sut.startRoutePreview(point, emptyList())
+            fail("expected IllegalArgumentException to be thrown")
+        } catch (e: IllegalArgumentException) {
+            // pass
+        }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `startNavigation should set preview routes as routes and set ActiveNavigation NavigationState`() {
+        val routes = listOf<NavigationRoute>(mockk())
+        testStore.updateState {
+            it.copy(
+                destination = Destination(Point.fromLngLat(1.0, 2.0)),
+                previewRoutes = RoutePreviewState.Ready(routes)
+            )
+        }
+
+        sut.startNavigation()
+
+        verify { testStore.dispatch(RoutesAction.SetRoutes(routes)) }
+        verify {
+            testStore.dispatch(NavigationStateAction.Update(NavigationState.ActiveNavigation))
+        }
+    }
+
+    @Test
+    fun `startNavigation should throw IllegalStateException if destination has not been set`() {
+        testStore.updateState {
+            it.copy(
+                destination = null,
+                previewRoutes = RoutePreviewState.Ready(listOf(mockk()))
+            )
+        }
+
+        try {
+            sut.startNavigation()
+            fail("expected IllegalStateException to be thrown")
+        } catch (e: IllegalStateException) {
+            // pass
+        }
+    }
+
+    @Test
+    fun `startNavigation should throw IllegalStateException if preview routes are empty`() {
+        testStore.updateState {
+            it.copy(
+                destination = Destination(Point.fromLngLat(1.0, 2.0)),
+                previewRoutes = RoutePreviewState.Ready(emptyList())
+            )
+        }
+        try {
+            sut.startNavigation()
+            fail("expected IllegalStateException to be thrown")
+        } catch (e: IllegalStateException) {
+            // pass
+        }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `startNavigation should set destination, preview routes and set RoutePreview NavigationState `() {
+        val point = Point.fromLngLat(11.0, 22.0)
+        val previewRoutes = listOf<NavigationRoute>(mockk())
+
+        sut.startNavigation(point, previewRoutes)
+
+        verify { testStore.dispatch(DestinationAction.SetDestination(Destination(point))) }
+        verify { testStore.dispatch(RoutePreviewAction.Ready(previewRoutes)) }
+        verify {
+            testStore.dispatch(NavigationStateAction.Update(NavigationState.ActiveNavigation))
+        }
+    }
+
+    @Test
+    fun `startNavigation should throw IllegalArgumentException if preview routes are empty`() {
+        val point = Point.fromLngLat(11.0, 22.0)
+        try {
+            sut.startNavigation(point, emptyList())
+            fail("expected IllegalArgumentException to be thrown")
+        } catch (e: IllegalArgumentException) {
+            // pass
+        }
+    }
+
+    @Test
+    fun `startArrival should set Arrival NavigationState`() {
+        sut.startArrival()
+
+        verify { testStore.dispatch(NavigationStateAction.Update(NavigationState.Arrival)) }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `endNavigation should clear Destination and Route data and set FreeDrive NavigationState`() {
+        sut.endNavigation()
+
+        verify { testStore.dispatch(DestinationAction.SetDestination(null)) }
+        verify { testStore.dispatch(RoutesAction.SetRoutes(emptyList())) }
+        verify { testStore.dispatch(RoutePreviewAction.Ready(emptyList())) }
+        verify { testStore.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive)) }
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewActivity.kt
@@ -28,11 +28,7 @@ class MapboxNavigationViewActivity : DrawerActivity() {
 
         menuBinding.toggleReplay.isChecked = binding.navigationView.api.isReplayEnabled()
         menuBinding.toggleReplay.setOnCheckedChangeListener { _, isChecked ->
-            if (isChecked) {
-                binding.navigationView.api.enableReplaySession()
-            } else {
-                binding.navigationView.api.enableTripSession()
-            }
+            binding.navigationView.api.routeReplayEnabled(isChecked)
         }
     }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -216,11 +216,7 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             menuBinding.toggleReplay,
             getValue = binding.navigationView.api::isReplayEnabled,
             setValue = { isChecked ->
-                if (isChecked) {
-                    binding.navigationView.api.enableReplaySession()
-                } else {
-                    binding.navigationView.api.enableTripSession()
-                }
+                binding.navigationView.api.routeReplayEnabled(isChecked)
             }
         )
     }


### PR DESCRIPTION
Closes [#1911](https://github.com/mapbox/navigation-sdks/issues/1911)

### Description

Changes:
- Introduced new`NavigationViewApi` methods:  `startFreeDrive`, `startRoutePreview`, `startNavigation`, `startArrival` and `endNavigation`.
- Refactored `NavigationViewApi` into abstract class and hid its implementation in `MapboxNavigationViewApi`
- Updated _libnavui-dropin_  module Metalava API file
