### PR TITLE
Improved progress state handling when setting new routes fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Mapbox welcomes participation and contributions from everyone.
 - Added Android 13 support. [#6196](https://github.com/mapbox/mapbox-navigation-android/pull/6196)
 - Declared [POST_NOTIFICATIONS](https://developer.android.com/reference/android/Manifest.permission#POST_NOTIFICATIONS) permission in SDK's AndroidManifest.xml. It is highly recommended for apps to request the permission in runtime. Without it, the SDK will not be able to show the notification with trip progress in the notification drawer for apps that target Android 13 or higher. [#6196](https://github.com/mapbox/mapbox-navigation-android/pull/6196)
 - Marked `MapboxNavigationApp` and `MapboxMavigationObserver` methods with `@UiThread` annotations. [#6254](https://github.com/mapbox/mapbox-navigation-android/pull/6254)
+- Fixed an issue where `RouteProgress#navigationRoute` could have been delivered with an incorrect route reference, if setting routes failed as reported by `RoutesSetCallback`. [#6255](https://github.com/mapbox/mapbox-navigation-android/pull/6255)
+- Expanded debug and warning logs around `RouteProgress` generation and route setting processes, including when incorrect progress is delivered to `MapboxRouteLineApi#updateWithRouteProgress`. [#6255](https://github.com/mapbox/mapbox-navigation-android/pull/6255)
 
 ## Mapbox Navigation SDK 2.8.0-beta.1 - 25 August, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -889,7 +889,10 @@ class MapboxNavigation @VisibleForTesting internal constructor(
                         )
                     }
                     is NativeSetRouteError -> {
-                        logE("Routes $routes will be ignored as they are not valid")
+                        logE(
+                            "Routes with IDs ${routes.map { it.id }} " +
+                                "will be ignored as they are not valid"
+                        )
                         routesSetResult = ExpectedFactory.createError(
                             RoutesSetError(processedRoutes.error)
                         )

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -31,7 +31,6 @@ import com.mapbox.navigator.BannerInstruction
 import com.mapbox.navigator.BannerSection
 import com.mapbox.navigator.NavigationStatus
 import com.mapbox.navigator.Navigator
-import com.mapbox.navigator.RouteInfo
 import com.mapbox.navigator.RouteState
 import com.mapbox.navigator.SpeedLimitSign
 import com.mapbox.navigator.SpeedLimitUnit
@@ -39,8 +38,6 @@ import com.mapbox.navigator.VoiceInstruction
 
 private const val ONE_INDEX = 1
 private const val ONE_SECOND_IN_MILLISECONDS = 1000.0
-
-internal fun getRouteInitInfo(routeInfo: RouteInfo?) = routeInfo.toRouteInitInfo()
 
 /**
  * Builds [RouteProgress] object based on [NavigationStatus] returned by [Navigator]
@@ -273,12 +270,6 @@ internal fun RouteState.convertState(): RouteProgressState {
         RouteState.COMPLETE -> RouteProgressState.COMPLETE
         RouteState.OFF_ROUTE -> RouteProgressState.OFF_ROUTE
         RouteState.UNCERTAIN -> RouteProgressState.UNCERTAIN
-    }
-}
-
-private fun RouteInfo?.toRouteInitInfo(): RouteInitInfo? {
-    return this?.let {
-        RouteInitInfo(alerts.toUpcomingRoadObjects())
     }
 }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/RouteInitInfo.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/RouteInitInfo.kt
@@ -1,7 +1,0 @@
-package com.mapbox.navigation.core.navigator
-
-import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
-
-internal data class RouteInitInfo(
-    val roadObjects: List<UpcomingRoadObject>
-)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/BannerInstructionsObserverRecorder.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/BannerInstructionsObserverRecorder.kt
@@ -1,0 +1,14 @@
+package com.mapbox.navigation.core.infra.recorders
+
+import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
+
+class BannerInstructionsObserverRecorder : BannerInstructionsObserver {
+
+    private val _records = mutableListOf<BannerInstructions>()
+    val records: List<BannerInstructions> get() = _records
+
+    override fun onNewBannerInstructions(bannerInstructions: BannerInstructions) {
+        _records.add(bannerInstructions)
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/OffRouteObserverRecorder.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/OffRouteObserverRecorder.kt
@@ -1,0 +1,13 @@
+package com.mapbox.navigation.core.infra.recorders
+
+import com.mapbox.navigation.core.trip.session.OffRouteObserver
+
+class OffRouteObserverRecorder : OffRouteObserver {
+
+    private val _records = mutableListOf<Boolean>()
+    val records: List<Boolean> get() = _records
+
+    override fun onOffRouteStateChanged(offRoute: Boolean) {
+        _records.add(offRoute)
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/RoadObjectsOnRouteObserverRecorder.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/infra/recorders/RoadObjectsOnRouteObserverRecorder.kt
@@ -1,0 +1,14 @@
+package com.mapbox.navigation.core.infra.recorders
+
+import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
+import com.mapbox.navigation.core.trip.session.RoadObjectsOnRouteObserver
+
+class RoadObjectsOnRouteObserverRecorder : RoadObjectsOnRouteObserver {
+
+    private val _records = mutableListOf<List<UpcomingRoadObject>>()
+    val records: List<List<UpcomingRoadObject>> get() = _records
+
+    override fun onNewRoadObjectsOnTheRoute(roadObjects: List<UpcomingRoadObject>) {
+        _records.add(roadObjects)
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -11,7 +11,6 @@ import com.mapbox.navigation.base.internal.factory.RouteStepProgressFactory.buil
 import com.mapbox.navigation.base.road.model.Road
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.speed.model.SpeedLimit
-import com.mapbox.navigation.base.trip.model.roadobject.RoadObjectType
 import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import com.mapbox.navigation.navigator.internal.TripStatus
 import com.mapbox.navigation.testing.FileUtils
@@ -22,7 +21,6 @@ import com.mapbox.navigator.RoadObject
 import com.mapbox.navigator.RoadObjectMetadata
 import com.mapbox.navigator.RoadObjectProvider
 import com.mapbox.navigator.RouteAlertLocation
-import com.mapbox.navigator.RouteInfo
 import com.mapbox.navigator.RouteState
 import com.mapbox.navigator.SpeedLimitSign
 import com.mapbox.navigator.SpeedLimitUnit
@@ -449,22 +447,6 @@ class NavigatorMapperTest {
         )
 
         assertFalse(routeProgress!!.stale)
-    }
-
-    @Test
-    fun `route init info is null when route info is null`() {
-        assertNull(getRouteInitInfo(null))
-    }
-
-    @Test
-    @Ignore("https://github.com/mapbox/mapbox-navigation-native/issues/3456")
-    fun `alerts are present in the route init info is they are delivered from native`() {
-        val routeInfo = RouteInfo(listOf(tunnel.toUpcomingRouteAlert()))
-
-        val result = getRouteInitInfo(routeInfo)!!
-
-        assertEquals(1, result.roadObjects.size)
-        assertEquals(RoadObjectType.TUNNEL, result.roadObjects[0].roadObject.objectType)
     }
 
     @Test

--- a/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
+++ b/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
@@ -9,10 +9,12 @@ import com.mapbox.navigation.base.internal.SDKRouteParser
 import com.mapbox.navigation.base.internal.utils.mapToNativeRouteOrigin
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigator.RouteInfo
 import com.mapbox.navigator.RouteInterface
 
 fun createNavigationRoute(
-    directionsRoute: DirectionsRoute = createDirectionsRoute()
+    directionsRoute: DirectionsRoute = createDirectionsRoute(),
+    routeInfo: RouteInfo = RouteInfo(emptyList())
 ): NavigationRoute {
     return com.mapbox.navigation.base.internal.route.createNavigationRoute(
         directionsRoute,
@@ -30,7 +32,8 @@ fun createNavigationRoute(
                             responseJson = response,
                             routerOrigin = routerOrigin.mapToNativeRouteOrigin(),
                             requestURI = directionsRoute.routeOptions()!!.toUrl("pk.*test_token*")
-                                .toString()
+                                .toString(),
+                            routeInfo = routeInfo
                         ),
                     )
                 )


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
This PR fixes an issue where route progress and the cached route instance inside of `MapboxTripSession` would be cleared or incorrectly reset when setting new routes to Nav Native would fail. In these instances, we should continue as if there was no update. This is especially important because before the changes `MapboxTripSession` would attempt to work with a new route reference (that we failed to set to Nav Native) which was never delivered through the `RoutesObserver` (because the update failed).

There are also additional logs sprinkled across the codebase and a new check in `MapboxRouteLineApi` that aborts updating state with a `RouteProgress` update that belongs to a route reference which wasn't set to `MapboxRouteLineApi`, which could be a symptom of the above mentioned faulty state.

I also cleaned up the `RouteInitInfo` class to simplify writing tests.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
