### PR TITLE
[Android Auto] Remove `MapboxNavigation` from `RoutePreviewCarContext`

### DIFF
--- a/libnavui-androidauto/api/current.txt
+++ b/libnavui-androidauto/api/current.txt
@@ -668,13 +668,11 @@ package com.mapbox.androidauto.car.preview {
     method public com.mapbox.androidauto.car.feedback.core.CarFeedbackPollProvider getFeedbackPollProvider();
     method public com.mapbox.androidauto.car.MainCarContext getMainCarContext();
     method public com.mapbox.maps.extension.androidauto.MapboxCarMap getMapboxCarMap();
-    method public com.mapbox.navigation.core.MapboxNavigation getMapboxNavigation();
     property public final androidx.car.app.CarContext carContext;
     property public final com.mapbox.navigation.base.formatter.DistanceFormatter distanceFormatter;
     property public final com.mapbox.androidauto.car.feedback.core.CarFeedbackPollProvider feedbackPollProvider;
     property public final com.mapbox.androidauto.car.MainCarContext mainCarContext;
     property public final com.mapbox.maps.extension.androidauto.MapboxCarMap mapboxCarMap;
-    property public final com.mapbox.navigation.core.MapboxNavigation mapboxNavigation;
   }
 
 }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitRenderer.kt
@@ -9,6 +9,9 @@ import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
 import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface
 import com.mapbox.navigation.base.formatter.UnitType
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import kotlin.math.roundToInt
@@ -30,6 +33,16 @@ class CarSpeedLimitRenderer(
 
         override fun onNewRawLocation(rawLocation: Location) {
             // no op
+        }
+    }
+
+    private val navigationObserver = object : MapboxNavigationObserver {
+        override fun onAttached(mapboxNavigation: MapboxNavigation) {
+            mapboxNavigation.registerLocationObserver(locationObserver)
+        }
+
+        override fun onDetached(mapboxNavigation: MapboxNavigation) {
+            mapboxNavigation.unregisterLocationObserver(locationObserver)
         }
     }
 
@@ -58,12 +71,12 @@ class CarSpeedLimitRenderer(
         logAndroidAuto("CarSpeedLimitRenderer carMapSurface loaded")
         val speedLimitWidget = SpeedLimitWidget().also { speedLimitWidget = it }
         mapboxCarMapSurface.mapSurface.addWidget(speedLimitWidget)
-        mainCarContext.mapboxNavigation.registerLocationObserver(locationObserver)
+        MapboxNavigationApp.registerObserver(navigationObserver)
     }
 
     override fun onDetached(mapboxCarMapSurface: MapboxCarMapSurface) {
         logAndroidAuto("CarSpeedLimitRenderer carMapSurface detached")
-        mainCarContext.mapboxNavigation.unregisterLocationObserver(locationObserver)
+        MapboxNavigationApp.unregisterObserver(navigationObserver)
         speedLimitWidget?.let { mapboxCarMapSurface.mapSurface.removeWidget(it) }
         speedLimitWidget = null
     }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRoutePreviewScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRoutePreviewScreen.kt
@@ -63,7 +63,7 @@ class CarRoutePreviewScreen(
 
         override fun handleOnBackPressed() {
             logAndroidAuto("CarRoutePreviewScreen OnBackPressedCallback")
-            MapboxNavigationApp.current()?.setNavigationRoutes(emptyList())
+            MapboxNavigationApp.current()!!.setNavigationRoutes(emptyList())
             screenManager.pop()
         }
     }
@@ -182,12 +182,11 @@ class CarRoutePreviewScreen(
                 Action.Builder()
                     .setTitle(carContext.getString(R.string.car_action_preview_navigate_button))
                     .setOnClickListener {
-                        MapboxNavigationApp.current()?.let { mapboxNavigation ->
-                            mapboxNavigation.setNavigationRoutes(
-                                carRoutesProvider.navigationRoutes.value
-                            )
-                            MapboxCarApp.updateCarAppState(ActiveGuidanceState)
-                        }
+                        val mapboxNavigation = MapboxNavigationApp.current()!!
+                        mapboxNavigation.setNavigationRoutes(
+                            carRoutesProvider.navigationRoutes.value
+                        )
+                        MapboxCarApp.updateCarAppState(ActiveGuidanceState)
                     }
                     .build(),
             )

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRoutePreviewScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRoutePreviewScreen.kt
@@ -34,6 +34,7 @@ import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
 import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface
 import com.mapbox.maps.plugin.delegates.listeners.OnStyleLoadedListener
 import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 
 /**
  * After a destination has been selected. This view previews the route and lets
@@ -62,7 +63,7 @@ class CarRoutePreviewScreen(
 
         override fun handleOnBackPressed() {
             logAndroidAuto("CarRoutePreviewScreen OnBackPressedCallback")
-            routePreviewCarContext.mapboxNavigation.setNavigationRoutes(emptyList())
+            MapboxNavigationApp.current()?.setNavigationRoutes(emptyList())
             screenManager.pop()
         }
     }
@@ -181,10 +182,12 @@ class CarRoutePreviewScreen(
                 Action.Builder()
                     .setTitle(carContext.getString(R.string.car_action_preview_navigate_button))
                     .setOnClickListener {
-                        routePreviewCarContext.mapboxNavigation.setNavigationRoutes(
-                            carRoutesProvider.navigationRoutes.value
-                        )
-                        MapboxCarApp.updateCarAppState(ActiveGuidanceState)
+                        MapboxNavigationApp.current()?.let { mapboxNavigation ->
+                            mapboxNavigation.setNavigationRoutes(
+                                carRoutesProvider.navigationRoutes.value
+                            )
+                            MapboxCarApp.updateCarAppState(ActiveGuidanceState)
+                        }
                     }
                     .build(),
             )

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/RoutePreviewCarContext.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/RoutePreviewCarContext.kt
@@ -9,6 +9,5 @@ data class RoutePreviewCarContext internal constructor(
     val carContext = mainCarContext.carContext
     val mapboxCarMap = mainCarContext.mapboxCarMap
     val distanceFormatter = mainCarContext.distanceFormatter
-    val mapboxNavigation = mainCarContext.mapboxNavigation
     val feedbackPollProvider = mainCarContext.feedbackPollProvider
 }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkNavigateAction.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkNavigateAction.kt
@@ -10,22 +10,29 @@ import com.mapbox.androidauto.car.placeslistonmap.PlaceMarkerRenderer
 import com.mapbox.androidauto.car.placeslistonmap.PlacesListItemMapper
 import com.mapbox.androidauto.car.placeslistonmap.PlacesListOnMapScreen
 import com.mapbox.androidauto.internal.logAndroidAuto
+import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.geodeeplink.GeoDeeplink
 import com.mapbox.navigation.core.geodeeplink.GeoDeeplinkParser
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 
 class GeoDeeplinkNavigateAction(
     val mainCarContext: MainCarContext,
     val lifecycle: Lifecycle
 ) {
     fun onNewIntent(intent: Intent): Screen? {
+        val mapboxNavigation = MapboxNavigationApp.current()
+            ?: return null
         val geoDeeplink = GeoDeeplinkParser.parse(intent.dataString)
             ?: return null
-        return preparePlacesListOnMapScreen(geoDeeplink)
+        return preparePlacesListOnMapScreen(mapboxNavigation, geoDeeplink)
     }
 
-    private fun preparePlacesListOnMapScreen(geoDeeplink: GeoDeeplink): Screen {
+    private fun preparePlacesListOnMapScreen(
+        mapboxNavigation: MapboxNavigation,
+        geoDeeplink: GeoDeeplink
+    ): Screen {
         logAndroidAuto("GeoDeeplinkNavigateAction preparePlacesListOnMapScreen")
-        val accessToken = mainCarContext.mapboxNavigation.navigationOptions.accessToken
+        val accessToken = mapboxNavigation.navigationOptions.accessToken
         checkNotNull(accessToken) {
             "GeoDeeplinkGeocoding requires an access token"
         }
@@ -35,14 +42,12 @@ class GeoDeeplinkNavigateAction(
         )
         val feedbackPoll = mainCarContext.feedbackPollProvider
             .getSearchFeedbackPoll(mainCarContext.carContext)
-
         return PlacesListOnMapScreen(
             mainCarContext,
             placesProvider,
             PlacesListItemMapper(
                 PlaceMarkerRenderer(mainCarContext.carContext),
-                mainCarContext
-                    .mapboxNavigation
+                mapboxNavigation
                     .navigationOptions
                     .distanceFormatterOptions
                     .unitType


### PR DESCRIPTION
## Description 

Addressing https://github.com/mapbox/mapbox-navigation-android/issues/6141

 - Migrate `CarSpeedLimitRenderer` to `MapboxNavigationApp`
 - `CarRoutePreviewScreen` can use `MapboxNavigationApp.current()` since it has single shot actions
 - `GeoDeeplinkNavigateAction` can use `MapboxNavigationApp.current()` since it has single shot actions

Skipping changelog because there is are no public api changes here. 

The remaining migrations are a bit more ambiguous, this classes were some low hanging fruit.
