### PR TITLE
add ability to observe when info panel is dragging or settling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed incorrect values in `AlternativeRouteInfo#duration` and `RouteProgress#durationRemaining`: now they rely on `route.leg.annotations.duration` if available, otherwise, `LegStep#duration` is used for calculations. [#6237](https://github.com/mapbox/mapbox-navigation-android/pull/6237)
 - Added `guideMapUri` to the `RestStop`. [#6237](https://github.com/mapbox/mapbox-navigation-android/pull/6237)
 - [TileStore Android Service] Fixed a crash when the service process is killed by the Android system. [#6237](https://github.com/mapbox/mapbox-navigation-android/pull/6237)
-- Fixed `MapboxNavigationApp#detach` will not fully detach. This causes `MapboxNavigation` to continue to be accessible, and causes `MapboxNavigationObserver.onDetached` to be called multiple times.
+- Fixed `MapboxNavigationApp#detach` will not fully detach. This causes `MapboxNavigation` to continue to be accessible, and causes `MapboxNavigationObserver.onDetached` to be called multiple times. [#6245](https://github.com/mapbox/mapbox-navigation-android/pull/6245)
+- Introduced `NavigationViewListener#onInfoPanelDragging` to inform user when `InfoPanel` is dragging. [#6249](https://github.com/mapbox/mapbox-navigation-android/pull/6249)
+- Introduced `NavigationViewListener#onInfoPanelSettling` to inform user when `InfoPanel` is settling. [#6249](https://github.com/mapbox/mapbox-navigation-android/pull/6249)
 
 ## Mapbox Navigation SDK 2.8.0-beta.1 - 25 August, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
@@ -120,4 +120,14 @@ abstract class NavigationViewListener {
      * Called when the info panel behavior updates to collapsed.
      */
     open fun onInfoPanelCollapsed() = Unit
+
+    /**
+     * Called when the info panel behavior updates to dragging.
+     */
+    open fun onInfoPanelDragging() = Unit
+
+    /**
+     * Called when the info panel behavior updates to settling.
+     */
+    open fun onInfoPanelSettling() = Unit
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
@@ -95,6 +95,8 @@ internal class NavigationViewListenerRegistry(
                             BottomSheetBehavior.STATE_HIDDEN -> listener.onInfoPanelHidden()
                             BottomSheetBehavior.STATE_EXPANDED -> listener.onInfoPanelExpanded()
                             BottomSheetBehavior.STATE_COLLAPSED -> listener.onInfoPanelCollapsed()
+                            BottomSheetBehavior.STATE_DRAGGING -> listener.onInfoPanelDragging()
+                            BottomSheetBehavior.STATE_SETTLING -> listener.onInfoPanelSettling()
                         }
                     }
             }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistryTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistryTest.kt
@@ -273,6 +273,31 @@ class NavigationViewListenerRegistryTest {
         }
     }
 
+    @Test
+    fun onInfoPanelDragging() {
+        sut.registerListener(testListener)
+        val newState = BottomSheetBehavior.STATE_DRAGGING
+
+        infoPanelBehaviorFlow.value = newState
+
+        verify {
+            testListener.onInfoPanelDragging()
+        }
+    }
+
+    @Test
+    fun onInfoPanelSettling() {
+        sut.registerListener(testListener)
+        val newState = BottomSheetBehavior.STATE_SETTLING
+
+        infoPanelBehaviorFlow.value = newState
+
+        verify {
+            testListener.onInfoPanelSettling()
+        }
+    }
+
+    @Test
     fun `onRouteFetching should NOT notify listener if requestId is 0`() {
         sut.registerListener(testListener)
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/LoggingNavigationViewListener.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/LoggingNavigationViewListener.kt
@@ -90,6 +90,14 @@ class LoggingNavigationViewListener(
         log("listener onInfoPanelCollapsed")
     }
 
+    override fun onInfoPanelDragging() {
+        log("listener onInfoPanelDragging")
+    }
+
+    override fun onInfoPanelSettling() {
+        log("listener onInfoPanelSettling")
+    }
+
     private fun log(message: String) {
         logD(message, tag)
     }


### PR DESCRIPTION
### Description
Refs #6212.
In 1TAP we would like to know when info panel is dragging. Also added support for observing settling state. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
