### PR TITLE
Updated QA route line related activities

### DIFF
--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -54,6 +54,13 @@ object TestActivitySuite {
             activity.startActivity<AppLifecycleActivity>()
         },
         TestActivityDescription(
+            "Display Road Objects",
+            R.string.road_object_activity_description,
+            launchAfterPermissionResult = false,
+        ) { activity ->
+            activity.startActivity<RoadObjectsActivity>()
+        },
+        TestActivityDescription(
             "Alternative Route Selection",
             R.string.alternative_route_selection_description,
         ) { activity ->
@@ -71,13 +78,6 @@ object TestActivitySuite {
             launchAfterPermissionResult = false,
         ) { activity ->
             activity.startActivity<RouteRestrictionsActivity>()
-        },
-        TestActivityDescription(
-            "Display Road Objects",
-            R.string.road_object_activity_description,
-            launchAfterPermissionResult = false,
-        ) { activity ->
-            activity.startActivity<RoadObjectsActivity>()
         },
         TestActivityDescription(
             "Dynamic Traffic Update",

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/RouteRestrictionsActivity.kt
@@ -17,6 +17,9 @@ import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.locationcomponent.OnIndicatorPositionChangedListener
 import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.base.route.toNavigationRoute
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
 import com.mapbox.navigation.core.replay.MapboxReplayer
@@ -39,7 +42,6 @@ import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
-import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
 
@@ -118,6 +120,11 @@ class RouteRestrictionsActivity : AppCompatActivity() {
         MapboxRouteArrowView(routeArrowOptions)
     }
 
+    private val navigationRoute: NavigationRoute by lazy {
+        val routeAsString = Utils.readRawFileText(this, R.raw.route_with_restrictions)
+        DirectionsRoute.fromJson(routeAsString).toNavigationRoute(RouterOrigin.Offboard)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
@@ -146,24 +153,29 @@ class RouteRestrictionsActivity : AppCompatActivity() {
         binding.mapView.getMapboxMap().loadStyleUri(
             NavigationStyles.NAVIGATION_DAY_STYLE
         ) { style ->
-
-            val route = getRoute()
-            routeLineApi.setRoutes(listOf(RouteLine(route, null))) {
+            routeLineApi.setNavigationRoutes(listOf(navigationRoute)) {
                 routeLineView.renderRouteDrawData(style, it)
             }
 
-            val routeOrigin = getRouteOriginPoint(route)
+            val routeOrigin = getRouteOriginPoint(navigationRoute.directionsRoute)
             val cameraOptions = CameraOptions.Builder().center(routeOrigin).zoom(15.0).build()
             binding.mapView.getMapboxMap().setCamera(cameraOptions)
         }
     }
 
     private fun initNavigation() {
+        val startingLocation = Location("ReplayRoute").also {
+            val routeOrigin = Utils.getRouteOriginPoint(navigationRoute.directionsRoute)
+            it.latitude = routeOrigin.latitude()
+            it.longitude = routeOrigin.longitude()
+        }
+        navigationLocationProvider.changePosition(startingLocation)
         binding.mapView.location.apply {
             setLocationProvider(navigationLocationProvider)
             enabled = true
         }
-        mapboxNavigation.setRoutes(listOf(getRoute()))
+        mapboxNavigation.setRerouteController(null)
+        mapboxNavigation.setNavigationRoutes(listOf(navigationRoute))
         mapboxNavigation.registerLocationObserver(locationObserver)
         mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
         mapboxReplayer.pushRealLocation(this, 0.0)
@@ -177,11 +189,13 @@ class RouteRestrictionsActivity : AppCompatActivity() {
         }
 
         override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
-            navigationLocationProvider.changePosition(
-                locationMatcherResult.enhancedLocation,
-                locationMatcherResult.keyPoints,
-            )
-            updateCamera(locationMatcherResult.enhancedLocation)
+            if (locationMatcherResult.enhancedLocation.provider == "ReplayRoute") {
+                navigationLocationProvider.changePosition(
+                    locationMatcherResult.enhancedLocation,
+                    locationMatcherResult.keyPoints,
+                )
+                updateCamera(locationMatcherResult.enhancedLocation)
+            }
         }
     }
 
@@ -240,9 +254,4 @@ class RouteRestrictionsActivity : AppCompatActivity() {
     }
 
     private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
-
-    private fun getRoute(): DirectionsRoute {
-        val routeAsString = Utils.readRawFileText(this, R.raw.route_with_restrictions)
-        return DirectionsRoute.fromJson(routeAsString)
-    }
 }


### PR DESCRIPTION
### Description
Some recent route line related API modifications check for matching route ID's in order to update the vanishing route line.  These changes broke a couple QA app. activities which use the deprecated `DirectionsRotue` rather than `NavigationRoute`.  Minor updates fix these activities. 

### Screenshots or Gifs

