### PR TITLE
[Android Auto] Suggestion from circle ci support to fix androidauto-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -738,6 +738,7 @@ jobs:
                 test-command: ./gradlew libnavui-androidauto:connectedDebugAndroidTest
                 system-image: system-images;android-30;google_apis_playstore;x86
                 wait-for-emulator: false
+                save-gradle-cache: false
             - run:
                 name: Save test results
                 command: |


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/5880

`androidauto-test` is a job that run instrumentation tests which uses circleci android machines. They fail sometimes and it appears to be a circleci issue.

I'm not sure if this will really resolve the ticket above but we'll give it a try.

Link to circle ci support https://support.circleci.com/hc/en-us/requests/116053
