### PR TITLE
Create a delegate for `MapboxNavigation` called `requireMapboxNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 - Improved the route refresh feature to also refresh _closures_ (`RouteLeg#closures`). [#6274](https://github.com/mapbox/mapbox-navigation-android/pull/6274)
-
 - Added `requireMapboxNavigation` to offer a simple way to use `MapboxNavigationApp`. [#6233](https://github.com/mapbox/mapbox-navigation-android/pull/6233)
 #### Bug fixes and improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 - Improved the route refresh feature to also refresh _closures_ (`RouteLeg#closures`). [#6274](https://github.com/mapbox/mapbox-navigation-android/pull/6274)
 
+- Added `requireMapboxNavigation` to offer a simple way to use `MapboxNavigationApp`. [#6233](https://github.com/mapbox/mapbox-navigation-android/pull/6233)
 #### Bug fixes and improvements
 
 ## Mapbox Navigation SDK 2.8.0-beta.2 - 01 September, 2022

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -337,6 +337,10 @@ package com.mapbox.navigation.core.lifecycle {
     method public com.mapbox.navigation.base.options.NavigationOptions createNavigationOptions();
   }
 
+  public final class RequireMapboxNavigation {
+    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public static kotlin.properties.ReadOnlyProperty<androidx.lifecycle.LifecycleOwner,com.mapbox.navigation.core.MapboxNavigation> requireMapboxNavigation(com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver? onCreatedObserver = null, com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver? onStartedObserver = null, com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver? onResumedObserver = null, kotlin.jvm.functions.Function0<kotlin.Unit>? onInitialize = null);
+  }
+
 }
 
 package com.mapbox.navigation.core.navigator {

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -338,7 +338,7 @@ package com.mapbox.navigation.core.lifecycle {
   }
 
   public final class RequireMapboxNavigation {
-    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public static kotlin.properties.ReadOnlyProperty<androidx.lifecycle.LifecycleOwner,com.mapbox.navigation.core.MapboxNavigation> requireMapboxNavigation(com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver? onCreatedObserver = null, com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver? onStartedObserver = null, com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver? onResumedObserver = null, kotlin.jvm.functions.Function0<kotlin.Unit>? onInitialize = null);
+    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public static kotlin.properties.ReadOnlyProperty<java.lang.Object,com.mapbox.navigation.core.MapboxNavigation> requireMapboxNavigation(androidx.lifecycle.LifecycleOwner, com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver? onCreatedObserver = null, com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver? onStartedObserver = null, com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver? onResumedObserver = null, kotlin.jvm.functions.Function0<kotlin.Unit>? onInitialize = null);
   }
 
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/RequireMapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/RequireMapboxNavigation.kt
@@ -1,0 +1,139 @@
+@file:JvmName("RequireMapboxNavigation")
+
+package com.mapbox.navigation.core.lifecycle
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Extension function to make it simple to create the [RequireMapboxNavigationDelegate]. Below are
+ * a couple examples of how you may use the delegate.
+ *
+ * Default can be used when [MapboxNavigationApp] is setup elsewhere.
+ * ```
+ * val mapboxNavigation by requireMapboxNavigation()
+ * ```
+ *
+ * Initialize the [MapboxNavigationApp] when you are ready to use it
+ * ```
+ * val mapboxNavigation by requireMapboxNavigation {
+ *   MapboxNavigationApp.setup(..)
+ * }
+ * ```
+ *
+ * Register subscriptions and setup MapboxNavigationApp
+ * ```
+ * private val mapboxNavigation by requireMapboxNavigation(
+ *   onResumedObserver = object : MapboxNavigationObserver {
+ *     override fun onAttached(mapboxNavigation: MapboxNavigation) {
+ *       mapboxNavigation.registerLocationObserver(locationObserver)
+ *       mapboxNavigation.registerRoutesObserver(routesObserver)
+ *     }
+ *     override fun onDetached(mapboxNavigation: MapboxNavigation) {
+ *       mapboxNavigation.unregisterLocationObserver(locationObserver)
+ *       mapboxNavigation.unregisterRoutesObserver(routesObserver)
+ *     }
+ *   }
+ * ) {
+ *   MapboxNavigationApp.setup(
+ *       NavigationOptions.Builder(this)
+ *           .accessToken(accessToken)
+ *           .build()
+ *     )
+ * }
+ * ```
+ *
+ * @see [RequireMapboxNavigationDelegate] for more details.
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+fun requireMapboxNavigation(
+    onCreatedObserver: MapboxNavigationObserver? = null,
+    onStartedObserver: MapboxNavigationObserver? = null,
+    onResumedObserver: MapboxNavigationObserver? = null,
+    onInitialize: (() -> Unit)? = null,
+): ReadOnlyProperty<LifecycleOwner, MapboxNavigation> = RequireMapboxNavigationDelegate(
+    onCreatedObserver = onCreatedObserver,
+    onStartedObserver = onStartedObserver,
+    onResumedObserver = onResumedObserver,
+    onInitialize = onInitialize
+)
+
+/**
+ * Attaches a [LifecycleOwner] to [MapboxNavigationApp] and provides access to [MapboxNavigation].
+ *
+ * You can choose to call [MapboxNavigationApp.setup] in the [onInitialize]. You can also setup in
+ * the onCreate calls, or any call that happens before this delegate is accessed. The delegate will
+ * crash if accessed when the app is not setup or an attached lifecycle has not been created.
+ *
+ * You can use the observers parameter to setup any subscriptions. This is important because the
+ * [MapboxNavigation] instance can be re-created with [MapboxNavigationApp.disable], or if all
+ * [MapboxNavigationApp.attach] lifecycles are destroyed.
+ *
+ * @param onCreatedObserver registered to the [Lifecycle.State.CREATED] lifecycle
+ * @param onStartedObserver registered to the [Lifecycle.State.STARTED] lifecycle
+ * @param onResumedObserver registered to the [Lifecycle.State.RESUMED] lifecycle
+ * @param onInitialize called when the property is read for the first time
+ */
+internal class RequireMapboxNavigationDelegate(
+    private val onCreatedObserver: MapboxNavigationObserver? = null,
+    private val onStartedObserver: MapboxNavigationObserver? = null,
+    private val onResumedObserver: MapboxNavigationObserver? = null,
+    private val onInitialize: (() -> Unit)? = null
+) : ReadOnlyProperty<LifecycleOwner, MapboxNavigation> {
+
+    private lateinit var lifecycleOwner: LifecycleOwner
+
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onCreate(owner: LifecycleOwner) {
+            onCreatedObserver?.let { MapboxNavigationApp.registerObserver(it) }
+        }
+
+        override fun onDestroy(owner: LifecycleOwner) {
+            onCreatedObserver?.let { MapboxNavigationApp.unregisterObserver(it) }
+        }
+
+        override fun onStart(owner: LifecycleOwner) {
+            onStartedObserver?.let { MapboxNavigationApp.registerObserver(it) }
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            onStartedObserver?.let { MapboxNavigationApp.unregisterObserver(it) }
+        }
+
+        override fun onResume(owner: LifecycleOwner) {
+            onResumedObserver?.let { MapboxNavigationApp.registerObserver(it) }
+        }
+
+        override fun onPause(owner: LifecycleOwner) {
+            onResumedObserver?.let { MapboxNavigationApp.unregisterObserver(it) }
+        }
+    }
+
+    /**
+     * Returns an instance of [MapboxNavigation], the first retrieval will attach the [thisRef]
+     * to [MapboxNavigationApp.attach]. If [MapboxNavigationApp.isSetup] is false after all
+     * observers and initializers, this property getter will crash.
+     *
+     * @param thisRef - the [LifecycleOwner] that needs access to [MapboxNavigation].
+     * @param property - ignored
+     */
+    override fun getValue(thisRef: LifecycleOwner, property: KProperty<*>): MapboxNavigation {
+        if (!this::lifecycleOwner.isInitialized) {
+            onInitialize?.invoke()
+            this.lifecycleOwner = thisRef
+            MapboxNavigationApp.attach(lifecycleOwner)
+            lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+        }
+        val mapboxNavigation = MapboxNavigationApp.current()
+        checkNotNull(mapboxNavigation) {
+            "MapboxNavigation cannot be null. Ensure that MapboxNavigationApp is setup and an" +
+                " attached lifecycle is at least CREATED."
+        }
+        return mapboxNavigation
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/RequireMapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/RequireMapboxNavigationTest.kt
@@ -82,6 +82,18 @@ class RequireMapboxNavigationTest {
     }
 
     @Test
+    fun `onInitialize is called before first reference to the delegate`() {
+        mockMapboxNavigationAppBehavior()
+        val mockOnInitialize: (() -> Unit) = mockk(relaxed = true)
+        val sut = SystemUnderTest(onInitialize = mockOnInitialize)
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.CREATED)
+
+        verify { mockOnInitialize.invoke() }
+    }
+
+    @Test
     fun `multiple delegate references are the same instance`() {
         mockMapboxNavigationAppBehavior()
         val sut = SystemUnderTest()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/RequireMapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/RequireMapboxNavigationTest.kt
@@ -1,0 +1,347 @@
+package com.mapbox.navigation.core.lifecycle
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RequireMapboxNavigationTest {
+
+    private class SystemUnderTest(
+        onCreatedObserver: MapboxNavigationObserver? = null,
+        onStartedObserver: MapboxNavigationObserver? = null,
+        onResumedObserver: MapboxNavigationObserver? = null,
+        onInitialize: (() -> Unit)? = null
+    ) : LifecycleOwner {
+        private val lifecycleRegistry = LifecycleRegistry(this)
+            .also { it.currentState = Lifecycle.State.INITIALIZED }
+
+        override fun getLifecycle(): Lifecycle = lifecycleRegistry
+
+        fun moveToState(state: Lifecycle.State) {
+            lifecycleRegistry.currentState = state
+        }
+
+        @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+        val mapboxNavigation by requireMapboxNavigation(
+            onCreatedObserver = onCreatedObserver,
+            onStartedObserver = onStartedObserver,
+            onResumedObserver = onResumedObserver,
+            onInitialize = onInitialize
+        )
+    }
+
+    @Before
+    fun setup() {
+        mockkObject(MapboxNavigationApp)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `crashes before setup`() {
+        SystemUnderTest().mapboxNavigation
+    }
+
+    @Test
+    fun `mapboxNavigation is available when current is not null`() {
+        every { MapboxNavigationApp.current() } returns mockk()
+
+        SystemUnderTest().mapboxNavigation
+    }
+
+    @Test
+    fun `mapboxNavigation is available after MapboxNavigationApp#setup and lifecycle is CREATED`() {
+        mockMapboxNavigationAppBehavior()
+        val sut = SystemUnderTest()
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.CREATED)
+
+        // This should not crash
+        sut.mapboxNavigation
+    }
+
+    @Test
+    fun `multiple delegate references are the same instance`() {
+        mockMapboxNavigationAppBehavior()
+        val sut = SystemUnderTest()
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.CREATED)
+        val firstRef = sut.mapboxNavigation
+        val secondRef = sut.mapboxNavigation
+
+        assertTrue(firstRef === secondRef)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `delegate reference will crash if accessed after lifecycle is DESTROYED`() {
+        mockMapboxNavigationAppBehavior()
+        val sut = SystemUnderTest()
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.CREATED)
+        sut.mapboxNavigation
+        sut.moveToState(Lifecycle.State.DESTROYED)
+
+        // This should crash
+        sut.mapboxNavigation
+    }
+
+    @Test
+    fun `delegate references changes after MapboxNavigationApp is reset`() {
+        mockMapboxNavigationAppBehavior()
+        val sut = SystemUnderTest()
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.CREATED)
+        val firstRef = sut.mapboxNavigation
+        MapboxNavigationApp.disable()
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        val secondRef = sut.mapboxNavigation
+
+        assertTrue(firstRef !== secondRef)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `delegate reference will crash if accessed after MapboxNavigationApp#disable`() {
+        mockMapboxNavigationAppBehavior()
+        val sut = SystemUnderTest()
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.CREATED)
+        sut.mapboxNavigation
+        MapboxNavigationApp.disable()
+
+        // This should crash
+        sut.mapboxNavigation
+    }
+
+    @Test
+    fun `onInitialize can be used to setup the app`() {
+        mockMapboxNavigationAppBehavior()
+
+        val sut = SystemUnderTest {
+            MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        }
+        sut.moveToState(Lifecycle.State.CREATED)
+
+        // This should not crash
+        sut.mapboxNavigation
+    }
+
+    @Test
+    fun `observer callback order of resetting MapboxNavigationApp`() {
+        mockMapboxNavigationAppBehavior()
+        val onCreatedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val onStartedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val onResumedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val sut = SystemUnderTest(
+            onCreatedObserver = onCreatedObserver,
+            onStartedObserver = onStartedObserver,
+            onResumedObserver = onResumedObserver,
+        )
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.RESUMED)
+        val firstRef = sut.mapboxNavigation
+        MapboxNavigationApp.disable()
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        val secondRef = sut.mapboxNavigation
+
+        verifyOrder {
+            onCreatedObserver.onAttached(firstRef)
+            onStartedObserver.onAttached(firstRef)
+            onResumedObserver.onAttached(firstRef)
+            onCreatedObserver.onDetached(firstRef)
+            onStartedObserver.onDetached(firstRef)
+            onResumedObserver.onDetached(firstRef)
+            onCreatedObserver.onAttached(secondRef)
+            onStartedObserver.onAttached(secondRef)
+            onResumedObserver.onAttached(secondRef)
+        }
+    }
+
+    @Test
+    fun `CREATED lifecycle state callback order`() {
+        mockMapboxNavigationAppBehavior()
+        val onCreatedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val onStartedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val onResumedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val sut = SystemUnderTest(
+            onCreatedObserver = onCreatedObserver,
+            onStartedObserver = onStartedObserver,
+            onResumedObserver = onResumedObserver,
+        )
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.CREATED)
+        val firstRef = sut.mapboxNavigation
+        sut.moveToState(Lifecycle.State.DESTROYED)
+
+        verifyOrder {
+            onCreatedObserver.onAttached(firstRef)
+            onCreatedObserver.onDetached(firstRef)
+        }
+        verify(exactly = 0) {
+            onStartedObserver.onDetached(any())
+            onStartedObserver.onDetached(any())
+            onResumedObserver.onDetached(any())
+            onResumedObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `STARTED lifecycle state callback order`() {
+        mockMapboxNavigationAppBehavior()
+        val onCreatedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val onStartedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val onResumedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val sut = SystemUnderTest(
+            onCreatedObserver = onCreatedObserver,
+            onStartedObserver = onStartedObserver,
+            onResumedObserver = onResumedObserver,
+        )
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.STARTED)
+        val firstRef = sut.mapboxNavigation
+        sut.moveToState(Lifecycle.State.CREATED)
+
+        verifyOrder {
+            onCreatedObserver.onAttached(firstRef)
+            onStartedObserver.onAttached(firstRef)
+            onStartedObserver.onDetached(firstRef)
+        }
+        verify(exactly = 0) {
+            onCreatedObserver.onDetached(any())
+            onResumedObserver.onAttached(any())
+            onResumedObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `RESUMED lifecycle state callback order`() {
+        mockMapboxNavigationAppBehavior()
+        val onCreatedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val onStartedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val onResumedObserver = mockk<MapboxNavigationObserver>(relaxed = true)
+        val sut = SystemUnderTest(
+            onCreatedObserver = onCreatedObserver,
+            onStartedObserver = onStartedObserver,
+            onResumedObserver = onResumedObserver,
+        )
+
+        MapboxNavigationApp.setup(mockk<NavigationOptions>())
+        sut.moveToState(Lifecycle.State.RESUMED)
+        val firstRef = sut.mapboxNavigation
+        sut.moveToState(Lifecycle.State.STARTED)
+
+        verifyOrder {
+            onCreatedObserver.onAttached(firstRef)
+            onStartedObserver.onAttached(firstRef)
+            onResumedObserver.onAttached(firstRef)
+            onResumedObserver.onDetached(firstRef)
+        }
+        verify(exactly = 0) {
+            onCreatedObserver.onDetached(any())
+            onStartedObserver.onDetached(any())
+        }
+    }
+
+    /**
+     * This mocks the behavior of [MapboxNavigationApp] in order to showcase what is expected from
+     * the [RequireMapboxNavigationDelegate].
+     */
+    private fun mockMapboxNavigationAppBehavior() {
+        var mockMapboxNavigation: MapboxNavigation? = null
+        var isSetup = false
+        val registeredMapboxNavigationObservers = mutableListOf<MapboxNavigationObserver>()
+        val attachedLifecycleOwner = mutableListOf<LifecycleOwner>()
+
+        every { MapboxNavigationApp.current() } answers {
+            mockMapboxNavigation
+        }
+        every { MapboxNavigationApp.disable() } answers {
+            registeredMapboxNavigationObservers.forEach { it.onDetached(mockMapboxNavigation!!) }
+            mockMapboxNavigation = null
+            isSetup = false
+            MapboxNavigationApp
+        }
+        every { MapboxNavigationApp.attach(any()) } answers {
+            attachedLifecycleOwner.add(firstArg())
+            firstArg<LifecycleOwner>().lifecycle.addObserver(object : DefaultLifecycleObserver {
+                override fun onCreate(owner: LifecycleOwner) {
+                    if (isSetup) {
+                        mockMapboxNavigation = mockk()
+                        registeredMapboxNavigationObservers.forEach { observer ->
+                            observer.onAttached(mockMapboxNavigation!!)
+                        }
+                    }
+                }
+
+                override fun onDestroy(owner: LifecycleOwner) {
+                    super.onDestroy(owner)
+                    attachedLifecycleOwner.remove(firstArg())
+                    val isCreated = attachedLifecycleOwner.any {
+                        it.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)
+                    }
+                    if (!isCreated) {
+                        registeredMapboxNavigationObservers.forEach { observer ->
+                            observer.onDetached(mockMapboxNavigation!!)
+                        }
+                        mockMapboxNavigation = null
+                    }
+                }
+            })
+            MapboxNavigationApp
+        }
+        every { MapboxNavigationApp.setup(any<NavigationOptions>()) } answers {
+            isSetup = true
+            val isCreated = attachedLifecycleOwner.any {
+                it.lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)
+            }
+            if (isCreated) {
+                mockMapboxNavigation = mockk()
+                registeredMapboxNavigationObservers.forEach { observer ->
+                    observer.onAttached(mockMapboxNavigation!!)
+                }
+            }
+            MapboxNavigationApp
+        }
+        every {
+            MapboxNavigationApp.registerObserver(any())
+        } answers {
+            registeredMapboxNavigationObservers.add(firstArg())
+            firstArg<MapboxNavigationObserver>().onAttached(mockMapboxNavigation!!)
+            MapboxNavigationApp
+        }
+        every {
+            MapboxNavigationApp.unregisterObserver(any())
+        } answers {
+            registeredMapboxNavigationObservers.remove(firstArg())
+            firstArg<MapboxNavigationObserver>().onDetached(mockMapboxNavigation!!)
+            MapboxNavigationApp
+        }
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/InactiveRouteStylingActivity.kt
@@ -93,7 +93,6 @@ class InactiveRouteStylingActivity : AppCompatActivity() {
     private val mapboxNavigation by requireMapboxNavigation(
         onCreatedObserver = object : MapboxNavigationObserver {
             override fun onAttached(mapboxNavigation: MapboxNavigation) {
-
                 mapboxNavigation.registerLocationObserver(locationObserver)
                 mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
                 mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MainActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.databinding.ActivityMainBinding
 import com.mapbox.navigation.qa_test_app.domain.TestActivityDescription
@@ -53,6 +54,9 @@ class MainActivity : AppCompatActivity() {
         (binding.activitiesList.adapter as GenericListAdapter<TestActivityDescription, *>).swap(
             TestActivitySuite.testActivities
         )
+
+        // Each example is responsible for setting up their NavigationOptions.
+        MapboxNavigationApp.disable()
     }
 
     override fun onRequestPermissionsResult(


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

There is some consistent boilerplate required to setup the `MapboxNavigationApp`. I've just spent a bit of time migrating `:libnavui-androidauto:` to use the `MapboxNavigationApp` https://github.com/mapbox/mapbox-navigation-android/issues/6141 and I've explored a few approaches with the examples repository https://github.com/mapbox/mapbox-navigation-android-examples/pull/129. We also discussed some ambiguous scenarios where we want to access `MapboxNavigation` directly and it requires an unsafe call `MapboxNavigationApp.current()!!`. https://github.com/mapbox/mapbox-navigation-android/pull/6226#discussion_r954784375. This delegate removes the need for `!!` with specific guidelines.

This is my favorite approach so far. Create a delegate that hooks up `MapboxNavigation` to your `LifecycleOwner`. I migrated a random example from the `qa-test-app` to show what it looks like, take a look at the `FeedbackActivity`. EDIT migrated another example `InactiveRouteStylingActivity`.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

Inside any `LifecycleOwner` you can use the `requireMapboxNavigation` delegate like this. And then you have access to `mapboxNavigation` as if you constructed it inside.

#### Default can be used when [MapboxNavigationApp] is setup elsewhere.
``` kotlin
val mapboxNavigation by requireMapboxNavigation()
```

#### Initialize the [MapboxNavigationApp] when you are ready to use it
``` kotlin
val mapboxNavigation by requireMapboxNavigation {
  MapboxNavigationApp.setup(..)
}
```

#### Initialize and setup subscriptions
``` kotlin
val mapboxNavigation by requireMapboxNavigation(
  onInitialize = {
    MapboxNavigationApp.setup(
      NavigationOptions.Builder(this)
          .accessToken(accessToken)
          .build()
    )
  },
  onResumedObserver = object : MapboxNavigationObserver {
    override fun onAttached(mapboxNavigation: MapboxNavigation) {
      mapboxNavigation.registerLocationObserver(locationObserver)
      mapboxNavigation.registerRoutesObserver(routesObserver)
    }
    override fun onDetached(mapboxNavigation: MapboxNavigation) {
      mapboxNavigation.unregisterLocationObserver(locationObserver)
      mapboxNavigation.unregisterRoutesObserver(routesObserver)
    }
  }
)
```

#### Another example
``` kotlin
private val mapboxNavigation by requireMapboxNavigation(
  onCreatedObserver = object : MapboxNavigationObserver {
    override fun onAttached(mapboxNavigation: MapboxNavigation) {
      binding.mapView.location.apply {
        setLocationProvider(navigationLocationProvider)
        enabled = true
      }
      mapboxNavigation.registerLocationObserver(locationObserver)
      mapboxNavigation.registerRoutesObserver(routesObserver)
    }

    override fun onDetached(mapboxNavigation: MapboxNavigation) {
      mapboxNavigation.unregisterLocationObserver(locationObserver)
      mapboxNavigation.unregisterRoutesObserver(routesObserver)
    }
   }
) {
  MapboxNavigationApp.setup(
    NavigationOptions.Builder(this)
        .accessToken(Utils.getMapboxAccessToken(this))
        .build()
  )
}
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
