### PR TITLE
[Android Auto] Remove `MapboxNavigation` from `CarLocationsOverviewCamera` constructor

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 #### Bug fixes and improvements
 - Removed `MapboxNavigation` from `RoadNameObserver` and `RoadLabelSurfaceLayer` constructor. [#6224](https://github.com/mapbox/mapbox-navigation-android/pull/6224)
+- Removed `MapboxNavigation` form `CarLocationsOverviewCamera` constructor. [#6225](https://github.com/mapbox/mapbox-navigation-android/pull/6225)
 
 ## androidauto-v0.8.0 - Aug 18, 2022
 ### Changelog

--- a/libnavui-androidauto/api/current.txt
+++ b/libnavui-androidauto/api/current.txt
@@ -330,13 +330,11 @@ package com.mapbox.androidauto.car.navigation {
   }
 
   public final class CarLocationsOverviewCamera implements com.mapbox.maps.extension.androidauto.MapboxCarMapObserver {
-    ctor public CarLocationsOverviewCamera(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation, com.mapbox.maps.CameraOptions initialCameraOptions = CameraOptions.<init>().zoom(DEFAULT_INITIAL_ZOOM).build());
-    method public com.mapbox.navigation.core.MapboxNavigation getMapboxNavigation();
+    ctor public CarLocationsOverviewCamera(com.mapbox.maps.CameraOptions initialCameraOptions = CameraOptions.<init>().zoom(DEFAULT_INITIAL_ZOOM).build());
     method public void onAttached(com.mapbox.maps.extension.androidauto.MapboxCarMapSurface mapboxCarMapSurface);
     method public void onDetached(com.mapbox.maps.extension.androidauto.MapboxCarMapSurface mapboxCarMapSurface);
     method public void onVisibleAreaChanged(android.graphics.Rect visibleArea, com.mapbox.maps.EdgeInsets edgeInsets);
     method public void updateWithLocations(java.util.List<com.mapbox.geojson.Point> points);
-    property public final com.mapbox.navigation.core.MapboxNavigation mapboxNavigation;
     field public static final double DEFAULT_INITIAL_ZOOM = 15.0;
   }
 

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapScreen.kt
@@ -54,7 +54,7 @@ class PlacesListOnMapScreen(
 
     private val placeRecords by lazy { CopyOnWriteArrayList<PlaceRecord>() }
     private val jobControl by lazy { mainCarContext.getJobControl() }
-    private val carNavigationCamera = CarLocationsOverviewCamera(mainCarContext.mapboxNavigation)
+    private val carNavigationCamera = CarLocationsOverviewCamera()
     private val locationRenderer = CarLocationRenderer(mainCarContext)
     private var styleLoadedListener: OnStyleLoadedListener? = null
 

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/CarLocationsOverviewCameraTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/CarLocationsOverviewCameraTest.kt
@@ -1,8 +1,8 @@
 package com.mapbox.androidauto.navigation
 
 import com.mapbox.androidauto.car.navigation.CarLocationsOverviewCamera
+import com.mapbox.androidauto.testing.CarAppTestRule
 import com.mapbox.androidauto.testing.MapboxRobolectricTestRunner
-import com.mapbox.common.Logger
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.MapSurface
 import com.mapbox.maps.MapboxExperimental
@@ -11,34 +11,20 @@ import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.navigation.core.MapboxNavigation
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import io.mockk.verify
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 @OptIn(MapboxExperimental::class)
 class CarLocationsOverviewCameraTest : MapboxRobolectricTestRunner() {
 
-    @Before
-    fun setup() {
-        mockkStatic(Logger::class)
-        every { Logger.e(any(), any()) } just Runs
-        every { Logger.i(any(), any()) } just Runs
-    }
-
-    @After
-    fun teardown() {
-        unmockkStatic(Logger::class)
-    }
+    @get:Rule
+    val carAppTestRule = CarAppTestRule()
 
     @Test
     fun loaded() {
@@ -52,8 +38,9 @@ class CarLocationsOverviewCameraTest : MapboxRobolectricTestRunner() {
         val mapboxCarMapSurface = mockk<MapboxCarMapSurface> {
             every { mapSurface } returns aMapSurface
         }
-        val camera = CarLocationsOverviewCamera(mapboxNavigation)
+        val camera = CarLocationsOverviewCamera()
 
+        carAppTestRule.onAttached(mapboxNavigation)
         camera.onAttached(mapboxCarMapSurface)
 
         verify { mapboxMap.setCamera(any<CameraOptions>()) }
@@ -69,8 +56,9 @@ class CarLocationsOverviewCameraTest : MapboxRobolectricTestRunner() {
         val mapboxCarMapSurface = mockk<MapboxCarMapSurface> {
             every { mapSurface } returns aMapSurface
         }
-        val camera = CarLocationsOverviewCamera(mapboxNavigation)
+        val camera = CarLocationsOverviewCamera()
 
+        carAppTestRule.onAttached(mapboxNavigation)
         camera.onDetached(mapboxCarMapSurface)
 
         assertNull(camera.mapboxCarMapSurface)

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/testing/CarAppTestRule.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/testing/CarAppTestRule.kt
@@ -1,11 +1,14 @@
 package com.mapbox.androidauto.testing
 
 import com.mapbox.androidauto.internal.AndroidAutoLog
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockkObject
-import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkAll
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
@@ -13,15 +16,53 @@ import org.junit.runner.Description
  * Top level test rule for the android auto library.
  */
 class CarAppTestRule : TestWatcher() {
-    override fun starting(description: Description?) {
-        mockkStatic(AndroidAutoLog::class)
+
+    private var attachedMapboxNavigation: MapboxNavigation? = null
+    private val registeredMapboxNavigationObservers = mutableListOf<MapboxNavigationObserver>()
+
+    override fun starting(description: Description) {
         mockkObject(AndroidAutoLog)
         every { AndroidAutoLog.logAndroidAuto(any()) } just runs
         every { AndroidAutoLog.logAndroidAutoFailure(any(), any()) } just runs
+
+        mockkObject(MapboxNavigationApp)
+        every {
+            MapboxNavigationApp.registerObserver(any())
+        } answers {
+            attachedMapboxNavigation?.let {
+                firstArg<MapboxNavigationObserver>().onAttached(it)
+            }
+            registeredMapboxNavigationObservers.add(firstArg())
+            MapboxNavigationApp
+        }
+        every {
+            MapboxNavigationApp.unregisterObserver(any())
+        } answers {
+            attachedMapboxNavigation?.let {
+                firstArg<MapboxNavigationObserver>().onDetached(it)
+            }
+            registeredMapboxNavigationObservers.remove(firstArg())
+            MapboxNavigationApp
+        }
     }
 
-    override fun finished(description: Description?) {
-        mockkStatic(AndroidAutoLog::class)
-        mockkObject(AndroidAutoLog)
+    override fun finished(description: Description) {
+        unmockkAll()
+    }
+
+    /**
+     * Simulate the mapboxNavigation is attached, all registered observers are notified.
+     */
+    fun onAttached(mapboxNavigation: MapboxNavigation) {
+        registeredMapboxNavigationObservers.forEach { it.onAttached(mapboxNavigation) }
+        this.attachedMapboxNavigation = mapboxNavigation
+    }
+
+    /**
+     * Simulate the mapboxNavigation is detached, all registered observers are notified.
+     */
+    fun onDetached(mapboxNavigation: MapboxNavigation) {
+        registeredMapboxNavigationObservers.forEach { it.onDetached(mapboxNavigation) }
+        this.attachedMapboxNavigation = null
     }
 }


### PR DESCRIPTION
### Description


Addressing https://github.com/mapbox/mapbox-navigation-android/issues/6141

Removing the `MapboxNavigation` constructor parameter from `CarLocationsOverviewCamera` constructor.