### PR TITLE
[Android Auto] Remove mapbox navigation from road name observer

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Removed `MapboxNavigation` from `RoadNameObserver` and `RoadLabelSurfaceLayer` constructor. [#6224](https://github.com/mapbox/mapbox-navigation-android/pull/6224)
 
 ## androidauto-v0.8.0 - Aug 18, 2022
 ### Changelog

--- a/libnavui-androidauto/api/current.txt
+++ b/libnavui-androidauto/api/current.txt
@@ -518,27 +518,23 @@ package com.mapbox.androidauto.car.navigation.roadlabel {
   }
 
   public final class RoadLabelSurfaceLayer extends com.mapbox.androidauto.surfacelayer.CarSurfaceLayer {
-    ctor public RoadLabelSurfaceLayer(androidx.car.app.CarContext carContext, com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
+    ctor public RoadLabelSurfaceLayer(androidx.car.app.CarContext carContext);
     method public java.util.List<com.mapbox.androidauto.surfacelayer.textview.CarScene2d> children();
     method public androidx.car.app.CarContext getCarContext();
-    method public com.mapbox.navigation.core.MapboxNavigation getMapboxNavigation();
     property public final androidx.car.app.CarContext carContext;
-    property public final com.mapbox.navigation.core.MapboxNavigation mapboxNavigation;
   }
 
-  public abstract class RoadNameObserver implements com.mapbox.navigation.core.trip.session.LocationObserver {
-    ctor public RoadNameObserver(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation, com.mapbox.navigation.ui.shield.api.MapboxRouteShieldApi routeShieldApi, com.mapbox.androidauto.car.navigation.MapUserStyleObserver mapUserStyleObserver);
+  public abstract class RoadNameObserver implements com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver {
+    ctor public RoadNameObserver(com.mapbox.navigation.ui.shield.api.MapboxRouteShieldApi routeShieldApi, com.mapbox.androidauto.car.navigation.MapUserStyleObserver mapUserStyleObserver);
     method public final java.util.List<com.mapbox.navigation.base.road.model.RoadComponent> getCurrentRoad();
     method public final java.util.List<com.mapbox.navigation.ui.shield.model.RouteShield> getCurrentShields();
-    method public final com.mapbox.navigation.core.MapboxNavigation getMapboxNavigation();
-    method public void onNewLocationMatcherResult(com.mapbox.navigation.core.trip.session.LocationMatcherResult locationMatcherResult);
-    method public void onNewRawLocation(android.location.Location rawLocation);
+    method public final void onAttached(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
+    method public final void onDetached(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
     method public abstract void onRoadUpdate(java.util.List<com.mapbox.navigation.base.road.model.RoadComponent> road, java.util.List<? extends com.mapbox.navigation.ui.shield.model.RouteShield> shields);
     method public final void setCurrentRoad(java.util.List<com.mapbox.navigation.base.road.model.RoadComponent>);
     method public final void setCurrentShields(java.util.List<? extends com.mapbox.navigation.ui.shield.model.RouteShield>);
     property public final java.util.List<com.mapbox.navigation.base.road.model.RoadComponent> currentRoad;
     property public final java.util.List<com.mapbox.navigation.ui.shield.model.RouteShield> currentShields;
-    property public final com.mapbox.navigation.core.MapboxNavigation mapboxNavigation;
   }
 
 }

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     // This defines the minimum version of Maps, Navigation, and Search which are included in
     // this SDK. To upgrade the SDK versions, you can specify a newer version in your downstream
     // build.gradle.
-    def carNavVersion = "2.7.0-rc.2"
-    def carSearchVersion = "1.0.0-beta.34"
+    def carNavVersion = "2.8.0-alpha.3"
+    def carSearchVersion = "1.0.0-beta.35"
     api("com.mapbox.navigation:android:${carNavVersion}")
     api("com.mapbox.search:mapbox-search-android:${carSearchVersion}")
     implementation("com.mapbox.navigation:ui-app:${carNavVersion}")

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarScreen.kt
@@ -31,11 +31,7 @@ class MainCarScreen(
         CarCameraMode.FOLLOWING,
         alternativeCarCameraMode = null,
     )
-    private val roadLabelSurfaceLayer = RoadLabelSurfaceLayer(
-        mainCarContext.carContext,
-        mainCarContext.mapboxNavigation,
-    )
-
+    private val roadLabelSurfaceLayer = RoadLabelSurfaceLayer(carContext)
     private val mainActionStrip = MainActionStrip(this, mainCarContext)
     private val mapActionStripBuilder = MainMapActionStrip(this, carNavigationCamera)
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/ActiveGuidanceScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/ActiveGuidanceScreen.kt
@@ -52,11 +52,7 @@ class ActiveGuidanceScreen(
         CarCameraMode.FOLLOWING,
         CarCameraMode.OVERVIEW,
     )
-    private val roadLabelSurfaceLayer = RoadLabelSurfaceLayer(
-        carActiveGuidanceContext.carContext,
-        carActiveGuidanceContext.mapboxNavigation,
-    )
-
+    private val roadLabelSurfaceLayer = RoadLabelSurfaceLayer(carContext)
     private val carRouteProgressObserver = CarNavigationInfoObserver(carActiveGuidanceContext)
     private val mapActionStripBuilder = MainMapActionStrip(this, carNavigationCamera)
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadLabelSurfaceLayer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadLabelSurfaceLayer.kt
@@ -18,7 +18,7 @@ import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface
 import com.mapbox.maps.plugin.delegates.listeners.OnStyleLoadedListener
 import com.mapbox.maps.plugin.locationcomponent.LocationComponentConstants
 import com.mapbox.navigation.base.road.model.RoadComponent
-import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.ui.shield.api.MapboxRouteShieldApi
 import com.mapbox.navigation.ui.shield.model.RouteShield
 
@@ -32,7 +32,6 @@ import com.mapbox.navigation.ui.shield.model.RouteShield
 @OptIn(MapboxExperimental::class)
 class RoadLabelSurfaceLayer(
     val carContext: CarContext,
-    val mapboxNavigation: MapboxNavigation,
 ) : CarSurfaceLayer() {
 
     private val roadLabelRenderer = RoadLabelRenderer(carContext.resources)
@@ -42,7 +41,6 @@ class RoadLabelSurfaceLayer(
     private var styleLoadedListener: OnStyleLoadedListener? = null
 
     private val roadNameObserver = object : RoadNameObserver(
-        mapboxNavigation,
         routeShieldApi,
         mapUserStyleObserver
     ) {
@@ -79,15 +77,14 @@ class RoadLabelSurfaceLayer(
         }
 
         mapUserStyleObserver.onAttached(mapboxCarMapSurface)
-        mapboxNavigation.registerLocationObserver(roadNameObserver)
+        MapboxNavigationApp.registerObserver(roadNameObserver)
     }
 
     override fun onDetached(mapboxCarMapSurface: MapboxCarMapSurface) {
         logAndroidAuto("RoadLabelSurfaceLayer carMapSurface detached")
-        mapboxCarMapSurface.handleStyleOnDetached(styleLoadedListener)?.let {
-            it.removeStyleLayer(CAR_NAVIGATION_VIEW_LAYER_ID)
-        }
-        mapboxNavigation.unregisterLocationObserver(roadNameObserver)
+        mapboxCarMapSurface.handleStyleOnDetached(styleLoadedListener)
+            ?.removeStyleLayer(CAR_NAVIGATION_VIEW_LAYER_ID)
+        MapboxNavigationApp.unregisterObserver(roadNameObserver)
         routeShieldApi.cancel()
         mapUserStyleObserver.onDetached(mapboxCarMapSurface)
         super.onDetached(mapboxCarMapSurface)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadNameObserver.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadNameObserver.kt
@@ -2,24 +2,24 @@ package com.mapbox.androidauto.car.navigation.roadlabel
 
 import android.location.Location
 import com.mapbox.androidauto.car.navigation.MapUserStyleObserver
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.navigation.base.road.model.RoadComponent
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.ui.shield.api.MapboxRouteShieldApi
 import com.mapbox.navigation.ui.shield.model.RouteShield
 import com.mapbox.navigation.ui.shield.model.RouteShieldCallback
 
-@OptIn(MapboxExperimental::class)
 abstract class RoadNameObserver(
-    val mapboxNavigation: MapboxNavigation,
     private val routeShieldApi: MapboxRouteShieldApi,
     private val mapUserStyleObserver: MapUserStyleObserver
-) : LocationObserver {
+) : MapboxNavigationObserver {
 
     var currentRoad = emptyList<RoadComponent>()
     var currentShields = emptyList<RouteShield>()
+
+    private var mapboxNavigation: MapboxNavigation? = null
 
     private val roadNameShieldsCallback = RouteShieldCallback { shieldResult ->
         val newShields = shieldResult.mapNotNull { it.value?.shield }
@@ -29,24 +29,37 @@ abstract class RoadNameObserver(
         }
     }
 
-    abstract fun onRoadUpdate(road: List<RoadComponent>, shields: List<RouteShield>)
+    private val locationObserver = object : LocationObserver {
 
-    override fun onNewRawLocation(rawLocation: Location) {
-        // Do nothing
+        override fun onNewRawLocation(rawLocation: Location) {
+            // Do nothing
+        }
+
+        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+            val newRoad = locationMatcherResult.road.components
+            if (currentRoad != newRoad) {
+                currentRoad = newRoad
+                onRoadUpdate(newRoad, currentShields)
+                routeShieldApi.getRouteShields(
+                    locationMatcherResult.road,
+                    mapUserStyleObserver.userId,
+                    mapUserStyleObserver.styleId,
+                    mapboxNavigation?.navigationOptions?.accessToken,
+                    roadNameShieldsCallback,
+                )
+            }
+        }
     }
 
-    override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
-        val newRoad = locationMatcherResult.road.components
-        if (currentRoad != newRoad) {
-            currentRoad = newRoad
-            onRoadUpdate(newRoad, currentShields)
-            routeShieldApi.getRouteShields(
-                locationMatcherResult.road,
-                mapUserStyleObserver.userId,
-                mapUserStyleObserver.styleId,
-                mapboxNavigation.navigationOptions.accessToken,
-                roadNameShieldsCallback,
-            )
-        }
+    abstract fun onRoadUpdate(road: List<RoadComponent>, shields: List<RouteShield>)
+
+    final override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        this.mapboxNavigation = mapboxNavigation
+        mapboxNavigation.registerLocationObserver(locationObserver)
+    }
+
+    final override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        mapboxNavigation.unregisterLocationObserver(locationObserver)
+        this.mapboxNavigation = null
     }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Addressing https://github.com/mapbox/mapbox-navigation-android/issues/6141

Removing the `MapboxNavigation` constructor parameter from `RoadNameObserver` and `CarSurfaceLayer`.