### PR TITLE
request WRITE_EXTERNAL_STORAGE only until Android R

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.mapbox.navigation.examples
 
+import android.Manifest
 import android.Manifest.permission
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -56,7 +58,7 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
         adapter.addSampleItems(sampleItemList)
 
         if (areLocationPermissionsGranted(this)) {
-            requestPermissionIfNotGranted(permission.WRITE_EXTERNAL_STORAGE)
+            maybeRequestStoragePermission()
         } else {
             permissionsHelper.requestLocationPermissions(this)
         }
@@ -152,7 +154,7 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
 
     override fun onPermissionResult(granted: Boolean) {
         if (granted) {
-            requestPermissionIfNotGranted(permission.WRITE_EXTERNAL_STORAGE)
+            maybeRequestStoragePermission()
         } else {
             Toast.makeText(
                 this,
@@ -162,16 +164,18 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
         }
     }
 
-    private fun requestPermissionIfNotGranted(permission: String) {
-        val permissionsNeeded: MutableList<String> = ArrayList()
+    private fun maybeRequestStoragePermission() {
+        // starting from Android R leak canary writes to Download storage without the permission
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return
+        }
         if (
-            ContextCompat.checkSelfPermission(this, permission) !=
+            ContextCompat.checkSelfPermission(this, permission.WRITE_EXTERNAL_STORAGE) !=
             PackageManager.PERMISSION_GRANTED
         ) {
-            permissionsNeeded.add(permission)
             ActivityCompat.requestPermissions(
                 this,
-                permissionsNeeded.toTypedArray(),
+                arrayOf(permission.WRITE_EXTERNAL_STORAGE),
                 10
             )
         } else {

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MainActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.qa_test_app.view
 
 import android.Manifest
+import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -110,9 +111,12 @@ class MainActivity : AppCompatActivity() {
         }
 
     companion object {
-        private val DEFAULT_PERMISSIONS = listOf(
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.WRITE_EXTERNAL_STORAGE,
-        )
+        private val DEFAULT_PERMISSIONS = listOf(Manifest.permission.ACCESS_FINE_LOCATION) +
+            // starting from Android R leak canary writes to Download storage without the permission
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                listOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            } else {
+                emptyList()
+            }
     }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MainActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MainActivity.kt
@@ -111,12 +111,14 @@ class MainActivity : AppCompatActivity() {
         }
 
     companion object {
-        private val DEFAULT_PERMISSIONS = listOf(Manifest.permission.ACCESS_FINE_LOCATION) +
-            // starting from Android R leak canary writes to Download storage without the permission
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                listOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
-            } else {
-                emptyList()
+        private val DEFAULT_PERMISSIONS = mutableListOf(Manifest.permission.ACCESS_FINE_LOCATION)
+            .apply {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                    add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    add(Manifest.permission.POST_NOTIFICATIONS)
+                }
             }
     }
 }


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-navigation-android/issues/6195.

### Description
The permission only appears in the Manifest because of the leakcanary library. According to [their docs](https://square.github.io/leakcanary/faq/#where-does-leakcanary-store-heap-dumps), it's required to store heap dumps in the Download folder. But they will be stored in the app directory if the permission has not been granted. However, they support writing to Download folder without the permission starting from Android R.