### PR TITLE
add changelog for androidauto-0.9.0

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -4,11 +4,25 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+#### Bug fixes and improvements
+
+## androidauto-v0.9.0 - Sep 1, 2022
+### Changelog
+[Changes between 0.8.0 and 0.9.0](https://github.com/mapbox/mapbox-navigation-android/compare/androidauto-v0.8.0...androidauto-v0.9.0)
+
+#### Features
 - Added support for remote icons in `CarGridFeedbackScreen`. [#6227](https://github.com/mapbox/mapbox-navigation-android/pull/6227)
+
 #### Bug fixes and improvements
 - Removed `MapboxNavigation` from `RoadNameObserver` and `RoadLabelSurfaceLayer` constructor. [#6224](https://github.com/mapbox/mapbox-navigation-android/pull/6224)
 - Removed `MapboxNavigation` form `CarLocationsOverviewCamera` constructor. [#6225](https://github.com/mapbox/mapbox-navigation-android/pull/6225)
 - Removed `MapboxNavigation` from `CarNavigationCamera` and `CarRouteLine` constructors. [#6219](https://github.com/mapbox/mapbox-navigation-android/pull/6219)
+
+### Mapbox dependencies
+This release defines minimum versions for the Mapbox dependencies.
+- Mapbox Maps Android Auto Extension `v0.2.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/extension-androidauto-v0.2.0))
+- Mapbox Navigation `v2.8.0-beta.2` ([release notes](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.8.0-beta.2))
+- Mapbox Search `v1.0.0-beta.35` ([release notes](https://github.com/mapbox/mapbox-search-android/releases/tag/v1.0.0-beta.35))
 
 ## androidauto-v0.8.0 - Aug 18, 2022
 ### Changelog
@@ -116,13 +130,6 @@ This release defines minimum versions for the Mapbox dependencies.
 - Mapbox Maps Android Auto Extension `v0.1.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/extension-androidauto-v0.1.0))
 - Mapbox Navigation `v2.5.0-rc.1` ([release notes](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.5.0-rc.1))
 - Mapbox Search `v1.0.0-beta.29` ([release notes](https://github.com/mapbox/mapbox-search-android/releases/tag/v1.0.0-beta.29))
-
-#### Features
- - Added notification interceptor for Android Auto. [#5778](https://github.com/mapbox/mapbox-navigation-android/pull/5778)
-
-#### Bug fixes and improvements
- - Remove extra arrival feedback options. [#5805](https://github.com/mapbox/mapbox-navigation-android/pull/5805)
- - Fixed an issue when the first voice instruction was not played. [#5825](https://github.com/mapbox/mapbox-navigation-android/pull/5825)
 
 ## androidauto-v0.1.0 - May 05, 2022
 

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     // This defines the minimum version of Maps, Navigation, and Search which are included in
     // this SDK. To upgrade the SDK versions, you can specify a newer version in your downstream
     // build.gradle.
-    def carNavVersion = "2.8.0-alpha.3"
+    def carNavVersion = "2.8.0-beta.2"
     def carSearchVersion = "1.0.0-beta.35"
     api("com.mapbox.navigation:android:${carNavVersion}")
     api("com.mapbox.search:mapbox-search-android:${carSearchVersion}")


### PR DESCRIPTION
## androidauto-v0.9.0 - Sep 1, 2022
### Changelog
[Changes between 0.8.0 and 0.9.0](https://github.com/mapbox/mapbox-navigation-android/compare/androidauto-v0.8.0...androidauto-v0.9.0)

#### Features
- Added support for remote icons in `CarGridFeedbackScreen`. [#6227](https://github.com/mapbox/mapbox-navigation-android/pull/6227)

#### Bug fixes and improvements
- Removed `MapboxNavigation` from `RoadNameObserver` and `RoadLabelSurfaceLayer` constructor. [#6224](https://github.com/mapbox/mapbox-navigation-android/pull/6224)
- Removed `MapboxNavigation` form `CarLocationsOverviewCamera` constructor. [#6225](https://github.com/mapbox/mapbox-navigation-android/pull/6225)
- Removed `MapboxNavigation` from `CarNavigationCamera` and `CarRouteLine` constructors. [#6219](https://github.com/mapbox/mapbox-navigation-android/pull/6219)

### Mapbox dependencies
This release defines minimum versions for the Mapbox dependencies.
- Mapbox Maps Android Auto Extension `v0.2.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/extension-androidauto-v0.2.0))
- Mapbox Navigation `v2.8.0-beta.2` ([release notes](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.8.0-beta.2))
- Mapbox Search `v1.0.0-beta.35` ([release notes](https://github.com/mapbox/mapbox-search-android/releases/tag/v1.0.0-beta.35))
