### PR TITLE
Alternatives: adopt new NN handling alternatives route flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,7 +340,6 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Mapbox Android Core `v5.0.2` ([release notes](https://github.com/mapbox/mapbox-events-android/releases/tag/core-5.0.2))
 - Mapbox Android Telemetry `v8.1.5` ([release notes](https://github.com/mapbox/mapbox-events-android/releases/tag/telem-8.1.5-core-5.0.2))
 
-
 ## Mapbox Navigation SDK 2.8.0-beta.1 - 25 August, 2022
 ### Changelog
 [Changes between v2.8.0-alpha.3 and v2.8.0-beta.1](https://github.com/mapbox/mapbox-navigation-android/compare/v2.8.0-alpha.3...v2.8.0-beta.1)

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteAlternativesTest.kt
@@ -2,14 +2,20 @@ package com.mapbox.navigation.instrumentation_tests.core
 
 import android.location.Location
 import androidx.test.espresso.Espresso
+import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouteAlternativesOptions
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.routealternatives.NavigationRouteAlternativesObserver
+import com.mapbox.navigation.core.routealternatives.RouteAlternativesError
 import com.mapbox.navigation.instrumentation_tests.R
 import com.mapbox.navigation.instrumentation_tests.activity.EmptyTestActivity
 import com.mapbox.navigation.instrumentation_tests.utils.MapboxNavigationRule
@@ -25,6 +31,8 @@ import com.mapbox.navigation.testing.ui.utils.getMapboxAccessTokenFromResources
 import com.mapbox.navigation.testing.ui.utils.runOnMainSync
 import com.mapbox.navigation.utils.internal.logE
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -54,6 +62,10 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
         Point.fromLngLat(-122.2647245, 37.8138895)
     )
 
+    private companion object {
+        private const val LOG_CATEGORY = "RouteAlternativesTest"
+    }
+
     override fun setupMockLocation(): Location = mockLocationUpdatesRule.generateLocationUpdate {
         latitude = coordinates[0].latitude()
         longitude = coordinates[0].longitude()
@@ -81,7 +93,7 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
         setupMockRequestHandlers(coordinates)
         val routes = requestDirectionsRouteSync(coordinates)
 
-        // Play the slower alternative route.
+        // Play primary route
         runOnMainSync {
             mapboxNavigation.historyRecorder.startRecording()
             mockLocationReplayerRule.playRoute(routes.first())
@@ -107,7 +119,61 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
         val countDownLatch = CountDownLatch(1)
         runOnMainSync {
             mapboxNavigation.historyRecorder.stopRecording {
-                logE("history path=$it", "DEBUG")
+                logE("history path=$it", LOG_CATEGORY)
+                countDownLatch.countDown()
+            }
+        }
+        countDownLatch.await()
+
+        // Verify alternative routes events were triggered.
+        assertEquals(2, routes.size)
+        assertTrue(mapboxNavigation.getNavigationRoutes().isNotEmpty())
+        firstAlternative.verifyOnRouteAlternativesAndProgressReceived()
+        firstAlternative.alternatives!!.forEach {
+            assertFalse(routes.contains(it))
+        }
+    }
+
+    @Test
+    fun alternative_routes_observer_is_not_triggered_for_set_routes() {
+        // Prepare with alternative routes.
+        setupMockRequestHandlers(coordinates)
+        val routes = requestDirectionsRouteSync(coordinates)
+
+        // Play primary route
+        runOnMainSync {
+            mapboxNavigation.historyRecorder.startRecording()
+            mockLocationReplayerRule.playRoute(routes.first())
+            mapboxNavigation.startTripSession()
+        }
+
+        // Wait for enhanced locations to start and then set the routes.
+        val firstLocationIdlingResource = FirstLocationIdlingResource(mapboxNavigation)
+        firstLocationIdlingResource.firstLocationSync()
+
+        // Subscribing for alternatives
+        val firstAlternative = RouteAlternativesIdlingResource(
+            mapboxNavigation
+        ) { _, alternatives, _ ->
+            alternatives.isNotEmpty()
+        }
+        firstAlternative.register()
+
+        runOnMainSync {
+            mapboxNavigation.setRoutes(routes)
+        }
+
+        mapboxHistoryTestRule.stopRecordingOnCrash("alternatives failed") {
+            Espresso.onIdle()
+        }
+        firstAlternative.unregister()
+
+        assertTrue(firstAlternative.calledOnMainThread)
+
+        val countDownLatch = CountDownLatch(1)
+        runOnMainSync {
+            mapboxNavigation.historyRecorder.stopRecording {
+                logE("history path=$it", LOG_CATEGORY)
                 countDownLatch.countDown()
             }
         }
@@ -116,8 +182,122 @@ class RouteAlternativesTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::cla
         // Verify alternative routes events were triggered.
         assertEquals(2, routes.size)
         assertTrue(mapboxNavigation.getRoutes().isNotEmpty())
-        assertNotNull(firstAlternative.routeProgress)
+        firstAlternative.verifyOnRouteAlternativesAndProgressReceived()
+
+        assertNotEquals(
+            "Verify setRoutes and alternatives are not the same routes",
+            routes.drop(1).sortedBy { it.hashCode() }, // drop primary route
+            firstAlternative.alternatives!!.sortedBy { it.hashCode() }
+        )
+    }
+
+    /**
+     * The test verifies that if set routes to Navigation that are come from alternatives + n
+     * (where n >= 1) external routes, alternatives routes observer is not triggered with these routes.
+     * That was happening in legacy versions of NN.
+     */
+    @Test
+    fun additional_alternative_is_not_force_to_invoke_alternatives_observer() {
+        // Prepare with alternative routes.
+        setupMockRequestHandlers(coordinates)
+        val routes = requestDirectionsRouteSync(coordinates)
+
+        // Play primary route
+        runOnMainSync {
+            mapboxNavigation.historyRecorder.startRecording()
+            mockLocationReplayerRule.playRoute(routes.first())
+            mapboxNavigation.startTripSession()
+        }
+
+        // Wait for enhanced locations to start and then set the routes.
+        val firstLocationIdlingResource = FirstLocationIdlingResource(mapboxNavigation)
+        firstLocationIdlingResource.firstLocationSync()
+        runOnMainSync {
+            // infinity subscription to avoid triggering NN on every new observer
+            mapboxNavigation.registerRouteAlternativesObserver(
+                object : NavigationRouteAlternativesObserver {
+                    override fun onRouteAlternatives(
+                        routeProgress: RouteProgress,
+                        alternatives: List<NavigationRoute>,
+                        routerOrigin: RouterOrigin
+                    ) = Unit
+
+                    override fun onRouteAlternativesError(error: RouteAlternativesError) = Unit
+                }
+            )
+            mapboxNavigation.setRoutes(routes)
+        }
+
+        // Subscribing for alternatives
+        val firstAlternative = RouteAlternativesIdlingResource(
+            mapboxNavigation
+        ) { _, alternatives, _ ->
+            alternatives.isNotEmpty()
+        }
+        firstAlternative.register()
+        mapboxHistoryTestRule.stopRecordingOnCrash("alternatives failed") {
+            Espresso.onIdle()
+        }
+        firstAlternative.unregister()
+
         assertNotNull(firstAlternative.alternatives)
+
+        val nextAlternativeObserver = RouteAlternativesIdlingResource(
+            mapboxNavigation
+        ) { _, alternatives, _ ->
+            alternatives.isNotEmpty()
+        }
+        nextAlternativeObserver.register()
+
+        val externalAlternatives = DirectionsResponse.fromJson(
+            readRawFileText(activity, R.raw.route_response_alternative_continue)
+        ).routes().also {
+            assertEquals(1, it.size)
+        }
+
+        lateinit var setRoutes: List<DirectionsRoute>
+        runOnMainSync {
+            setRoutes = (
+                mutableListOf(
+                    mapboxNavigation.getRoutes().first()
+                ) + firstAlternative.alternatives!! + externalAlternatives
+                ).also {
+                assertTrue(
+                    "Primary route + >=1 alternatives + external alternatives",
+                    it.size >= 3
+                )
+            }
+            mapboxNavigation.setRoutes(setRoutes)
+        }
+
+        mapboxHistoryTestRule.stopRecordingOnCrash("next alternatives failed") {
+            Espresso.onIdle()
+        }
+        nextAlternativeObserver.unregister()
+
+        val countDownLatch = CountDownLatch(1)
+        runOnMainSync {
+            mapboxNavigation.historyRecorder.stopRecording {
+                logE("history path=$it", LOG_CATEGORY)
+                countDownLatch.countDown()
+            }
+        }
+        countDownLatch.await()
+
+        // Verify alternative routes events were triggered.
+        firstAlternative.verifyOnRouteAlternativesAndProgressReceived()
+
+        // Verify next alternative routes events were triggered
+        nextAlternativeObserver.verifyOnRouteAlternativesAndProgressReceived()
+
+        // verify that set routes with  alternatives + 1 external alternatives is not triggered
+        // alternative observer
+        assertNotEquals(
+            "Alternative are not the same as setRoutes (alternatives might have " +
+                "additional routes or remove one or a few but not equal)",
+            setRoutes.drop(1).sortedBy { it.hashCode() }, // drop primary route
+            nextAlternativeObserver.alternatives!!.sortedBy { it.hashCode() }
+        )
     }
 
     private fun setupMockRequestHandlers(coordinates: List<Point>) {

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteAlternativesIdlingResource.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/idling/RouteAlternativesIdlingResource.kt
@@ -9,6 +9,7 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.routealternatives.RouteAlternativesObserver
 import com.mapbox.navigation.testing.ui.idling.NavigationIdlingResource
 import com.mapbox.navigation.testing.ui.utils.runOnMainSync
+import junit.framework.Assert.assertNotNull
 
 /**
  * Becomes idle when [RouteAlternativesObserver.onRouteAlternatives] is invoked,
@@ -17,16 +18,25 @@ import com.mapbox.navigation.testing.ui.utils.runOnMainSync
  *
  * If your test needs to receive the next set of alternatives, you must create a new
  * instance of [RouteAlternativesIdlingResource] to capture the next callback.
+ * @param mapboxNavigation the instance of [MapboxNavigation]
+ * @param onRoutesAlternatives lambda returns boolean value: true if alternatives
+ * observer must keep working, false otherwise. If false is returned resource transiting for busy
+ * to idling (see [IdlingResource.ResourceCallback.onTransitionToIdle]).
  */
 class RouteAlternativesIdlingResource(
-    val mapboxNavigation: MapboxNavigation
+    val mapboxNavigation: MapboxNavigation,
+    private val onRoutesAlternatives: (
+        RouteProgress,
+        List<DirectionsRoute>,
+        RouterOrigin
+    ) -> Boolean = { _, _, _ -> true },
 ) : NavigationIdlingResource(), RouteAlternativesObserver {
 
     var routeProgress: RouteProgress? = null
         private set
     var alternatives: List<DirectionsRoute>? = null
         private set
-    var calledOnMainThread = true
+    var calledOnMainThread = false
 
     private var callback: IdlingResource.ResourceCallback? = null
 
@@ -52,14 +62,24 @@ class RouteAlternativesIdlingResource(
         alternatives: List<DirectionsRoute>,
         routerOrigin: RouterOrigin
     ) {
+        if (!onRoutesAlternatives.invoke(routeProgress, alternatives, routerOrigin)) {
+            return
+        }
+
         // Verify this happens on the main thread.
-        if (Looper.myLooper() != Looper.getMainLooper()) {
-            calledOnMainThread = false
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            calledOnMainThread = true
         }
 
         mapboxNavigation.unregisterRouteAlternativesObserver(this)
         this.routeProgress = routeProgress
         this.alternatives = alternatives
+
         callback?.onTransitionToIdle()
+    }
+
+    fun verifyOnRouteAlternativesAndProgressReceived() {
+        assertNotNull(routeProgress)
+        assertNotNull(alternatives)
     }
 }

--- a/instrumentation-tests/src/main/res/raw/route_response_alternative_continue.json
+++ b/instrumentation-tests/src/main/res/raw/route_response_alternative_continue.json
@@ -1,0 +1,702 @@
+{
+  "code": "Ok",
+  "uuid": "-hc46GOZUc_KI1oLiubfntQjtUGo_FT1fui0xUdAwxLMlR1J8h6oGg==",
+  "waypoints": [
+    {
+      "distance": 3.262,
+      "name": "Broadway",
+      "location": [
+        -122.266513,
+        37.811816
+      ]
+    },
+    {
+      "distance": 0.017,
+      "name": "Webster Street",
+      "location": [
+        -122.264756,
+        37.813895
+      ]
+    }
+  ],
+  "routes": [
+    {
+      "routeIndex": "0",
+      "country_crossed": false,
+      "weight_typical": 130.999,
+      "duration_typical": 87.58,
+      "weight_name": "auto",
+      "weight": 130.999,
+      "duration": 87.58,
+      "distance": 348.273,
+      "legs": [
+        {
+          "via_waypoints": [],
+          "admins": [
+            {
+              "iso_3166_1_alpha3": "USA",
+              "iso_3166_1": "US"
+            }
+          ],
+          "weight_typical": 130.999,
+          "duration_typical": 87.58,
+          "weight": 130.999,
+          "duration": 87.58,
+          "steps": [
+            {
+              "bannerInstructions": [
+                {
+                  "sub": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Webster Street"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "left",
+                    "text": "Webster Street"
+                  },
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "23rd Street"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right",
+                    "text": "23rd Street"
+                  },
+                  "distanceAlongGeometry": 45.072
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive northeast on <say-as interpret-as=\"address\">Broadway</say-as>. Then Turn right onto <say-as interpret-as=\"address\">23rd Street</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "Drive northeast on Broadway. Then Turn right onto 23rd Street.",
+                  "distanceAlongGeometry": 45.072
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true
+                  ],
+                  "bearings": [
+                    26
+                  ],
+                  "duration": 0.83,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 1.017,
+                  "geometry_index": 0,
+                  "location": [
+                    -122.266513,
+                    37.811816
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    25,
+                    206
+                  ],
+                  "duration": 1.473,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 1.804,
+                  "geometry_index": 2,
+                  "location": [
+                    -122.266486,
+                    37.81186
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    13,
+                    38,
+                    205
+                  ],
+                  "duration": 3.772,
+                  "turn_weight": 1.5,
+                  "turn_duration": 0.015,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 6.102,
+                  "geometry_index": 3,
+                  "location": [
+                    -122.266442,
+                    37.811933
+                  ]
+                },
+                {
+                  "bearings": [
+                    26,
+                    99,
+                    216,
+                    283
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "turn_duration": 0.038,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 6,
+                  "location": [
+                    -122.266282,
+                    37.8121
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "depart",
+                "instruction": "Drive northeast on Broadway.",
+                "bearing_after": 26,
+                "bearing_before": 0,
+                "location": [
+                  -122.266513,
+                  37.811816
+                ]
+              },
+              "name": "Broadway",
+              "weight_typical": 10.265,
+              "duration_typical": 7.209,
+              "duration": 7.209,
+              "distance": 45.072,
+              "driving_side": "right",
+              "weight": 10.265,
+              "mode": "driving",
+              "geometry": "oezbgA`xpehFu@_@a@UqCwA}BwC_AiAoC}AoBeA"
+            },
+            {
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Webster Street"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "left",
+                    "text": "Webster Street"
+                  },
+                  "distanceAlongGeometry": 88
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn left onto <say-as interpret-as=\"address\">Webster Street</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "Turn left onto Webster Street.",
+                  "distanceAlongGeometry": 50
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    27,
+                    102,
+                    206,
+                    282
+                  ],
+                  "duration": 2.735,
+                  "turn_weight": 5,
+                  "turn_duration": 0.935,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 7.205,
+                  "geometry_index": 7,
+                  "location": [
+                    -122.266247,
+                    37.812156
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "bearings": [
+                    31,
+                    102,
+                    207,
+                    282
+                  ],
+                  "duration": 18.533,
+                  "turn_weight": 2,
+                  "turn_duration": 0.019,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 24.68,
+                  "geometry_index": 8,
+                  "location": [
+                    -122.266165,
+                    37.812142
+                  ]
+                },
+                {
+                  "bearings": [
+                    13,
+                    102,
+                    191,
+                    282
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "turn_weight": 2,
+                  "turn_duration": 0.019,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 1,
+                  "geometry_index": 9,
+                  "location": [
+                    -122.265366,
+                    37.81201
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "turn",
+                "instruction": "Turn right onto 23rd Street.",
+                "modifier": "right",
+                "bearing_after": 102,
+                "bearing_before": 26,
+                "location": [
+                  -122.266247,
+                  37.812156
+                ]
+              },
+              "name": "23rd Street",
+              "weight_typical": 36.72,
+              "duration_typical": 23.602,
+              "duration": 23.602,
+              "distance": 88,
+              "driving_side": "right",
+              "weight": 36.72,
+              "mode": "driving",
+              "geometry": "wzzbgAlgpehFZcDfG}p@`@gE"
+            },
+            {
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "You will arrive at your destination"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight",
+                    "text": "You will arrive at your destination"
+                  },
+                  "distanceAlongGeometry": 215.201
+                },
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "You have arrived at your destination"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight",
+                    "text": "You have arrived at your destination"
+                  },
+                  "distanceAlongGeometry": 41.667
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 700 feet, You will arrive at your destination.</prosody></amazon:effect></speak>",
+                  "announcement": "In 700 feet, You will arrive at your destination.",
+                  "distanceAlongGeometry": 205.201
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">You have arrived at your destination.</prosody></amazon:effect></speak>",
+                  "announcement": "You have arrived at your destination.",
+                  "distanceAlongGeometry": 41.667
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "bearings": [
+                    12,
+                    103,
+                    191,
+                    282
+                  ],
+                  "duration": 7.332,
+                  "turn_weight": 10,
+                  "turn_duration": 5.275,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 12.52,
+                  "geometry_index": 10,
+                  "location": [
+                    -122.265266,
+                    37.811993
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    11,
+                    96,
+                    192,
+                    275
+                  ],
+                  "duration": 2.578,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 5.15,
+                  "geometry_index": 11,
+                  "location": [
+                    -122.265247,
+                    37.812062
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    12,
+                    191,
+                    284
+                  ],
+                  "duration": 4.894,
+                  "turn_weight": 1,
+                  "turn_duration": 0.008,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 6.985,
+                  "geometry_index": 12,
+                  "location": [
+                    -122.265225,
+                    37.812149
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "bearings": [
+                    12,
+                    192,
+                    282
+                  ],
+                  "duration": 15.951,
+                  "turn_weight": 1,
+                  "turn_duration": 0.008,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 20.53,
+                  "geometry_index": 13,
+                  "location": [
+                    -122.265181,
+                    37.812313
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    12,
+                    101,
+                    192
+                  ],
+                  "duration": 10.551,
+                  "turn_weight": 1,
+                  "turn_duration": 0.008,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 13.915,
+                  "geometry_index": 14,
+                  "location": [
+                    -122.265031,
+                    37.812861
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    12,
+                    101,
+                    192,
+                    280
+                  ],
+                  "duration": 1.808,
+                  "turn_weight": 2,
+                  "turn_duration": 0.008,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 4.205,
+                  "geometry_index": 15,
+                  "location": [
+                    -122.264936,
+                    37.813224
+                  ]
+                },
+                {
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    12,
+                    101,
+                    192,
+                    282
+                  ],
+                  "duration": 1.808,
+                  "turn_weight": 2,
+                  "turn_duration": 0.008,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 4.205,
+                  "geometry_index": 16,
+                  "location": [
+                    -122.264919,
+                    37.81329
+                  ]
+                },
+                {
+                  "bearings": [
+                    12,
+                    101,
+                    192,
+                    282
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "turn_weight": 2,
+                  "turn_duration": 0.008,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 17,
+                  "location": [
+                    -122.264897,
+                    37.813371
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "turn",
+                "instruction": "Turn left onto Webster Street.",
+                "modifier": "left",
+                "bearing_after": 12,
+                "bearing_before": 102,
+                "location": [
+                  -122.265266,
+                  37.811993
+                ]
+              },
+              "name": "Webster Street",
+              "weight_typical": 84.014,
+              "duration_typical": 56.77,
+              "duration": 56.77,
+              "distance": 215.201,
+              "driving_side": "right",
+              "weight": 84.014,
+              "mode": "driving",
+              "geometry": "qpzbgAbjnehFiCe@mDk@gIwAga@kHuU}DcCa@aDk@}Ci@yZoF"
+            },
+            {
+              "bannerInstructions": [],
+              "voiceInstructions": [],
+              "intersections": [
+                {
+                  "bearings": [
+                    192
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "admin_index": 0,
+                  "geometry_index": 19,
+                  "location": [
+                    -122.264756,
+                    37.813895
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "arrive",
+                "instruction": "You have arrived at your destination.",
+                "bearing_after": 0,
+                "bearing_before": 12,
+                "location": [
+                  -122.264756,
+                  37.813895
+                ]
+              },
+              "name": "Webster Street",
+              "weight_typical": 0,
+              "duration_typical": 0,
+              "duration": 0,
+              "distance": 0,
+              "driving_side": "right",
+              "weight": 0,
+              "mode": "driving",
+              "geometry": "mg~bgAfjmehF??"
+            }
+          ],
+          "distance": 348.273,
+          "summary": "23rd Street, Webster Street"
+        }
+      ],
+      "geometry": "oezbgA`xpehFu@_@a@UqCwA}BwC_AiAoC}AoBeAZcDfG}p@`@gEiCe@mDk@gIwAga@kHuU}DcCa@aDk@}Ci@yZoF",
+      "voiceLocale": "en-US",
+      "routeOptions": {
+        "baseUrl": "https://api.mapbox.com",
+        "user": "mapbox",
+        "profile": "driving-traffic",
+        "coordinates": "-122.26647993099465,37.81180345026722;-122.264756,37.813895",
+        "alternatives": true,
+        "language": "en",
+        "continue_straight": true,
+        "roundabout_exits": true,
+        "geometries": "polyline6",
+        "overview": "full",
+        "steps": true,
+        "voice_instructions": true,
+        "banner_instructions": true,
+        "voice_units": "imperial",
+        "enable_refresh": true
+      }
+    }
+  ]
+}

--- a/instrumentation-tests/src/main/res/raw/route_response_alternative_start.json
+++ b/instrumentation-tests/src/main/res/raw/route_response_alternative_start.json
@@ -1,1 +1,4729 @@
-{"code":"Ok","waypoints":[{"name":"Jefferson Street","location":[-122.275113,37.805222]},{"name":"Webster Street","location":[-122.264756,37.813895]}],"routes":[{"routeIndex":"0","distance":2016.495,"duration":358.397,"duration_typical":384.378,"geometry":"kimbgApqafhFkZaPuC}AwA~EeV|y@Sn@sAtEuAxEY~@qDzLuFbRsH`WqAhF{DsBaWuM}K_Gah@qXm_@gS]QgDkB_H{DeDmBoBeAkNuHoBcAwE_CoEuBwOoI_QeJqf@sWkLiGuJgFuBiAqBoAkBaBqBoBaBqBy@sCq@_Cy@sCu@_DyAuIq@}DwAcFi@sC{BkLaBgEu@qAWe@aBkBY]gAy@eAs@qBy@qBm@iBG}CLyDu@yB_@mKkBuCi@j@cGpCgYhFsi@\\gDH{@d@aF\\mDrJibAfFai@tBoTp@uGt@_Hf@aFrAiMtE{c@XsCTeClAyL`AkJnDy]V_DLcDeDeBaCmA}NwHs@]oCyAeIeEaCmAMaAWw@a@i@qhA}l@iSsK{HmEuIiFmBiA{GaEtHwG~@k@hA[vAK|AJl@J","weight":475.421,"weight_name":"auto","legs":[{"distance":2016.495,"duration":358.397,"duration_typical":384.378,"summary":"Castro Street, West Grand Avenue","admins":[{"iso_3166_1":"US","iso_3166_1_alpha3":"USA"}],"steps":[{"distance":63.674,"duration":28.654,"duration_typical":28.654,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"kimbgApqafhFkZaPuC}A","name":"Jefferson Street","mode":"driving","maneuver":{"location":[-122.275113,37.805222],"bearing_before":0.0,"bearing_after":26.0,"instruction":"Drive northeast on Jefferson Street.","type":"depart"},"voiceInstructions":[{"distanceAlongGeometry":63.674,"announcement":"Drive northeast on Jefferson Street. Then Turn left onto 14th Street.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive northeast on Jefferson Street. Then Turn left onto 14th Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":63.674,"primary":{"text":"14th Street","components":[{"text":"14th Street","type":"text"}],"type":"turn","modifier":"left"}}],"driving_side":"right","weight":34.384,"intersections":[{"location":[-122.275113,37.805222],"bearings":[26],"entry":[true],"out":0,"geometry_index":0,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}}]},{"distance":232.0,"duration":44.965,"duration_typical":44.965,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"minbgAp}`fhFwA~EeV|y@Sn@sAtEuAxEY~@qDzLuFbRsH`WqAhF","name":"14th Street","mode":"driving","maneuver":{"location":[-122.274793,37.805735],"bearing_before":26.0,"bearing_after":296.0,"instruction":"Turn left onto 14th Street.","type":"turn","modifier":"left"},"voiceInstructions":[{"distanceAlongGeometry":216.0,"announcement":"In 800 feet, Turn right onto Castro Street.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 800 feet, Turn right onto Castro Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":80.0,"announcement":"Turn right onto Castro Street.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto Castro Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":232.0,"primary":{"text":"Castro Street","components":[{"text":"Castro Street","type":"text"}],"type":"turn","modifier":"right"}}],"driving_side":"right","weight":68.16,"intersections":[{"location":[-122.274793,37.805735],"bearings":[206,296],"entry":[false,true],"in":0,"out":1,"geometry_index":2,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}},{"location":[-122.275979,37.806202],"bearings":[117,297],"entry":[false,true],"in":0,"out":1,"geometry_index":6,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}},{"location":[-122.276342,37.806347],"bearings":[117,297],"entry":[false,true],"in":0,"out":1,"geometry_index":9,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}},{"location":[-122.276648,37.80647],"bearings":[117,297],"entry":[false,true],"in":0,"out":1,"geometry_index":10,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}}]},{"distance":579.0,"duration":79.771,"duration_typical":82.162,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"qcpbgAzpefhF{DsBaWuM}K_Gah@qXm_@gS]QgDkB_H{DeDmBoBeAkNuHoBcAwE_CoEuBwOoI_QeJqf@sWkLiGuJgFuBiAqBoAkBaBqBoBaBqB","name":"Castro Street","mode":"driving","maneuver":{"location":[-122.27715,37.806665],"bearing_before":295.0,"bearing_after":26.0,"instruction":"Turn right onto Castro Street.","type":"turn","modifier":"right"},"voiceInstructions":[{"distanceAlongGeometry":565.667,"announcement":"In a quarter mile, Bear right to stay on Castro Street.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Bear right to stay on Castro Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":107.778,"announcement":"Bear right to stay on Castro Street. Then, in 400 feet, Bear left onto Martin Luther King Junior Way.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eBear right to stay on Castro Street. Then, in 400 feet, Bear left onto Martin Luther King Junior Way.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":579.0,"primary":{"text":"Castro Street","components":[{"text":"Castro Street","type":"text"}],"type":"turn","modifier":"slight right"},"sub":{"text":"","components":[{"text":"","type":"lane","directions":["left"],"active":false},{"text":"","type":"lane","directions":["straight","right"],"active":true,"active_direction":"right"},{"text":"","type":"lane","directions":["right"],"active":false}]}}],"driving_side":"right","weight":104.434,"intersections":[{"location":[-122.27715,37.806665],"bearings":[26,115],"entry":[true,false],"in":1,"out":0,"geometry_index":12,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.276857,37.807144],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":14,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.276729,37.807351],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":15,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.27632,37.808008],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":16,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.275933,37.808626],"bearings":[27,207],"entry":[true,false],"in":1,"out":0,"geometry_index":19,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.275839,37.80877],"bearings":[28,207],"entry":[true,false],"in":1,"out":0,"geometry_index":20,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.275784,37.808853],"bearings":[26,208],"entry":[true,false],"in":1,"out":0,"geometry_index":21,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.275749,37.808909],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":22,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.275594,37.809155],"bearings":[25,206],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["left","straight"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]}],"geometry_index":23,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.275496,37.809319],"bearings":[25,205],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["left","straight"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]}],"geometry_index":25,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.27509,37.809979],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":28,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.274696,37.810612],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":29,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.274563,37.810826],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":30,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}}]},{"distance":126.0,"duration":16.329,"duration_typical":17.919,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"qdybgA~x_fhFy@sCq@_Cy@sCu@_DyAuIq@}DwAcFi@sC{BkLaBgEu@qAWe@aBkBY]gAy@eAs@","name":"Castro Street","mode":"driving","maneuver":{"location":[-122.274208,37.811289],"bearing_before":39.0,"bearing_after":64.0,"instruction":"Bear right to stay on Castro Street.","type":"continue","modifier":"slight right"},"voiceInstructions":[{"distanceAlongGeometry":115.694,"announcement":"Bear left onto Martin Luther King Junior Way. Then Turn right onto West Grand Avenue.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eBear left onto Martin Luther King Junior Way. Then Turn right onto West Grand Avenue.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":126.0,"primary":{"text":"Martin Luther King Junior Way","components":[{"text":"Martin Luther King Junior Way","type":"text"}],"type":"turn","modifier":"slight left"},"sub":{"text":"West Grand Avenue","components":[{"text":"West Grand Avenue","type":"text"}],"type":"turn","modifier":"right"}}],"driving_side":"right","weight":21.171,"intersections":[{"location":[-122.274208,37.811289],"bearings":[64,219],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":true,"valid_indication":"right","indications":["straight","right"]},{"valid":true,"active":false,"valid_indication":"right","indications":["right"]}],"geometry_index":36,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.27365,37.811469],"bearings":[64,252],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]},{"valid":false,"active":false,"indications":["right"]}],"geometry_index":42,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}},{"location":[-122.273536,37.811513],"bearings":[70,244],"entry":[true,false],"in":1,"out":0,"geometry_index":43,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}},{"location":[-122.273248,37.811596],"bearings":[53,250],"entry":[true,false],"in":1,"out":0,"geometry_index":45,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}},{"location":[-122.273019,37.811746],"bearings":[31,228],"entry":[true,false],"in":1,"out":0,"geometry_index":50,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}}]},{"distance":77.0,"duration":16.618,"duration_typical":16.618,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"qezbgAfk}ehFqBy@qBm@iBG}CLyDu@yB_@mKkBuCi@","name":"Martin Luther King Junior Way","mode":"driving","maneuver":{"location":[-122.272964,37.811817],"bearing_before":31.0,"bearing_after":13.0,"instruction":"Bear left onto Martin Luther King Junior Way.","type":"turn","modifier":"slight left"},"voiceInstructions":[{"distanceAlongGeometry":60.667,"announcement":"Turn right onto West Grand Avenue.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto West Grand Avenue.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":77.0,"primary":{"text":"West Grand Avenue","components":[{"text":"West Grand Avenue","type":"text"}],"type":"turn","modifier":"right"}}],"driving_side":"right","weight":26.504,"intersections":[{"location":[-122.272964,37.811817],"bearings":[13,211],"entry":[true,false],"in":1,"out":0,"geometry_index":52,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}},{"location":[-122.272915,37.812063],"bearings":[12,185],"entry":[true,false],"in":1,"out":0,"geometry_index":56,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}}]},{"distance":545.0,"duration":101.856,"duration_typical":123.856,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"uo{bgAx`}ehFj@cGpCgYhFsi@\\gDH{@d@aF\\mDrJibAfFai@tBoTp@uGt@_Hf@aFrAiMtE{c@XsCTeClAyL`AkJnDy]V_DLcD","name":"West Grand Avenue","mode":"driving","maneuver":{"location":[-122.272797,37.812491],"bearing_before":12.0,"bearing_after":102.0,"instruction":"Turn right onto West Grand Avenue.","type":"turn","modifier":"right"},"voiceInstructions":[{"distanceAlongGeometry":526.0,"announcement":"In a quarter mile, Turn left onto Broadway.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn left onto Broadway.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":88.667,"announcement":"Turn left onto Broadway.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto Broadway.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":545.0,"primary":{"text":"Broadway","components":[{"text":"Broadway","type":"text"}],"type":"turn","modifier":"left"},"sub":{"text":"","components":[{"text":"","type":"lane","directions":["left"],"active":true,"active_direction":"left"},{"text":"","type":"lane","directions":["straight"],"active":false},{"text":"","type":"lane","directions":["straight","right"],"active":false}]}}],"driving_side":"right","weight":123.752,"intersections":[{"location":[-122.272797,37.812491],"bearings":[102,192],"entry":[true,false],"in":1,"out":0,"geometry_index":60,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.272247,37.812396],"bearings":[102,282],"entry":[true,false],"in":1,"out":0,"geometry_index":62,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.271481,37.812264],"bearings":[102,282],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]}],"geometry_index":64,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.271451,37.812259],"bearings":[102,282],"entry":[true,false],"in":1,"out":0,"geometry_index":65,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.271338,37.81224],"bearings":[102,282],"entry":[true,false],"in":1,"out":0,"geometry_index":66,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.270174,37.812039],"bearings":[102,282],"entry":[true,false],"in":1,"out":0,"geometry_index":68,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.269018,37.811839],"bearings":[103,283],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight","right"]}],"geometry_index":71,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.267868,37.81163],"bearings":[102,283],"entry":[true,false],"in":1,"out":0,"geometry_index":76,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.26758,37.81158],"bearings":[103,283],"entry":[true,false],"in":1,"out":0,"geometry_index":78,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.267398,37.811547],"bearings":[103,283],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":true,"active":true,"valid_indication":"left","indications":["left"]},{"valid":false,"active":false,"indications":["straight"]},{"valid":false,"active":false,"indications":["straight"]}],"geometry_index":79,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266905,37.811459],"bearings":[98,283],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":true,"active":true,"valid_indication":"left","indications":["left"]},{"valid":false,"active":false,"indications":["straight"]},{"valid":false,"active":false,"indications":["straight"]}],"geometry_index":80,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}}]},{"distance":352.0,"duration":51.826,"duration_typical":51.826,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"_nybgAlfqehFeDeBaCmA}NwHs@]oCyAeIeEaCmAMaAWw@a@i@qhA}l@iSsK{HmEuIiFmBiA{GaE","name":"Broadway","mode":"driving","maneuver":{"location":[-122.266743,37.81144],"bearing_before":98.0,"bearing_after":25.0,"instruction":"Turn left onto Broadway.","type":"turn","modifier":"left"},"voiceInstructions":[{"distanceAlongGeometry":323.0,"announcement":"In a quarter mile, Turn right onto Webster Street.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn right onto Webster Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":105.333,"announcement":"Turn right onto Webster Street. Then Your destination will be on the left.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto Webster Street. Then Your destination will be on the left.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":352.0,"primary":{"text":"Webster Street","components":[{"text":"Webster Street","type":"text"}],"type":"turn","modifier":"right"}}],"driving_side":"right","weight":71.401,"intersections":[{"location":[-122.266743,37.81144],"bearings":[26,278],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":true,"active":true,"valid_indication":"left","indications":["left"]},{"valid":false,"active":false,"indications":["straight"]},{"valid":false,"active":false,"indications":["straight","right"]}],"geometry_index":82,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266692,37.811523],"bearings":[25,206],"entry":[true,false],"in":1,"out":0,"geometry_index":83,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266653,37.811588],"bearings":[26,205],"entry":[true,false],"in":1,"out":0,"geometry_index":84,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266482,37.811869],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":86,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266437,37.811941],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":87,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266299,37.812169],"bearings":[40,206],"entry":[true,false],"in":1,"out":0,"geometry_index":89,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.265482,37.813382],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":93,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.265023,37.814091],"bearings":[28,208],"entry":[true,false],"in":1,"out":0,"geometry_index":97,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}}]},{"distance":41.821,"duration":18.379,"duration_typical":18.379,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"q|~bgAztmehFtHwG~@k@hA[vAK|AJl@J","name":"Webster Street","mode":"driving","maneuver":{"location":[-122.264926,37.814233],"bearing_before":28.0,"bearing_after":144.0,"instruction":"Turn right onto Webster Street.","type":"turn","modifier":"right"},"voiceInstructions":[{"distanceAlongGeometry":41.667,"announcement":"Your destination is on the left.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYour destination is on the left.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":41.821,"primary":{"text":"Your destination will be on the left","components":[{"text":"Your destination will be on the left","type":"text"}],"type":"arrive","modifier":"left"}},{"distanceAlongGeometry":41.667,"primary":{"text":"Your destination is on the left","components":[{"text":"Your destination is on the left","type":"text"}],"type":"arrive","modifier":"left"}}],"driving_side":"right","weight":25.615,"intersections":[{"location":[-122.264926,37.814233],"bearings":[144,208],"entry":[true,false],"in":1,"out":0,"geometry_index":98,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}},{"location":[-122.264786,37.814078],"bearings":[158,324],"entry":[true,false],"in":1,"out":0,"geometry_index":99,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}},{"location":[-122.26475,37.814009],"bearings":[182,338],"entry":[true,false],"in":1,"out":0,"geometry_index":101,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}}]},{"distance":0.0,"duration":0.0,"duration_typical":0.0,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"mg~bgAfjmehF??","name":"Webster Street","mode":"driving","maneuver":{"location":[-122.264756,37.813895],"bearing_before":182.0,"bearing_after":0.0,"instruction":"Your destination is on the left.","type":"arrive","modifier":"left"},"voiceInstructions":[],"bannerInstructions":[],"driving_side":"right","weight":0.0,"intersections":[{"location":[-122.264756,37.813895],"bearings":[2],"entry":[true],"in":0,"geometry_index":104,"admin_index":0}]}],"annotation":{"distance":[54.4,9.3,11.0,92.7,2.4,10.5,10.7,3.2,21.9,30.2,38.0,11.3,11.6,47.6,25.6,81.5,64.4,1.8,10.5,18.0,10.4,7.0,30.6,6.9,13.3,12.7,33.3,35.7,78.5,26.5,23.2,7.3,7.3,7.4,8.0,7.4,7.3,6.3,7.3,7.7,15.9,8.8,11.2,6.9,20.0,10.3,4.7,2.1,7.2,2.0,4.8,4.5,6.8,6.7,5.9,8.8,10.6,6.9,22.7,8.6,11.7,37.8,61.4,7.6,2.7,10.2,7.8,97.0,60.6,31.0,12.5,13.0,10.2,20.7,53.2,6.7,6.0,19.9,16.4,44.5,7.2,7.3,10.3,8.0,31.5,3.2,8.9,20.1,8.0,3.0,2.8,2.6,146.1,40.3,19.8,21.6,6.9,18.0,21.2,4.1,4.3,4.9,5.3,2.6],"duration":[24.461,4.192,1.65,13.898,0.358,1.576,1.677,0.495,3.427,4.726,5.941,1.762,1.164,4.758,2.565,6.986,23.191,0.665,3.775,2.164,1.073,0.894,3.933,1.185,2.276,1.015,2.663,2.857,4.874,1.592,1.391,0.44,0.435,0.444,0.482,0.445,0.436,0.377,0.436,0.459,0.951,0.528,1.826,0.803,2.328,1.202,0.545,0.249,0.84,0.228,0.552,0.525,0.724,0.705,0.626,0.933,2.941,1.92,6.274,2.368,2.338,7.564,12.275,1.515,0.278,1.045,0.742,9.185,5.739,2.933,1.188,1.339,1.048,2.127,5.476,0.686,2.167,7.169,5.912,16.002,2.578,2.611,2.641,1.31,5.159,0.52,1.463,3.293,1.31,0.338,0.315,0.297,16.436,4.031,1.978,2.164,0.693,2.812,7.631,1.459,1.548,1.043,1.114,0.558],"speed":[2.2,2.2,6.7,6.7,6.7,6.7,6.4,6.4,6.4,6.4,6.4,6.4,10.0,10.0,10.0,11.7,2.8,2.8,2.8,8.3,9.7,7.8,7.8,5.8,5.8,12.5,12.5,12.5,16.1,16.7,16.7,16.7,16.7,16.7,16.7,16.7,16.7,16.7,16.7,16.7,16.7,16.7,6.1,8.6,8.6,8.6,8.6,8.6,8.6,8.6,8.6,8.6,9.4,9.4,9.4,9.4,3.6,3.6,3.6,3.6,5.0,5.0,5.0,5.0,9.7,9.7,10.6,10.6,10.6,10.6,10.6,9.7,9.7,9.7,9.7,9.7,2.8,2.8,2.8,2.8,2.8,2.8,3.9,6.1,6.1,6.1,6.1,6.1,6.1,8.9,8.9,8.9,8.9,10.0,10.0,10.0,10.0,6.4,2.8,2.8,2.8,4.7,4.7,4.7],"maxspeed":[{"unknown":true},{"unknown":true},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true}],"congestion_numeric":[null,null,0,0,0,0,11,11,11,11,11,11,11,11,11,8,null,null,null,null,null,17,17,null,null,null,null,null,0,0,0,0,0,0,0,0,0,0,0,0,0,0,null,0,0,11,11,11,11,11,11,11,0,0,0,0,null,null,null,null,12,12,12,12,null,null,0,0,0,0,0,12,12,12,12,12,null,null,null,null,null,null,null,null,null,null,null,null,null,9,9,9,9,null,null,null,null,null,null,null,null,null,null,null]}}],"routeOptions":{"baseUrl":"https://api.mapbox.com","user":"mapbox","profile":"driving-traffic","coordinates":"-122.2750659,37.8052036;-122.2647245,37.8138895","alternatives":true,"language":"en","continue_straight":true,"roundabout_exits":true,"geometries":"polyline6","overview":"full","steps":true,"annotations":"congestion_numeric,maxspeed,speed,duration,distance,closure","voice_instructions":true,"banner_instructions":true,"voice_units":"imperial","enable_refresh":true},"voiceLocale":"en-US","requestUuid":"1SSd29ZxmjD7ELLqDJHRPPDP5W4wdh633IbGo41pJrL6wpJRmzNaMA\u003d\u003d"},{"routeIndex":"1","distance":1652.495,"duration":390.064,"duration_typical":390.064,"geometry":"kimbgApqafhFkZaPuC}AyDsBm`@{SuBgAmCwAu_@eSiCuAeCsA}QyJaDcByDuBnAkEhLq`@v@mCPm@J_@~FkS`@_Bj@eCZmB\\_CZkCPuDDoBFiB`OyeBh@gFt@iFfAiFpA{El@uBlB{GiCwA}CaByF{CgKsFyd@qVqBiAgCsAq@a@iIkEs_@kSeXwNoCyAqDoBoD}AkF}BcAsBeAyAyA_As_@qSgCuAcCqA{l@s[w@a@c@Cc@Fq@NyBiAmAo@mE}BOIoDkB{H_E{BkAeDeBaCmA}NwHs@]oCyAeIeEaCmAMaAWw@a@i@qhA}l@iSsK{HmEuIiFmBiA{GaEtHwG~@k@hA[vAK|AJl@J","weight":490.114,"weight_name":"auto","legs":[{"distance":1652.495,"duration":390.064,"duration_typical":390.064,"summary":"17th Street, Broadway","admins":[{"iso_3166_1":"US","iso_3166_1_alpha3":"USA"}],"steps":[{"distance":298.674,"duration":84.575,"duration_typical":84.575,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"kimbgApqafhFkZaPuC}AyDsBm`@{SuBgAmCwAu_@eSiCuAeCsA}QyJaDcByDuB","name":"Jefferson Street","mode":"driving","maneuver":{"location":[-122.275113,37.805222],"bearing_before":0.0,"bearing_after":26.0,"instruction":"Drive northeast on Jefferson Street.","type":"depart"},"voiceInstructions":[{"distanceAlongGeometry":298.674,"announcement":"Drive northeast on Jefferson Street. Then, in 1,000 feet, Turn right onto 17th Street.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive northeast on Jefferson Street. Then, in 1,000 feet, Turn right onto 17th Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":50.0,"announcement":"Turn right onto 17th Street.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto 17th Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":298.674,"primary":{"text":"17th Street","components":[{"text":"17th Street","type":"text"}],"type":"turn","modifier":"right"}}],"driving_side":"right","weight":103.23,"intersections":[{"location":[-122.275113,37.805222],"bearings":[26],"entry":[true],"out":0,"geometry_index":0,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}},{"location":[-122.274793,37.805735],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":2,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}},{"location":[-122.274365,37.806422],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":5,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}},{"location":[-122.273955,37.807085],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":8,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}},{"location":[-122.273724,37.807455],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":10,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}}]},{"distance":362.0,"duration":100.424,"duration_typical":100.424,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"y_rbgA|s~ehFnAkEhLq`@v@mCPm@J_@~FkS`@_Bj@eCZmB\\_CZkCPuDDoBFiB`OyeBh@gFt@iFfAiFpA{El@uBlB{G","name":"17th Street","mode":"driving","maneuver":{"location":[-122.273615,37.807629],"bearing_before":26.0,"bearing_after":117.0,"instruction":"Turn right onto 17th Street.","type":"turn","modifier":"right"},"voiceInstructions":[{"distanceAlongGeometry":348.667,"announcement":"In a quarter mile, Turn left onto Broadway.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn left onto Broadway.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":62.222,"announcement":"Turn left onto Broadway.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto Broadway.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":362.0,"primary":{"text":"Broadway","components":[{"text":"Broadway","type":"text"}],"type":"turn","modifier":"left"},"sub":{"text":"","components":[{"text":"","type":"lane","directions":["left"],"active":true,"active_direction":"left"},{"text":"","type":"lane","directions":["straight"],"active":false},{"text":"","type":"lane","directions":["straight","right"],"active":false}]}}],"driving_side":"right","weight":125.568,"intersections":[{"location":[-122.273615,37.807629],"bearings":[117,206],"entry":[true,false],"in":1,"out":0,"geometry_index":12,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.272976,37.807376],"bearings":[117,297],"entry":[true,false],"in":1,"out":0,"geometry_index":14,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.272905,37.807348],"bearings":[116,297],"entry":[true,false],"in":1,"out":0,"geometry_index":15,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.272882,37.807339],"bearings":[115,296],"entry":[true,false],"in":1,"out":0,"geometry_index":16,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.272866,37.807333],"bearings":[116,295],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":false,"active":false,"indications":["right"]}],"geometry_index":17,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.272425,37.807166],"bearings":[106,295],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":false,"active":false,"indications":["right"]}],"geometry_index":20,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}},{"location":[-122.272236,37.807123],"bearings":[97,286],"entry":[true,false],"in":1,"out":0,"geometry_index":23,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}},{"location":[-122.272145,37.807114],"bearings":[98,277],"entry":[true,false],"in":1,"out":0,"geometry_index":24,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"secondary"}},{"location":[-122.270275,37.806829],"bearings":[109,282],"entry":[true,false],"in":1,"out":0,"geometry_index":28,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"tertiary"}}]},{"distance":950.0,"duration":186.686,"duration_typical":186.686,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"mbpbgAbawehFiCwA}CaByF{CgKsFyd@qVqBiAgCsAq@a@iIkEs_@kSeXwNoCyAqDoBoD}AkF}BcAsBeAyAyA_As_@qSgCuAcCqA{l@s[w@a@c@Cc@Fq@NyBiAmAo@mE}BOIoDkB{H_E{BkAeDeBaCmA}NwHs@]oCyAeIeEaCmAMaAWw@a@i@qhA}l@iSsK{HmEuIiFmBiA{GaE","name":"Broadway","mode":"driving","maneuver":{"location":[-122.26973,37.806647],"bearing_before":116.0,"bearing_after":26.0,"instruction":"Turn left onto Broadway.","type":"turn","modifier":"left"},"voiceInstructions":[{"distanceAlongGeometry":931.0,"announcement":"Continue for a half mile.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eContinue for a half mile.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":402.336,"announcement":"In a quarter mile, Turn right onto Webster Street.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn right onto Webster Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"},{"distanceAlongGeometry":105.333,"announcement":"Turn right onto Webster Street. Then Your destination will be on the left.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto Webster Street. Then Your destination will be on the left.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":950.0,"primary":{"text":"Webster Street","components":[{"text":"Webster Street","type":"text"}],"type":"turn","modifier":"right"}}],"driving_side":"right","weight":235.7,"intersections":[{"location":[-122.26973,37.806647],"bearings":[26,296],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":true,"active":true,"valid_indication":"left","indications":["left"]},{"valid":false,"active":false,"indications":["straight"]},{"valid":false,"active":false,"indications":["straight","right"]}],"geometry_index":33,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.269637,37.806795],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":35,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.269437,37.807116],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":37,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.269023,37.807778],"bearings":[26,207],"entry":[true,false],"in":1,"out":0,"geometry_index":39,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.268239,37.809033],"bearings":[25,206],"entry":[true,false],"in":1,"out":0,"geometry_index":45,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.268073,37.809328],"bearings":[43,203],"entry":[true,false],"in":1,"out":0,"geometry_index":48,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.267938,37.809442],"bearings":[26,223],"entry":[true,false],"in":1,"out":0,"geometry_index":51,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.267566,37.810032],"bearings":[26,207],"entry":[true,false],"in":1,"out":0,"geometry_index":53,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.26706,37.810921],"bearings":[26,195],"entry":[true,false],"in":1,"out":0,"geometry_index":59,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266999,37.811021],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":61,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266936,37.811124],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]}],"geometry_index":62,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266931,37.811132],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]}],"geometry_index":63,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266877,37.81122],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]},{"valid":false,"active":false,"indications":["right"]}],"geometry_index":64,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266781,37.811378],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]},{"valid":false,"active":false,"indications":["right"]}],"geometry_index":65,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266743,37.81144],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"lanes":[{"valid":false,"active":false,"indications":["left"]},{"valid":true,"active":false,"valid_indication":"straight","indications":["straight"]},{"valid":true,"active":true,"valid_indication":"straight","indications":["straight"]},{"valid":false,"active":false,"indications":["right"]}],"geometry_index":66,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266692,37.811523],"bearings":[25,206],"entry":[true,false],"in":1,"out":0,"geometry_index":67,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266653,37.811588],"bearings":[26,205],"entry":[true,false],"in":1,"out":0,"geometry_index":68,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266482,37.811869],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":70,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266437,37.811941],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":71,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.266299,37.812169],"bearings":[40,206],"entry":[true,false],"in":1,"out":0,"geometry_index":73,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.265482,37.813382],"bearings":[26,206],"entry":[true,false],"in":1,"out":0,"geometry_index":77,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}},{"location":[-122.265023,37.814091],"bearings":[28,208],"entry":[true,false],"in":1,"out":0,"geometry_index":81,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"primary"}}]},{"distance":41.821,"duration":18.379,"duration_typical":18.379,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"q|~bgAztmehFtHwG~@k@hA[vAK|AJl@J","name":"Webster Street","mode":"driving","maneuver":{"location":[-122.264926,37.814233],"bearing_before":28.0,"bearing_after":144.0,"instruction":"Turn right onto Webster Street.","type":"turn","modifier":"right"},"voiceInstructions":[{"distanceAlongGeometry":41.667,"announcement":"Your destination is on the left.","ssmlAnnouncement":"\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYour destination is on the left.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"}],"bannerInstructions":[{"distanceAlongGeometry":41.821,"primary":{"text":"Your destination will be on the left","components":[{"text":"Your destination will be on the left","type":"text"}],"type":"arrive","modifier":"left"}},{"distanceAlongGeometry":41.667,"primary":{"text":"Your destination is on the left","components":[{"text":"Your destination is on the left","type":"text"}],"type":"arrive","modifier":"left"}}],"driving_side":"right","weight":25.615,"intersections":[{"location":[-122.264926,37.814233],"bearings":[144,208],"entry":[true,false],"in":1,"out":0,"geometry_index":82,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}},{"location":[-122.264786,37.814078],"bearings":[158,324],"entry":[true,false],"in":1,"out":0,"geometry_index":83,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}},{"location":[-122.26475,37.814009],"bearings":[182,338],"entry":[true,false],"in":1,"out":0,"geometry_index":85,"is_urban":true,"admin_index":0,"mapbox_streets_v8":{"class":"street"}}]},{"distance":0.0,"duration":0.0,"duration_typical":0.0,"speedLimitUnit":"mph","speedLimitSign":"mutcd","geometry":"mg~bgAfjmehF??","name":"Webster Street","mode":"driving","maneuver":{"location":[-122.264756,37.813895],"bearing_before":182.0,"bearing_after":0.0,"instruction":"Your destination is on the left.","type":"arrive","modifier":"left"},"voiceInstructions":[],"bannerInstructions":[],"driving_side":"right","weight":0.0,"intersections":[{"location":[-122.264756,37.813895],"bearings":[2],"entry":[true],"in":0,"geometry_index":88,"admin_index":0}]}],"annotation":{"distance":[54.4,9.3,11.5,66.4,7.3,8.8,64.8,8.6,8.3,37.6,10.0,11.6,10.0,52.8,7.0,2.3,1.6,32.0,4.6,6.4,5.1,5.9,6.4,8.1,4.9,4.7,147.5,10.5,10.7,11.0,10.7,5.8,13.9,8.6,9.8,15.5,24.3,75.1,7.1,8.4,3.2,20.4,64.8,50.0,8.9,11.1,10.6,14.3,6.4,5.6,5.7,64.9,8.5,8.2,91.1,3.5,2.0,2.0,2.9,7.5,4.8,12.7,1.0,10.9,19.5,7.7,10.3,8.0,31.5,3.2,8.9,20.1,8.0,3.0,2.8,2.6,146.1,40.3,19.8,21.6,6.9,18.0,21.2,4.1,4.3,4.9,5.3,2.6],"duration":[24.461,4.192,2.597,14.942,1.64,1.76,12.956,1.712,1.998,9.025,2.408,2.779,2.121,11.191,1.478,0.478,0.329,6.78,0.98,1.351,1.83,2.114,2.286,0.83,1.045,0.992,31.231,2.217,4.288,4.417,4.279,2.315,5.564,1.821,2.074,3.285,5.149,15.897,1.51,1.378,0.517,3.345,10.603,8.188,1.463,1.897,1.823,2.444,1.345,1.176,1.217,13.747,1.792,1.841,20.497,0.778,0.453,0.458,0.646,1.936,1.241,3.275,0.256,2.799,5.017,1.972,2.641,1.31,5.159,0.52,1.463,3.293,1.31,0.338,0.315,0.297,16.436,4.031,1.978,2.164,0.693,2.812,7.631,1.459,1.548,1.043,1.114,0.558],"speed":[2.2,2.2,4.4,4.4,4.4,5.0,5.0,5.0,4.2,4.2,4.2,4.2,4.7,4.7,4.7,4.7,4.7,4.7,4.7,4.7,2.8,2.8,2.8,9.7,4.7,4.7,4.7,4.7,2.5,2.5,2.5,2.5,2.5,4.7,4.7,4.7,4.7,4.7,4.7,6.1,6.1,6.1,6.1,6.1,6.1,5.8,5.8,5.8,4.7,4.7,4.7,4.7,4.7,4.4,4.4,4.4,4.4,4.4,4.4,3.9,3.9,3.9,3.9,3.9,3.9,3.9,3.9,6.1,6.1,6.1,6.1,6.1,6.1,8.9,8.9,8.9,8.9,10.0,10.0,10.0,10.0,6.4,2.8,2.8,2.8,4.7,4.7,4.7],"maxspeed":[{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"speed":40,"unit":"km/h"},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"speed":48,"unit":"km/h"},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true},{"unknown":true}],"congestion_numeric":[null,null,null,null,null,0,0,0,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,0,9,9,9,9,null,null,null,null,null,null,null,null,null,null,null,0,0,0,0,0,0,null,null,null,null,null,null,null,null,9,9,9,9,9,9,6,6,6,6,6,6,6,null,null,null,null,null,null,null,9,9,9,9,null,null,null,null,null,null,null,null,null,null,null]}}],"routeOptions":{"baseUrl":"https://api.mapbox.com","user":"mapbox","profile":"driving-traffic","coordinates":"-122.2750659,37.8052036;-122.2647245,37.8138895","alternatives":true,"language":"en","continue_straight":true,"roundabout_exits":true,"geometries":"polyline6","overview":"full","steps":true,"annotations":"congestion_numeric,maxspeed,speed,duration,distance,closure","voice_instructions":true,"banner_instructions":true,"voice_units":"imperial","enable_refresh":true},"voiceLocale":"en-US","requestUuid":"1SSd29ZxmjD7ELLqDJHRPPDP5W4wdh633IbGo41pJrL6wpJRmzNaMA\u003d\u003d"}],"uuid":"1SSd29ZxmjD7ELLqDJHRPPDP5W4wdh633IbGo41pJrL6wpJRmzNaMA\u003d\u003d"}
+{
+  "code": "Ok",
+  "waypoints": [
+    {
+      "name": "Jefferson Street",
+      "location": [
+        -122.275113,
+        37.805222
+      ]
+    },
+    {
+      "name": "Webster Street",
+      "location": [
+        -122.264756,
+        37.813895
+      ]
+    }
+  ],
+  "routes": [
+    {
+      "routeIndex": "0",
+      "distance": 2016.495,
+      "duration": 358.397,
+      "duration_typical": 384.378,
+      "geometry": "kimbgApqafhFkZaPuC}AwA~EeV|y@Sn@sAtEuAxEY~@qDzLuFbRsH`WqAhF{DsBaWuM}K_Gah@qXm_@gS]QgDkB_H{DeDmBoBeAkNuHoBcAwE_CoEuBwOoI_QeJqf@sWkLiGuJgFuBiAqBoAkBaBqBoBaBqBy@sCq@_Cy@sCu@_DyAuIq@}DwAcFi@sC{BkLaBgEu@qAWe@aBkBY]gAy@eAs@qBy@qBm@iBG}CLyDu@yB_@mKkBuCi@j@cGpCgYhFsi@\\gDH{@d@aF\\mDrJibAfFai@tBoTp@uGt@_Hf@aFrAiMtE{c@XsCTeClAyL`AkJnDy]V_DLcDeDeBaCmA}NwHs@]oCyAeIeEaCmAMaAWw@a@i@qhA}l@iSsK{HmEuIiFmBiA{GaEtHwG~@k@hA[vAK|AJl@J",
+      "weight": 475.421,
+      "weight_name": "auto",
+      "legs": [
+        {
+          "distance": 2016.495,
+          "duration": 358.397,
+          "duration_typical": 384.378,
+          "summary": "Castro Street, West Grand Avenue",
+          "admins": [
+            {
+              "iso_3166_1": "US",
+              "iso_3166_1_alpha3": "USA"
+            }
+          ],
+          "steps": [
+            {
+              "distance": 63.674,
+              "duration": 28.654,
+              "duration_typical": 28.654,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "kimbgApqafhFkZaPuC}A",
+              "name": "Jefferson Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.275113,
+                  37.805222
+                ],
+                "bearing_before": 0.0,
+                "bearing_after": 26.0,
+                "instruction": "Drive northeast on Jefferson Street.",
+                "type": "depart"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 63.674,
+                  "announcement": "Drive northeast on Jefferson Street. Then Turn left onto 14th Street.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive northeast on Jefferson Street. Then Turn left onto 14th Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 63.674,
+                  "primary": {
+                    "text": "14th Street",
+                    "components": [
+                      {
+                        "text": "14th Street",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "left"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 34.384,
+              "intersections": [
+                {
+                  "location": [
+                    -122.275113,
+                    37.805222
+                  ],
+                  "bearings": [
+                    26
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "out": 0,
+                  "geometry_index": 0,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 232.0,
+              "duration": 44.965,
+              "duration_typical": 44.965,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "minbgAp}`fhFwA~EeV|y@Sn@sAtEuAxEY~@qDzLuFbRsH`WqAhF",
+              "name": "14th Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.274793,
+                  37.805735
+                ],
+                "bearing_before": 26.0,
+                "bearing_after": 296.0,
+                "instruction": "Turn left onto 14th Street.",
+                "type": "turn",
+                "modifier": "left"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 216.0,
+                  "announcement": "In 800 feet, Turn right onto Castro Street.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 800 feet, Turn right onto Castro Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 80.0,
+                  "announcement": "Turn right onto Castro Street.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto Castro Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 232.0,
+                  "primary": {
+                    "text": "Castro Street",
+                    "components": [
+                      {
+                        "text": "Castro Street",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 68.16,
+              "intersections": [
+                {
+                  "location": [
+                    -122.274793,
+                    37.805735
+                  ],
+                  "bearings": [
+                    206,
+                    296
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 2,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.275979,
+                    37.806202
+                  ],
+                  "bearings": [
+                    117,
+                    297
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 6,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.276342,
+                    37.806347
+                  ],
+                  "bearings": [
+                    117,
+                    297
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 9,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.276648,
+                    37.80647
+                  ],
+                  "bearings": [
+                    117,
+                    297
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 10,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 579.0,
+              "duration": 79.771,
+              "duration_typical": 82.162,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "qcpbgAzpefhF{DsBaWuM}K_Gah@qXm_@gS]QgDkB_H{DeDmBoBeAkNuHoBcAwE_CoEuBwOoI_QeJqf@sWkLiGuJgFuBiAqBoAkBaBqBoBaBqB",
+              "name": "Castro Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.27715,
+                  37.806665
+                ],
+                "bearing_before": 295.0,
+                "bearing_after": 26.0,
+                "instruction": "Turn right onto Castro Street.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 565.667,
+                  "announcement": "In a quarter mile, Bear right to stay on Castro Street.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Bear right to stay on Castro Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 107.778,
+                  "announcement": "Bear right to stay on Castro Street. Then, in 400 feet, Bear left onto Martin Luther King Junior Way.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eBear right to stay on Castro Street. Then, in 400 feet, Bear left onto Martin Luther King Junior Way.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 579.0,
+                  "primary": {
+                    "text": "Castro Street",
+                    "components": [
+                      {
+                        "text": "Castro Street",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "slight right"
+                  },
+                  "sub": {
+                    "text": "",
+                    "components": [
+                      {
+                        "text": "",
+                        "type": "lane",
+                        "directions": [
+                          "left"
+                        ],
+                        "active": false
+                      },
+                      {
+                        "text": "",
+                        "type": "lane",
+                        "directions": [
+                          "straight",
+                          "right"
+                        ],
+                        "active": true,
+                        "active_direction": "right"
+                      },
+                      {
+                        "text": "",
+                        "type": "lane",
+                        "directions": [
+                          "right"
+                        ],
+                        "active": false
+                      }
+                    ]
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 104.434,
+              "intersections": [
+                {
+                  "location": [
+                    -122.27715,
+                    37.806665
+                  ],
+                  "bearings": [
+                    26,
+                    115
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 12,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.276857,
+                    37.807144
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 14,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.276729,
+                    37.807351
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 15,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.27632,
+                    37.808008
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 16,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.275933,
+                    37.808626
+                  ],
+                  "bearings": [
+                    27,
+                    207
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 19,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.275839,
+                    37.80877
+                  ],
+                  "bearings": [
+                    28,
+                    207
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 20,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.275784,
+                    37.808853
+                  ],
+                  "bearings": [
+                    26,
+                    208
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 21,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.275749,
+                    37.808909
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 22,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.275594,
+                    37.809155
+                  ],
+                  "bearings": [
+                    25,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "left",
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 23,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.275496,
+                    37.809319
+                  ],
+                  "bearings": [
+                    25,
+                    205
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "left",
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 25,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.27509,
+                    37.809979
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 28,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.274696,
+                    37.810612
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 29,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.274563,
+                    37.810826
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 30,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 126.0,
+              "duration": 16.329,
+              "duration_typical": 17.919,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "qdybgA~x_fhFy@sCq@_Cy@sCu@_DyAuIq@}DwAcFi@sC{BkLaBgEu@qAWe@aBkBY]gAy@eAs@",
+              "name": "Castro Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.274208,
+                  37.811289
+                ],
+                "bearing_before": 39.0,
+                "bearing_after": 64.0,
+                "instruction": "Bear right to stay on Castro Street.",
+                "type": "continue",
+                "modifier": "slight right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 115.694,
+                  "announcement": "Bear left onto Martin Luther King Junior Way. Then Turn right onto West Grand Avenue.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eBear left onto Martin Luther King Junior Way. Then Turn right onto West Grand Avenue.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 126.0,
+                  "primary": {
+                    "text": "Martin Luther King Junior Way",
+                    "components": [
+                      {
+                        "text": "Martin Luther King Junior Way",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "slight left"
+                  },
+                  "sub": {
+                    "text": "West Grand Avenue",
+                    "components": [
+                      {
+                        "text": "West Grand Avenue",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 21.171,
+              "intersections": [
+                {
+                  "location": [
+                    -122.274208,
+                    37.811289
+                  ],
+                  "bearings": [
+                    64,
+                    219
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "right",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "right",
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 36,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.27365,
+                    37.811469
+                  ],
+                  "bearings": [
+                    64,
+                    252
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 42,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.273536,
+                    37.811513
+                  ],
+                  "bearings": [
+                    70,
+                    244
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 43,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.273248,
+                    37.811596
+                  ],
+                  "bearings": [
+                    53,
+                    250
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 45,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.273019,
+                    37.811746
+                  ],
+                  "bearings": [
+                    31,
+                    228
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 50,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 77.0,
+              "duration": 16.618,
+              "duration_typical": 16.618,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "qezbgAfk}ehFqBy@qBm@iBG}CLyDu@yB_@mKkBuCi@",
+              "name": "Martin Luther King Junior Way",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.272964,
+                  37.811817
+                ],
+                "bearing_before": 31.0,
+                "bearing_after": 13.0,
+                "instruction": "Bear left onto Martin Luther King Junior Way.",
+                "type": "turn",
+                "modifier": "slight left"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 60.667,
+                  "announcement": "Turn right onto West Grand Avenue.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto West Grand Avenue.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 77.0,
+                  "primary": {
+                    "text": "West Grand Avenue",
+                    "components": [
+                      {
+                        "text": "West Grand Avenue",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 26.504,
+              "intersections": [
+                {
+                  "location": [
+                    -122.272964,
+                    37.811817
+                  ],
+                  "bearings": [
+                    13,
+                    211
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 52,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.272915,
+                    37.812063
+                  ],
+                  "bearings": [
+                    12,
+                    185
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 56,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 545.0,
+              "duration": 101.856,
+              "duration_typical": 123.856,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "uo{bgAx`}ehFj@cGpCgYhFsi@\\gDH{@d@aF\\mDrJibAfFai@tBoTp@uGt@_Hf@aFrAiMtE{c@XsCTeClAyL`AkJnDy]V_DLcD",
+              "name": "West Grand Avenue",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.272797,
+                  37.812491
+                ],
+                "bearing_before": 12.0,
+                "bearing_after": 102.0,
+                "instruction": "Turn right onto West Grand Avenue.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 526.0,
+                  "announcement": "In a quarter mile, Turn left onto Broadway.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn left onto Broadway.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 88.667,
+                  "announcement": "Turn left onto Broadway.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto Broadway.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 545.0,
+                  "primary": {
+                    "text": "Broadway",
+                    "components": [
+                      {
+                        "text": "Broadway",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "left"
+                  },
+                  "sub": {
+                    "text": "",
+                    "components": [
+                      {
+                        "text": "",
+                        "type": "lane",
+                        "directions": [
+                          "left"
+                        ],
+                        "active": true,
+                        "active_direction": "left"
+                      },
+                      {
+                        "text": "",
+                        "type": "lane",
+                        "directions": [
+                          "straight"
+                        ],
+                        "active": false
+                      },
+                      {
+                        "text": "",
+                        "type": "lane",
+                        "directions": [
+                          "straight",
+                          "right"
+                        ],
+                        "active": false
+                      }
+                    ]
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 123.752,
+              "intersections": [
+                {
+                  "location": [
+                    -122.272797,
+                    37.812491
+                  ],
+                  "bearings": [
+                    102,
+                    192
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 60,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.272247,
+                    37.812396
+                  ],
+                  "bearings": [
+                    102,
+                    282
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 62,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.271481,
+                    37.812264
+                  ],
+                  "bearings": [
+                    102,
+                    282
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 64,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.271451,
+                    37.812259
+                  ],
+                  "bearings": [
+                    102,
+                    282
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 65,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.271338,
+                    37.81224
+                  ],
+                  "bearings": [
+                    102,
+                    282
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 66,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.270174,
+                    37.812039
+                  ],
+                  "bearings": [
+                    102,
+                    282
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 68,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.269018,
+                    37.811839
+                  ],
+                  "bearings": [
+                    103,
+                    283
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 71,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.267868,
+                    37.81163
+                  ],
+                  "bearings": [
+                    102,
+                    283
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 76,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.26758,
+                    37.81158
+                  ],
+                  "bearings": [
+                    103,
+                    283
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 78,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.267398,
+                    37.811547
+                  ],
+                  "bearings": [
+                    103,
+                    283
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "left",
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 79,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266905,
+                    37.811459
+                  ],
+                  "bearings": [
+                    98,
+                    283
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "left",
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 80,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 352.0,
+              "duration": 51.826,
+              "duration_typical": 51.826,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "_nybgAlfqehFeDeBaCmA}NwHs@]oCyAeIeEaCmAMaAWw@a@i@qhA}l@iSsK{HmEuIiFmBiA{GaE",
+              "name": "Broadway",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.266743,
+                  37.81144
+                ],
+                "bearing_before": 98.0,
+                "bearing_after": 25.0,
+                "instruction": "Turn left onto Broadway.",
+                "type": "turn",
+                "modifier": "left"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 323.0,
+                  "announcement": "In a quarter mile, Turn right onto Webster Street.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn right onto Webster Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 105.333,
+                  "announcement": "Turn right onto Webster Street. Then Your destination will be on the left.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto Webster Street. Then Your destination will be on the left.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 352.0,
+                  "primary": {
+                    "text": "Webster Street",
+                    "components": [
+                      {
+                        "text": "Webster Street",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 71.401,
+              "intersections": [
+                {
+                  "location": [
+                    -122.266743,
+                    37.81144
+                  ],
+                  "bearings": [
+                    26,
+                    278
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "left",
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 82,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266692,
+                    37.811523
+                  ],
+                  "bearings": [
+                    25,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 83,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266653,
+                    37.811588
+                  ],
+                  "bearings": [
+                    26,
+                    205
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 84,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266482,
+                    37.811869
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 86,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266437,
+                    37.811941
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 87,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266299,
+                    37.812169
+                  ],
+                  "bearings": [
+                    40,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 89,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.265482,
+                    37.813382
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 93,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.265023,
+                    37.814091
+                  ],
+                  "bearings": [
+                    28,
+                    208
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 97,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 41.821,
+              "duration": 18.379,
+              "duration_typical": 18.379,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "q|~bgAztmehFtHwG~@k@hA[vAK|AJl@J",
+              "name": "Webster Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.264926,
+                  37.814233
+                ],
+                "bearing_before": 28.0,
+                "bearing_after": 144.0,
+                "instruction": "Turn right onto Webster Street.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 41.667,
+                  "announcement": "Your destination is on the left.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYour destination is on the left.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 41.821,
+                  "primary": {
+                    "text": "Your destination will be on the left",
+                    "components": [
+                      {
+                        "text": "Your destination will be on the left",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left"
+                  }
+                },
+                {
+                  "distanceAlongGeometry": 41.667,
+                  "primary": {
+                    "text": "Your destination is on the left",
+                    "components": [
+                      {
+                        "text": "Your destination is on the left",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 25.615,
+              "intersections": [
+                {
+                  "location": [
+                    -122.264926,
+                    37.814233
+                  ],
+                  "bearings": [
+                    144,
+                    208
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 98,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "location": [
+                    -122.264786,
+                    37.814078
+                  ],
+                  "bearings": [
+                    158,
+                    324
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 99,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "location": [
+                    -122.26475,
+                    37.814009
+                  ],
+                  "bearings": [
+                    182,
+                    338
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 101,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 0.0,
+              "duration": 0.0,
+              "duration_typical": 0.0,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "mg~bgAfjmehF??",
+              "name": "Webster Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.264756,
+                  37.813895
+                ],
+                "bearing_before": 182.0,
+                "bearing_after": 0.0,
+                "instruction": "Your destination is on the left.",
+                "type": "arrive",
+                "modifier": "left"
+              },
+              "voiceInstructions": [],
+              "bannerInstructions": [],
+              "driving_side": "right",
+              "weight": 0.0,
+              "intersections": [
+                {
+                  "location": [
+                    -122.264756,
+                    37.813895
+                  ],
+                  "bearings": [
+                    2
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "geometry_index": 104,
+                  "admin_index": 0
+                }
+              ]
+            }
+          ],
+          "annotation": {
+            "distance": [
+              54.4,
+              9.3,
+              11.0,
+              92.7,
+              2.4,
+              10.5,
+              10.7,
+              3.2,
+              21.9,
+              30.2,
+              38.0,
+              11.3,
+              11.6,
+              47.6,
+              25.6,
+              81.5,
+              64.4,
+              1.8,
+              10.5,
+              18.0,
+              10.4,
+              7.0,
+              30.6,
+              6.9,
+              13.3,
+              12.7,
+              33.3,
+              35.7,
+              78.5,
+              26.5,
+              23.2,
+              7.3,
+              7.3,
+              7.4,
+              8.0,
+              7.4,
+              7.3,
+              6.3,
+              7.3,
+              7.7,
+              15.9,
+              8.8,
+              11.2,
+              6.9,
+              20.0,
+              10.3,
+              4.7,
+              2.1,
+              7.2,
+              2.0,
+              4.8,
+              4.5,
+              6.8,
+              6.7,
+              5.9,
+              8.8,
+              10.6,
+              6.9,
+              22.7,
+              8.6,
+              11.7,
+              37.8,
+              61.4,
+              7.6,
+              2.7,
+              10.2,
+              7.8,
+              97.0,
+              60.6,
+              31.0,
+              12.5,
+              13.0,
+              10.2,
+              20.7,
+              53.2,
+              6.7,
+              6.0,
+              19.9,
+              16.4,
+              44.5,
+              7.2,
+              7.3,
+              10.3,
+              8.0,
+              31.5,
+              3.2,
+              8.9,
+              20.1,
+              8.0,
+              3.0,
+              2.8,
+              2.6,
+              146.1,
+              40.3,
+              19.8,
+              21.6,
+              6.9,
+              18.0,
+              21.2,
+              4.1,
+              4.3,
+              4.9,
+              5.3,
+              2.6
+            ],
+            "duration": [
+              24.461,
+              4.192,
+              1.65,
+              13.898,
+              0.358,
+              1.576,
+              1.677,
+              0.495,
+              3.427,
+              4.726,
+              5.941,
+              1.762,
+              1.164,
+              4.758,
+              2.565,
+              6.986,
+              23.191,
+              0.665,
+              3.775,
+              2.164,
+              1.073,
+              0.894,
+              3.933,
+              1.185,
+              2.276,
+              1.015,
+              2.663,
+              2.857,
+              4.874,
+              1.592,
+              1.391,
+              0.44,
+              0.435,
+              0.444,
+              0.482,
+              0.445,
+              0.436,
+              0.377,
+              0.436,
+              0.459,
+              0.951,
+              0.528,
+              1.826,
+              0.803,
+              2.328,
+              1.202,
+              0.545,
+              0.249,
+              0.84,
+              0.228,
+              0.552,
+              0.525,
+              0.724,
+              0.705,
+              0.626,
+              0.933,
+              2.941,
+              1.92,
+              6.274,
+              2.368,
+              2.338,
+              7.564,
+              12.275,
+              1.515,
+              0.278,
+              1.045,
+              0.742,
+              9.185,
+              5.739,
+              2.933,
+              1.188,
+              1.339,
+              1.048,
+              2.127,
+              5.476,
+              0.686,
+              2.167,
+              7.169,
+              5.912,
+              16.002,
+              2.578,
+              2.611,
+              2.641,
+              1.31,
+              5.159,
+              0.52,
+              1.463,
+              3.293,
+              1.31,
+              0.338,
+              0.315,
+              0.297,
+              16.436,
+              4.031,
+              1.978,
+              2.164,
+              0.693,
+              2.812,
+              7.631,
+              1.459,
+              1.548,
+              1.043,
+              1.114,
+              0.558
+            ],
+            "speed": [
+              2.2,
+              2.2,
+              6.7,
+              6.7,
+              6.7,
+              6.7,
+              6.4,
+              6.4,
+              6.4,
+              6.4,
+              6.4,
+              6.4,
+              10.0,
+              10.0,
+              10.0,
+              11.7,
+              2.8,
+              2.8,
+              2.8,
+              8.3,
+              9.7,
+              7.8,
+              7.8,
+              5.8,
+              5.8,
+              12.5,
+              12.5,
+              12.5,
+              16.1,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              16.7,
+              6.1,
+              8.6,
+              8.6,
+              8.6,
+              8.6,
+              8.6,
+              8.6,
+              8.6,
+              8.6,
+              8.6,
+              9.4,
+              9.4,
+              9.4,
+              9.4,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              9.7,
+              9.7,
+              10.6,
+              10.6,
+              10.6,
+              10.6,
+              10.6,
+              9.7,
+              9.7,
+              9.7,
+              9.7,
+              9.7,
+              2.8,
+              2.8,
+              2.8,
+              2.8,
+              2.8,
+              2.8,
+              3.9,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              8.9,
+              8.9,
+              8.9,
+              8.9,
+              10.0,
+              10.0,
+              10.0,
+              10.0,
+              6.4,
+              2.8,
+              2.8,
+              2.8,
+              4.7,
+              4.7,
+              4.7
+            ],
+            "maxspeed": [
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              }
+            ],
+            "congestion_numeric": [
+              null,
+              null,
+              0,
+              0,
+              0,
+              0,
+              11,
+              11,
+              11,
+              11,
+              11,
+              11,
+              11,
+              11,
+              11,
+              8,
+              null,
+              null,
+              null,
+              null,
+              null,
+              17,
+              17,
+              null,
+              null,
+              null,
+              null,
+              null,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              null,
+              0,
+              0,
+              11,
+              11,
+              11,
+              11,
+              11,
+              11,
+              11,
+              0,
+              0,
+              0,
+              0,
+              null,
+              null,
+              null,
+              null,
+              12,
+              12,
+              12,
+              12,
+              null,
+              null,
+              0,
+              0,
+              0,
+              0,
+              0,
+              12,
+              12,
+              12,
+              12,
+              12,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              9,
+              9,
+              9,
+              9,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ]
+          }
+        }
+      ],
+      "routeOptions": {
+        "baseUrl": "https://api.mapbox.com",
+        "user": "mapbox",
+        "profile": "driving-traffic",
+        "coordinates": "-122.2750659,37.8052036;-122.2647245,37.8138895",
+        "alternatives": true,
+        "language": "en",
+        "continue_straight": true,
+        "roundabout_exits": true,
+        "geometries": "polyline6",
+        "overview": "full",
+        "steps": true,
+        "annotations": "congestion_numeric,maxspeed,speed,duration,distance,closure",
+        "voice_instructions": true,
+        "banner_instructions": true,
+        "voice_units": "imperial",
+        "enable_refresh": true
+      },
+      "voiceLocale": "en-US",
+      "requestUuid": "1SSd29ZxmjD7ELLqDJHRPPDP5W4wdh633IbGo41pJrL6wpJRmzNaMA\u003d\u003d"
+    },
+    {
+      "routeIndex": "1",
+      "distance": 1652.495,
+      "duration": 390.064,
+      "duration_typical": 390.064,
+      "geometry": "kimbgApqafhFkZaPuC}AyDsBm`@{SuBgAmCwAu_@eSiCuAeCsA}QyJaDcByDuBnAkEhLq`@v@mCPm@J_@~FkS`@_Bj@eCZmB\\_CZkCPuDDoBFiB`OyeBh@gFt@iFfAiFpA{El@uBlB{GiCwA}CaByF{CgKsFyd@qVqBiAgCsAq@a@iIkEs_@kSeXwNoCyAqDoBoD}AkF}BcAsBeAyAyA_As_@qSgCuAcCqA{l@s[w@a@c@Cc@Fq@NyBiAmAo@mE}BOIoDkB{H_E{BkAeDeBaCmA}NwHs@]oCyAeIeEaCmAMaAWw@a@i@qhA}l@iSsK{HmEuIiFmBiA{GaEtHwG~@k@hA[vAK|AJl@J",
+      "weight": 490.114,
+      "weight_name": "auto",
+      "legs": [
+        {
+          "distance": 1652.495,
+          "duration": 390.064,
+          "duration_typical": 390.064,
+          "summary": "17th Street, Broadway",
+          "admins": [
+            {
+              "iso_3166_1": "US",
+              "iso_3166_1_alpha3": "USA"
+            }
+          ],
+          "steps": [
+            {
+              "distance": 298.674,
+              "duration": 84.575,
+              "duration_typical": 84.575,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "kimbgApqafhFkZaPuC}AyDsBm`@{SuBgAmCwAu_@eSiCuAeCsA}QyJaDcByDuB",
+              "name": "Jefferson Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.275113,
+                  37.805222
+                ],
+                "bearing_before": 0.0,
+                "bearing_after": 26.0,
+                "instruction": "Drive northeast on Jefferson Street.",
+                "type": "depart"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 298.674,
+                  "announcement": "Drive northeast on Jefferson Street. Then, in 1,000 feet, Turn right onto 17th Street.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive northeast on Jefferson Street. Then, in 1,000 feet, Turn right onto 17th Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 50.0,
+                  "announcement": "Turn right onto 17th Street.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto 17th Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 298.674,
+                  "primary": {
+                    "text": "17th Street",
+                    "components": [
+                      {
+                        "text": "17th Street",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 103.23,
+              "intersections": [
+                {
+                  "location": [
+                    -122.275113,
+                    37.805222
+                  ],
+                  "bearings": [
+                    26
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "out": 0,
+                  "geometry_index": 0,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "location": [
+                    -122.274793,
+                    37.805735
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 2,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "location": [
+                    -122.274365,
+                    37.806422
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 5,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "location": [
+                    -122.273955,
+                    37.807085
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 8,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "location": [
+                    -122.273724,
+                    37.807455
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 10,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 362.0,
+              "duration": 100.424,
+              "duration_typical": 100.424,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "y_rbgA|s~ehFnAkEhLq`@v@mCPm@J_@~FkS`@_Bj@eCZmB\\_CZkCPuDDoBFiB`OyeBh@gFt@iFfAiFpA{El@uBlB{G",
+              "name": "17th Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.273615,
+                  37.807629
+                ],
+                "bearing_before": 26.0,
+                "bearing_after": 117.0,
+                "instruction": "Turn right onto 17th Street.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 348.667,
+                  "announcement": "In a quarter mile, Turn left onto Broadway.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn left onto Broadway.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 62.222,
+                  "announcement": "Turn left onto Broadway.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto Broadway.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 362.0,
+                  "primary": {
+                    "text": "Broadway",
+                    "components": [
+                      {
+                        "text": "Broadway",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "left"
+                  },
+                  "sub": {
+                    "text": "",
+                    "components": [
+                      {
+                        "text": "",
+                        "type": "lane",
+                        "directions": [
+                          "left"
+                        ],
+                        "active": true,
+                        "active_direction": "left"
+                      },
+                      {
+                        "text": "",
+                        "type": "lane",
+                        "directions": [
+                          "straight"
+                        ],
+                        "active": false
+                      },
+                      {
+                        "text": "",
+                        "type": "lane",
+                        "directions": [
+                          "straight",
+                          "right"
+                        ],
+                        "active": false
+                      }
+                    ]
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 125.568,
+              "intersections": [
+                {
+                  "location": [
+                    -122.273615,
+                    37.807629
+                  ],
+                  "bearings": [
+                    117,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 12,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.272976,
+                    37.807376
+                  ],
+                  "bearings": [
+                    117,
+                    297
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 14,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.272905,
+                    37.807348
+                  ],
+                  "bearings": [
+                    116,
+                    297
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 15,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.272882,
+                    37.807339
+                  ],
+                  "bearings": [
+                    115,
+                    296
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 16,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.272866,
+                    37.807333
+                  ],
+                  "bearings": [
+                    116,
+                    295
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 17,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.272425,
+                    37.807166
+                  ],
+                  "bearings": [
+                    106,
+                    295
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 20,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.272236,
+                    37.807123
+                  ],
+                  "bearings": [
+                    97,
+                    286
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 23,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.272145,
+                    37.807114
+                  ],
+                  "bearings": [
+                    98,
+                    277
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 24,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.270275,
+                    37.806829
+                  ],
+                  "bearings": [
+                    109,
+                    282
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 28,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 950.0,
+              "duration": 186.686,
+              "duration_typical": 186.686,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "mbpbgAbawehFiCwA}CaByF{CgKsFyd@qVqBiAgCsAq@a@iIkEs_@kSeXwNoCyAqDoBoD}AkF}BcAsBeAyAyA_As_@qSgCuAcCqA{l@s[w@a@c@Cc@Fq@NyBiAmAo@mE}BOIoDkB{H_E{BkAeDeBaCmA}NwHs@]oCyAeIeEaCmAMaAWw@a@i@qhA}l@iSsK{HmEuIiFmBiA{GaE",
+              "name": "Broadway",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.26973,
+                  37.806647
+                ],
+                "bearing_before": 116.0,
+                "bearing_after": 26.0,
+                "instruction": "Turn left onto Broadway.",
+                "type": "turn",
+                "modifier": "left"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 931.0,
+                  "announcement": "Continue for a half mile.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eContinue for a half mile.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 402.336,
+                  "announcement": "In a quarter mile, Turn right onto Webster Street.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn right onto Webster Street.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 105.333,
+                  "announcement": "Turn right onto Webster Street. Then Your destination will be on the left.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto Webster Street. Then Your destination will be on the left.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 950.0,
+                  "primary": {
+                    "text": "Webster Street",
+                    "components": [
+                      {
+                        "text": "Webster Street",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 235.7,
+              "intersections": [
+                {
+                  "location": [
+                    -122.26973,
+                    37.806647
+                  ],
+                  "bearings": [
+                    26,
+                    296
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "left",
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 33,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.269637,
+                    37.806795
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 35,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.269437,
+                    37.807116
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 37,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.269023,
+                    37.807778
+                  ],
+                  "bearings": [
+                    26,
+                    207
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 39,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.268239,
+                    37.809033
+                  ],
+                  "bearings": [
+                    25,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 45,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.268073,
+                    37.809328
+                  ],
+                  "bearings": [
+                    43,
+                    203
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 48,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.267938,
+                    37.809442
+                  ],
+                  "bearings": [
+                    26,
+                    223
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 51,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.267566,
+                    37.810032
+                  ],
+                  "bearings": [
+                    26,
+                    207
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 53,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.26706,
+                    37.810921
+                  ],
+                  "bearings": [
+                    26,
+                    195
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 59,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266999,
+                    37.811021
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 61,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266936,
+                    37.811124
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 62,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266931,
+                    37.811132
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 63,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266877,
+                    37.81122
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 64,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266781,
+                    37.811378
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 65,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266743,
+                    37.81144
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 66,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266692,
+                    37.811523
+                  ],
+                  "bearings": [
+                    25,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 67,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266653,
+                    37.811588
+                  ],
+                  "bearings": [
+                    26,
+                    205
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 68,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266482,
+                    37.811869
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 70,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266437,
+                    37.811941
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 71,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.266299,
+                    37.812169
+                  ],
+                  "bearings": [
+                    40,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 73,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.265482,
+                    37.813382
+                  ],
+                  "bearings": [
+                    26,
+                    206
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 77,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                },
+                {
+                  "location": [
+                    -122.265023,
+                    37.814091
+                  ],
+                  "bearings": [
+                    28,
+                    208
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 81,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "primary"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 41.821,
+              "duration": 18.379,
+              "duration_typical": 18.379,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "q|~bgAztmehFtHwG~@k@hA[vAK|AJl@J",
+              "name": "Webster Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.264926,
+                  37.814233
+                ],
+                "bearing_before": 28.0,
+                "bearing_after": 144.0,
+                "instruction": "Turn right onto Webster Street.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 41.667,
+                  "announcement": "Your destination is on the left.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYour destination is on the left.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 41.821,
+                  "primary": {
+                    "text": "Your destination will be on the left",
+                    "components": [
+                      {
+                        "text": "Your destination will be on the left",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left"
+                  }
+                },
+                {
+                  "distanceAlongGeometry": 41.667,
+                  "primary": {
+                    "text": "Your destination is on the left",
+                    "components": [
+                      {
+                        "text": "Your destination is on the left",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 25.615,
+              "intersections": [
+                {
+                  "location": [
+                    -122.264926,
+                    37.814233
+                  ],
+                  "bearings": [
+                    144,
+                    208
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 82,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "location": [
+                    -122.264786,
+                    37.814078
+                  ],
+                  "bearings": [
+                    158,
+                    324
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 83,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "location": [
+                    -122.26475,
+                    37.814009
+                  ],
+                  "bearings": [
+                    182,
+                    338
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 85,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "distance": 0.0,
+              "duration": 0.0,
+              "duration_typical": 0.0,
+              "speedLimitUnit": "mph",
+              "speedLimitSign": "mutcd",
+              "geometry": "mg~bgAfjmehF??",
+              "name": "Webster Street",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  -122.264756,
+                  37.813895
+                ],
+                "bearing_before": 182.0,
+                "bearing_after": 0.0,
+                "instruction": "Your destination is on the left.",
+                "type": "arrive",
+                "modifier": "left"
+              },
+              "voiceInstructions": [],
+              "bannerInstructions": [],
+              "driving_side": "right",
+              "weight": 0.0,
+              "intersections": [
+                {
+                  "location": [
+                    -122.264756,
+                    37.813895
+                  ],
+                  "bearings": [
+                    2
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "geometry_index": 88,
+                  "admin_index": 0
+                }
+              ]
+            }
+          ],
+          "annotation": {
+            "distance": [
+              54.4,
+              9.3,
+              11.5,
+              66.4,
+              7.3,
+              8.8,
+              64.8,
+              8.6,
+              8.3,
+              37.6,
+              10.0,
+              11.6,
+              10.0,
+              52.8,
+              7.0,
+              2.3,
+              1.6,
+              32.0,
+              4.6,
+              6.4,
+              5.1,
+              5.9,
+              6.4,
+              8.1,
+              4.9,
+              4.7,
+              147.5,
+              10.5,
+              10.7,
+              11.0,
+              10.7,
+              5.8,
+              13.9,
+              8.6,
+              9.8,
+              15.5,
+              24.3,
+              75.1,
+              7.1,
+              8.4,
+              3.2,
+              20.4,
+              64.8,
+              50.0,
+              8.9,
+              11.1,
+              10.6,
+              14.3,
+              6.4,
+              5.6,
+              5.7,
+              64.9,
+              8.5,
+              8.2,
+              91.1,
+              3.5,
+              2.0,
+              2.0,
+              2.9,
+              7.5,
+              4.8,
+              12.7,
+              1.0,
+              10.9,
+              19.5,
+              7.7,
+              10.3,
+              8.0,
+              31.5,
+              3.2,
+              8.9,
+              20.1,
+              8.0,
+              3.0,
+              2.8,
+              2.6,
+              146.1,
+              40.3,
+              19.8,
+              21.6,
+              6.9,
+              18.0,
+              21.2,
+              4.1,
+              4.3,
+              4.9,
+              5.3,
+              2.6
+            ],
+            "duration": [
+              24.461,
+              4.192,
+              2.597,
+              14.942,
+              1.64,
+              1.76,
+              12.956,
+              1.712,
+              1.998,
+              9.025,
+              2.408,
+              2.779,
+              2.121,
+              11.191,
+              1.478,
+              0.478,
+              0.329,
+              6.78,
+              0.98,
+              1.351,
+              1.83,
+              2.114,
+              2.286,
+              0.83,
+              1.045,
+              0.992,
+              31.231,
+              2.217,
+              4.288,
+              4.417,
+              4.279,
+              2.315,
+              5.564,
+              1.821,
+              2.074,
+              3.285,
+              5.149,
+              15.897,
+              1.51,
+              1.378,
+              0.517,
+              3.345,
+              10.603,
+              8.188,
+              1.463,
+              1.897,
+              1.823,
+              2.444,
+              1.345,
+              1.176,
+              1.217,
+              13.747,
+              1.792,
+              1.841,
+              20.497,
+              0.778,
+              0.453,
+              0.458,
+              0.646,
+              1.936,
+              1.241,
+              3.275,
+              0.256,
+              2.799,
+              5.017,
+              1.972,
+              2.641,
+              1.31,
+              5.159,
+              0.52,
+              1.463,
+              3.293,
+              1.31,
+              0.338,
+              0.315,
+              0.297,
+              16.436,
+              4.031,
+              1.978,
+              2.164,
+              0.693,
+              2.812,
+              7.631,
+              1.459,
+              1.548,
+              1.043,
+              1.114,
+              0.558
+            ],
+            "speed": [
+              2.2,
+              2.2,
+              4.4,
+              4.4,
+              4.4,
+              5.0,
+              5.0,
+              5.0,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              2.8,
+              2.8,
+              2.8,
+              9.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              2.5,
+              2.5,
+              2.5,
+              2.5,
+              2.5,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              5.8,
+              5.8,
+              5.8,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              8.9,
+              8.9,
+              8.9,
+              8.9,
+              10.0,
+              10.0,
+              10.0,
+              10.0,
+              6.4,
+              2.8,
+              2.8,
+              2.8,
+              4.7,
+              4.7,
+              4.7
+            ],
+            "maxspeed": [
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "speed": 48,
+                "unit": "km/h"
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              },
+              {
+                "unknown": true
+              }
+            ],
+            "congestion_numeric": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              0,
+              0,
+              0,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              0,
+              9,
+              9,
+              9,
+              9,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              9,
+              9,
+              9,
+              9,
+              9,
+              9,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              6,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              9,
+              9,
+              9,
+              9,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
+            ]
+          }
+        }
+      ],
+      "routeOptions": {
+        "baseUrl": "https://api.mapbox.com",
+        "user": "mapbox",
+        "profile": "driving-traffic",
+        "coordinates": "-122.2750659,37.8052036;-122.2647245,37.8138895",
+        "alternatives": true,
+        "language": "en",
+        "continue_straight": true,
+        "roundabout_exits": true,
+        "geometries": "polyline6",
+        "overview": "full",
+        "steps": true,
+        "annotations": "congestion_numeric,maxspeed,speed,duration,distance,closure",
+        "voice_instructions": true,
+        "banner_instructions": true,
+        "voice_units": "imperial",
+        "enable_refresh": true
+      },
+      "voiceLocale": "en-US",
+      "requestUuid": "1SSd29ZxmjD7ELLqDJHRPPDP5W4wdh633IbGo41pJrL6wpJRmzNaMA\u003d\u003d"
+    }
+  ],
+  "uuid": "1SSd29ZxmjD7ELLqDJHRPPDP5W4wdh633IbGo41pJrL6wpJRmzNaMA\u003d\u003d"
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -928,7 +928,6 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         routes: List<NavigationRoute>,
         setRoutesInfo: SetRoutesInfo,
     ): NativeSetRouteResult {
-        routeAlternativesController.pauseUpdates()
         return tripSession.setRoutes(routes, setRoutesInfo).apply {
             if (this is NativeSetRouteValue) {
                 routeAlternativesController.processAlternativesMetadata(
@@ -936,8 +935,6 @@ class MapboxNavigation @VisibleForTesting internal constructor(
                     nativeAlternatives
                 )
             }
-        }.also {
-            routeAlternativesController.resumeUpdates()
         }
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -1386,7 +1386,6 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             mapboxNavigation.setNavigationRoutes(routes)
 
             coVerifyOrder {
-                routeAlternativesController.pauseUpdates()
                 tripSession.setRoutes(
                     routes,
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, 0)
@@ -1395,7 +1394,6 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
                     processedRoutes,
                     nativeAlternatives
                 )
-                routeAlternativesController.resumeUpdates()
                 directionsSession.setRoutes(
                     processedRoutes,
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, 0)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
@@ -715,45 +715,6 @@ class RouteAlternativesControllerTest {
             assertNull(metadata)
         }
 
-    @Test
-    fun `native updates ignored when controller paused, and resumed successfully`() =
-        coroutineRule.runBlockingTest {
-            mockkStatic(RouteOptions::fromUrl) {
-                every { RouteOptions.fromUrl(eq(genericURL)) } returns mockk()
-                val routeAlternativesController = createRouteAlternativesController()
-                val nativeObserver = slot<com.mapbox.navigator.RouteAlternativesObserver>()
-                every { controllerInterface.addObserver(capture(nativeObserver)) } just runs
-                val routeProgress = mockk<RouteProgress>()
-                every { tripSession.getRouteProgress() } returns routeProgress
-                val firstObserver: NavigationRouteAlternativesObserver = mockk(relaxed = true)
-                routeAlternativesController.register(firstObserver)
-
-                routeAlternativesController.pauseUpdates()
-                nativeObserver.captured.onRouteAlternativesChanged(
-                    listOf(
-                        createNativeAlternativeMock()
-                    ),
-                    emptyList()
-                )
-
-                verify(exactly = 0) {
-                    firstObserver.onRouteAlternatives(any(), any(), any())
-                }
-
-                routeAlternativesController.resumeUpdates()
-                nativeObserver.captured.onRouteAlternativesChanged(
-                    listOf(
-                        createNativeAlternativeMock()
-                    ),
-                    emptyList()
-                )
-
-                verify(exactly = 1) {
-                    firstObserver.onRouteAlternatives(any(), any(), any())
-                }
-            }
-        }
-
     private val nativeInfoFork = com.mapbox.navigator.AlternativeRouteInfo(
         100.0, // distance
         200.0, // duration


### PR DESCRIPTION
### Description
Alternative routes. Adopt new NN handling flow:
- Alternatives observer does not spread routes that has been set via `MapboxNavigation#setRoutes`;
- Alternatives observer does not spread routes if set to `MapboxNavigation#setRoutes`alternatives routes + one or few additional routes.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
