### PR TITLE
Bump `mapboxSearchSdk` dependency version to `1.0.0-beta.35` to fix broken `qa-test-app`

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,7 +24,7 @@ ext {
       mapboxCore                : '5.0.2',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '23.0.0-beta.1',
-      mapboxSearchSdk           : '1.0.0-beta.29',
+      mapboxSearchSdk           : '1.0.0-beta.35',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.8.0',


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Regression from https://github.com/mapbox/mapbox-navigation-android/pull/6168 

- Bumps `mapboxSearchSdk` dependency version to `1.0.0-beta.35` to fix broken `qa-test-app`

This is a workaround to get the `qa-test-app` back up and running. Proper solution is to tackle https://github.com/mapbox/mapbox-navigation-android/issues/6172 

Refs. https://github.com/mapbox/mapbox-navigation-android/pull/6165

cc @LukasPaczos @DzmitryFomchyn @kmadsen 