### PR TITLE
[Drop-In UI] Allow users to handle back press events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+- Added `NavigationViewListener.onBackPressed()`. This method allows client code to intercept any `NavigationView` BACK press events. [#6244](https://github.com/mapbox/mapbox-navigation-android/pull/6244)
+
 #### Bug fixes and improvements
 - Fixed an issue where portions of alternative routes that overlap with the primary route weren't hidden correctly, suffering from precision problems. [#6228](https://github.com/mapbox/mapbox-navigation-android/pull/6228)
 - Fixed incorrect values in `AlternativeRouteInfo#duration` and `RouteProgress#durationRemaining`: now they rely on `route.leg.annotations.duration` if available, otherwise, `LegStep#duration` is used for calculations. [#6237](https://github.com/mapbox/mapbox-navigation-android/pull/6237)

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -80,6 +80,7 @@ package com.mapbox.navigation.dropin {
     method public void onActiveNavigation();
     method public void onArrival();
     method public void onAudioGuidanceStateChanged(boolean muted);
+    method public boolean onBackPressed();
     method public void onCameraPaddingChanged(com.mapbox.maps.EdgeInsets padding);
     method public void onDestinationChanged(com.mapbox.geojson.Point? destination);
     method public void onDestinationPreview();
@@ -87,8 +88,10 @@ package com.mapbox.navigation.dropin {
     method public void onFreeDrive();
     method public void onIdleCameraMode();
     method public void onInfoPanelCollapsed();
+    method public void onInfoPanelDragging();
     method public void onInfoPanelExpanded();
     method public void onInfoPanelHidden();
+    method public void onInfoPanelSettling();
     method public void onOverviewCameraMode();
     method public void onRouteFetchCanceled(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
     method public void onRouteFetchFailed(java.util.List<com.mapbox.navigation.base.route.RouterFailure> reasons, com.mapbox.api.directions.v5.models.RouteOptions routeOptions);

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -125,7 +125,11 @@ class NavigationView @JvmOverloads constructor(
             LocationPermissionComponent(context.toComponentActivityRef(), navigationContext.store),
             TripSessionComponent(lifecycle, navigationContext.store),
             MapLayoutCoordinator(navigationContext, binding),
-            OnKeyListenerComponent(navigationContext.store, this),
+            OnKeyListenerComponent(
+                navigationContext.store,
+                this,
+                navigationContext.listenerRegistry
+            ),
             ManeuverCoordinator(navigationContext, binding.guidanceLayout),
             InfoPanelCoordinator(
                 navigationContext,

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
@@ -130,4 +130,11 @@ abstract class NavigationViewListener {
      * Called when the info panel behavior updates to settling.
      */
     open fun onInfoPanelSettling() = Unit
+
+    /**
+     * Called when hardware back button has been pressed.
+     *
+     * @return True if the listener has consumed the event, false otherwise.
+     */
+    open fun onBackPressed(): Boolean = false
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
@@ -1,5 +1,7 @@
 package com.mapbox.navigation.dropin
 
+import android.view.KeyEvent
+import android.view.View
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.component.infopanel.InfoPanelBehavior
@@ -18,7 +20,7 @@ internal class NavigationViewListenerRegistry(
     private val store: Store,
     private val infoPanelSubscriber: InfoPanelBehavior,
     private val coroutineScope: CoroutineScope
-) {
+) : View.OnKeyListener {
     private var listeners = mutableMapOf<NavigationViewListener, Job>()
 
     fun registerListener(listener: NavigationViewListener) {
@@ -29,6 +31,19 @@ internal class NavigationViewListenerRegistry(
     fun unregisterListener(listener: NavigationViewListener) {
         listeners.remove(listener)?.cancel()
     }
+
+    //region View.OnKeyListener
+
+    override fun onKey(v: View, keyCode: Int, event: KeyEvent): Boolean {
+        if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+            listeners.forEach { (listener, _) ->
+                if (listener.onBackPressed()) return true
+            }
+        }
+        return false
+    }
+
+    //endregion
 
     private fun connectListener(listener: NavigationViewListener): Job {
         return coroutineScope.launch {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/backpress/OnKeyListenerComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/backpress/OnKeyListenerComponent.kt
@@ -25,6 +25,7 @@ import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 internal class OnKeyListenerComponent(
     private val store: Store,
     private val view: View,
+    private val delegateOnKeyListener: View.OnKeyListener? = null
 ) : UIComponent() {
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
@@ -32,7 +33,10 @@ internal class OnKeyListenerComponent(
 
         view.isFocusableInTouchMode = true
         view.requestFocus()
-        view.setOnKeyListener { _, keyCode, event ->
+        view.setOnKeyListener { v, keyCode, event ->
+            if (delegateOnKeyListener?.onKey(v, keyCode, event) == true) {
+                return@setOnKeyListener true
+            }
             if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
                 handleBackPress()
             } else {

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -126,6 +126,7 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
 
         binding.navigationView.addListener(freeDriveInfoPanelInstaller)
         binding.navigationView.addListener(navViewListener)
+        binding.navigationView.addListener(backPressOverride)
         binding.navigationView.customizeViewOptions {
             routeArrowOptions = customRouteArrowOptions()
         }
@@ -558,6 +559,38 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             binding.navigationView.customizeViewBinders {
                 infoPanelHeaderBinder = UIBinder.USE_DEFAULT
             }
+        }
+    }
+
+    private val backPressOverride = object : NavigationViewListener() {
+        private var inRoutePreview = false
+
+        override fun onFreeDrive() {
+            inRoutePreview = false
+        }
+
+        override fun onDestinationPreview() {
+            inRoutePreview = false
+        }
+
+        override fun onRoutePreview() {
+            inRoutePreview = true
+        }
+
+        override fun onActiveNavigation() {
+            inRoutePreview = false
+        }
+
+        override fun onArrival() {
+            inRoutePreview = false
+        }
+
+        override fun onBackPressed(): Boolean {
+            if (inRoutePreview) {
+                binding.navigationView.api.startFreeDrive()
+                return true
+            }
+            return super.onBackPressed()
         }
     }
 


### PR DESCRIPTION
Closes [#1938](https://github.com/mapbox/navigation-sdks/issues/1938)

### Description

- Added `NavigationViewListener.onBackPressed()`
- Updated `OnKeyListenerComponent` to preprocess all key event with delegate `View.OnKeyListener`
- Updated `NavigationViewListenerRegistry` to implement `View.OnKeyListener` interface and call   `NavigationViewListener.onBackPressed()` when hardware back press button is detected.

### Screenshots or Gifs

_Recording of QA Test App captured on Pixel 6_

https://user-images.githubusercontent.com/2678039/187529628-0d7821d6-e430-4262-bbf8-4ce9422be637.mp4

The "Default NavigationView" Activity uses the default BACK press behaviour
```
FreeDrive -> Destination Preview -> Route Preview -> Active Guidance
FreeDrive <- Destination Preview <- Route Preview <- Active Guidance
```

The "Customized NavigationView" Activity intercepts BACK press when in **Route Preview** state and requests transition to **Free Drive** instead.
```
FreeDrive -> Destination Preview -> Route Preview -> Active Guidance
FreeDrive <------------------------ Route Preview <- Active Guidance
```