### PR TITLE
Fix `MapboxNavigation#detach` issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed incorrect values in `AlternativeRouteInfo#duration` and `RouteProgress#durationRemaining`: now they rely on `route.leg.annotations.duration` if available, otherwise, `LegStep#duration` is used for calculations. [#6237](https://github.com/mapbox/mapbox-navigation-android/pull/6237)
 - Added `guideMapUri` to the `RestStop`. [#6237](https://github.com/mapbox/mapbox-navigation-android/pull/6237)
 - [TileStore Android Service] Fixed a crash when the service process is killed by the Android system. [#6237](https://github.com/mapbox/mapbox-navigation-android/pull/6237)
+- Fixed `MapboxNavigationApp#detach` will not fully detach. This causes `MapboxNavigation` to continue to be accessible, and causes `MapboxNavigationObserver.onDetached` to be called multiple times.
 
 ## Mapbox Navigation SDK 2.8.0-beta.1 - 25 August, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
@@ -60,6 +60,8 @@ internal class MapboxNavigationOwner {
             attached = false
             services.forEach { it.onDetached(mapboxNavigation!!) }
             MapboxNavigationProvider.destroy()
+            mapboxNavigation = null
+            logI("disabled ${services.size} observers", LOG_CATEGORY)
         }
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
@@ -275,6 +275,23 @@ class MapboxNavigationAppDelegateTest {
     }
 
     @Test
+    fun `verify disable will detach and current becomes null`() {
+        mapboxNavigationApp.setup { navigationOptions }
+
+        val testLifecycleOwner = CarAppLifecycleOwnerTest.TestLifecycleOwner()
+        mapboxNavigationApp.attach(testLifecycleOwner)
+        testLifecycleOwner.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
+
+        val observer = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationApp.registerObserver(observer)
+        mapboxNavigationApp.disable()
+        mapboxNavigationApp.unregisterObserver(observer)
+
+        assertNull(MapboxNavigationApp.current())
+        verify(exactly = 1) { observer.onDetached(any()) }
+    }
+
+    @Test
     fun `verify current is null when all lifecycle owners are destroyed`() {
         mapboxNavigationApp.setup { navigationOptions }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Found this issue while testing this https://github.com/mapbox/mapbox-navigation-android/pull/6233

`mapboxNavigation` is still valid after calling `detach`. This means all calls to `current()` will return non-null, and if you unregister an observer it can result detach calls after it has been disabled. It is expected, to have a single onDetached call per every onAttached.

I separated this pull request from 6233 because it would definitely impact anyone using `detach`.