### PR TITLE
prefer active routes to preview ones in camera component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Introduced `MapboxRestAreaApi#generateUpcomingRestAreaGuideMap` to be used to fetch service/parking area guide maps using `RestStop`. [#6239](https://github.com/mapbox/mapbox-navigation-android/pull/6239)
 #### Bug fixes and improvements
 - Fixed an issue with `NavigationView` that caused overview camera to have wrong pitch. [#6278](https://github.com/mapbox/mapbox-navigation-android/pull/6278)
+- Fixed an issue with `NavigationView` that caused camera issues after reroute or switching to an alternative route. [#6283](https://github.com/mapbox/mapbox-navigation-android/pull/6283)
 
 ## Mapbox Navigation SDK 2.8.0-beta.2 - 01 September, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/camera/CameraComponent.kt
@@ -204,12 +204,10 @@ internal class CameraComponent constructor(
                 routesFlow,
                 navigation
             ) { previewRoutes, navigationRoutes, navigationState ->
-                val routes = if (previewRoutes is RoutePreviewState.Ready) {
-                    previewRoutes.routes
-                } else if (navigationRoutes.isNotEmpty()) {
-                    navigationRoutes
-                } else {
-                    emptyList()
+                val routes = when {
+                    navigationRoutes.isNotEmpty() -> navigationRoutes
+                    previewRoutes is RoutePreviewState.Ready -> previewRoutes.routes
+                    else -> emptyList()
                 }
                 when (routes.isNotEmpty()) {
                     true -> {


### PR DESCRIPTION
### Description
Refs #6251. This fixes issues with numbers 1 and 4. Preview routes are not updated after reroute or switching to alternative, that's why we should prefer active routes. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
