### PR TITLE
Introduced new state flow to `MapboxManeuverView` to allow users to observe maneuver view expand/collapse state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Mapbox welcomes participation and contributions from everyone.
 - Implemented continuous alternatives in Drop-In UI. [#6213](https://github.com/mapbox/mapbox-navigation-android/pull/6213)
 - Introduced `MapboxRestAreaApi#generateRestAreaGuideMap` to be used to fetch service/parking area guide maps using `BannerInstruction`. [#6239](https://github.com/mapbox/mapbox-navigation-android/pull/6239)
 - Introduced `MapboxRestAreaApi#generateUpcomingRestAreaGuideMap` to be used to fetch service/parking area guide maps using `RestStop`. [#6239](https://github.com/mapbox/mapbox-navigation-android/pull/6239)
+- Introduced `MapboxManeuverView#maneuverViewState` to allow users to observe changes to `MapboxManeuverViewState` when the view expands and collapses. [#6286](https://github.com/mapbox/mapbox-navigation-android/pull/6286)
+- Introduced `NavigationViewApi#onManeuverCollapsed` and `NavigationViewApi#onManeuverExpanded` callback which is triggered upon changes to `MapboxManeuverViewState`. [#6286](https://github.com/mapbox/mapbox-navigation-android/pull/6286)
 #### Bug fixes and improvements
 - Fixed an issue with `NavigationView` that caused overview camera to have wrong pitch. [#6278](https://github.com/mapbox/mapbox-navigation-android/pull/6278)
 - Fixed an issue with `NavigationView` that caused camera issues after reroute or switching to an alternative route. [#6283](https://github.com/mapbox/mapbox-navigation-android/pull/6283)

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -92,6 +92,8 @@ package com.mapbox.navigation.dropin {
     method public void onInfoPanelExpanded();
     method public void onInfoPanelHidden();
     method public void onInfoPanelSettling();
+    method public void onManeuverCollapsed();
+    method public void onManeuverExpanded();
     method public void onOverviewCameraMode();
     method public void onRouteFetchCanceled(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.RouterOrigin routerOrigin);
     method public void onRouteFetchFailed(java.util.List<com.mapbox.navigation.base.route.RouterFailure> reasons, com.mapbox.api.directions.v5.models.RouteOptions routeOptions);

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.lifecycleScope
 import com.mapbox.maps.MapView
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.component.infopanel.InfoPanelBehavior
+import com.mapbox.navigation.dropin.component.maneuver.ManeuverBehavior
 import com.mapbox.navigation.dropin.component.marker.MapMarkerFactory
 import com.mapbox.navigation.dropin.util.BitmapMemoryCache
 import com.mapbox.navigation.dropin.util.BitmapMemoryCache.Companion.MB_IN_BYTES
@@ -40,12 +41,14 @@ internal class NavigationViewContext(
     val uiBinders = ViewBinder()
     val styles = NavigationViewStyles(context)
     val options = NavigationViewOptions(context)
+    val maneuverBehavior = ManeuverBehavior()
     val infoPanelBehavior = InfoPanelBehavior()
     val mapViewOwner = MapViewOwner()
     val mapStyleLoader = MapStyleLoader(context, options)
     val listenerRegistry by lazy {
         NavigationViewListenerRegistry(
             store,
+            maneuverBehavior,
             infoPanelBehavior,
             lifecycleOwner.lifecycleScope
         )

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListener.kt
@@ -137,4 +137,14 @@ abstract class NavigationViewListener {
      * @return True if the listener has consumed the event, false otherwise.
      */
     open fun onBackPressed(): Boolean = false
+
+    /**
+     * Called when maneuver view has been expanded.
+     */
+    open fun onManeuverExpanded() = Unit
+
+    /**
+     * Called when maneuver view has been collapsed.
+     */
+    open fun onManeuverCollapsed() = Unit
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewListenerRegistry.kt
@@ -5,10 +5,12 @@ import android.view.View
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.component.infopanel.InfoPanelBehavior
+import com.mapbox.navigation.dropin.component.maneuver.ManeuverBehavior
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.camera.TargetCameraMode
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
+import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
@@ -18,6 +20,7 @@ import kotlinx.coroutines.launch
 @ExperimentalPreviewMapboxNavigationAPI
 internal class NavigationViewListenerRegistry(
     private val store: Store,
+    private val maneuverSubscriber: ManeuverBehavior,
     private val infoPanelSubscriber: InfoPanelBehavior,
     private val coroutineScope: CoroutineScope
 ) : View.OnKeyListener {
@@ -112,6 +115,21 @@ internal class NavigationViewListenerRegistry(
                             BottomSheetBehavior.STATE_COLLAPSED -> listener.onInfoPanelCollapsed()
                             BottomSheetBehavior.STATE_DRAGGING -> listener.onInfoPanelDragging()
                             BottomSheetBehavior.STATE_SETTLING -> listener.onInfoPanelSettling()
+                        }
+                    }
+            }
+
+            launch {
+                maneuverSubscriber
+                    .maneuverBehavior
+                    .collect { behavior ->
+                        when (behavior) {
+                            MapboxManeuverViewState.EXPANDED -> {
+                                listener.onManeuverExpanded()
+                            }
+                            MapboxManeuverViewState.COLLAPSED -> {
+                                listener.onManeuverCollapsed()
+                            }
                         }
                     }
             }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehavior.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehavior.kt
@@ -1,0 +1,17 @@
+package com.mapbox.navigation.dropin.component.maneuver
+
+import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal class ManeuverBehavior {
+
+    private val _maneuverBehavior = MutableStateFlow<MapboxManeuverViewState>(
+        MapboxManeuverViewState.COLLAPSED
+    )
+    val maneuverBehavior = _maneuverBehavior.asStateFlow()
+
+    fun updateBehavior(newState: MapboxManeuverViewState) {
+        _maneuverBehavior.value = newState
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImpl.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImpl.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.dropin.component.maneuver
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.ui.maneuver.internal.ManeuverComponentContract
+import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class ManeuverComponentContractImpl(
+    val context: NavigationViewContext
+) : ManeuverComponentContract {
+
+    override fun onManeuverViewStateChanged(state: MapboxManeuverViewState) {
+        context.maneuverBehavior.updateBehavior(state)
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverViewBinder.kt
@@ -7,6 +7,7 @@ import com.mapbox.maps.Style
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxManeuverGuidanceLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.reloadOnChange
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 internal class ManeuverViewBinder(
+    private val context: NavigationViewContext,
     private val loadedMapStyle: StateFlow<Style?>,
     private val formatterOptions: StateFlow<DistanceFormatterOptions>,
     private val maneuverViewOptions: StateFlow<ManeuverViewOptions>,
@@ -43,7 +45,8 @@ internal class ManeuverViewBinder(
                     userId = mapStyle.getUserId(),
                     styleId = mapStyle.getStyleId(),
                     options = options,
-                    formatterOptions = distanceFormatterOptions
+                    formatterOptions = distanceFormatterOptions,
+                    contract = { ManeuverComponentContractImpl(context) }
                 )
             } else {
                 null

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ManeuverCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ManeuverCoordinator.kt
@@ -32,6 +32,7 @@ internal class ManeuverCoordinator(
                 context.uiBinders.maneuver.map {
                     if (navigationState == NavigationState.ActiveNavigation) {
                         it ?: ManeuverViewBinder(
+                            context,
                             context.mapStyleLoader.loadedMapStyle,
                             context.options.distanceFormatterOptions,
                             context.styles.maneuverViewOptions,

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehaviorTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehaviorTest.kt
@@ -1,0 +1,17 @@
+package com.mapbox.navigation.dropin.component.maneuver
+
+import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ManeuverBehaviorTest {
+
+    @Test
+    fun `when maneuver behavior is updated`() {
+        val sut = ManeuverBehavior()
+
+        sut.updateBehavior(MapboxManeuverViewState.EXPANDED)
+
+        assertEquals(MapboxManeuverViewState.EXPANDED, sut.maneuverBehavior.value)
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImplTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImplTest.kt
@@ -3,12 +3,11 @@ package com.mapbox.navigation.dropin.component.maneuver
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.just
 import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
 import io.mockk.verify
-
 import org.junit.Test
 
 @ExperimentalPreviewMapboxNavigationAPI

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImplTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImplTest.kt
@@ -1,0 +1,30 @@
+package com.mapbox.navigation.dropin.component.maneuver
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.just
+import io.mockk.Runs
+import io.mockk.verify
+
+import org.junit.Test
+
+@ExperimentalPreviewMapboxNavigationAPI
+class ManeuverComponentContractImplTest {
+
+    @Test
+    fun `when maneuver view state is changed, contract is notified`() {
+        val navigationViewContext: NavigationViewContext = mockk(relaxed = true) {
+            every { maneuverBehavior.updateBehavior(any()) } just Runs
+        }
+        val sut = ManeuverComponentContractImpl(navigationViewContext)
+
+        sut.onManeuverViewStateChanged(MapboxManeuverViewState.EXPANDED)
+
+        verify {
+            navigationViewContext.maneuverBehavior.updateBehavior(MapboxManeuverViewState.EXPANDED)
+        }
+    }
+}

--- a/libnavui-maneuver/api/current.txt
+++ b/libnavui-maneuver/api/current.txt
@@ -999,6 +999,7 @@ package com.mapbox.navigation.ui.maneuver.view {
     ctor public MapboxManeuverView(android.content.Context context, android.util.AttributeSet? attrs);
     ctor public MapboxManeuverView(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr, com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions options = ManeuverViewOptions.<init>().build());
     ctor public MapboxManeuverView(android.content.Context context, android.util.AttributeSet? attrs, int defStyleAttr);
+    method public kotlinx.coroutines.flow.StateFlow<com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState> getManeuverViewState();
     method public boolean getUpcomingManeuverRenderingEnabled();
     method public void renderAddLanes(com.mapbox.navigation.ui.maneuver.model.Lane lane);
     method public void renderDistanceRemaining(com.mapbox.navigation.ui.maneuver.model.StepDistance stepDistance);
@@ -1032,7 +1033,19 @@ package com.mapbox.navigation.ui.maneuver.view {
     method public void updateUpcomingManeuversVisibility(int visibility);
     method @Deprecated public void updateUpcomingPrimaryManeuverTextAppearance(@StyleRes int style);
     method @Deprecated public void updateUpcomingSecondaryManeuverTextAppearance(@StyleRes int style);
+    property public final kotlinx.coroutines.flow.StateFlow<com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState> maneuverViewState;
     property public final boolean upcomingManeuverRenderingEnabled;
+  }
+
+  public abstract sealed class MapboxManeuverViewState {
+  }
+
+  public static final class MapboxManeuverViewState.COLLAPSED extends com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState {
+    field public static final com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState.COLLAPSED INSTANCE;
+  }
+
+  public static final class MapboxManeuverViewState.EXPANDED extends com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState {
+    field public static final com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState.EXPANDED INSTANCE;
   }
 
   public final class MapboxPrimaryManeuver extends androidx.appcompat.widget.AppCompatTextView {

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverView.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverView.kt
@@ -34,6 +34,8 @@ import com.mapbox.navigation.ui.shield.model.RouteShieldError
 import com.mapbox.navigation.ui.shield.model.RouteShieldResult
 import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.navigation.utils.internal.logE
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Default view to render a maneuver.
@@ -41,6 +43,15 @@ import com.mapbox.navigation.utils.internal.logE
  * @see MapboxManeuverApi
  */
 class MapboxManeuverView : ConstraintLayout {
+
+    private val _maneuverViewState = MutableStateFlow<MapboxManeuverViewState>(
+        MapboxManeuverViewState.COLLAPSED
+    )
+
+    /**
+     * Observe on [maneuverViewState] to get notified about changes to [MapboxManeuverViewState].
+     */
+    val maneuverViewState = _maneuverViewState.asStateFlow()
 
     private var maneuverViewOptions = ManeuverViewOptions.Builder().build()
 
@@ -311,6 +322,10 @@ class MapboxManeuverView : ConstraintLayout {
      * @param visibility Int
      */
     fun updateUpcomingManeuversVisibility(visibility: Int) {
+        when (visibility) {
+            VISIBLE -> { _maneuverViewState.value = MapboxManeuverViewState.EXPANDED }
+            else -> { _maneuverViewState.value = MapboxManeuverViewState.COLLAPSED }
+        }
         binding.upcomingManeuverRecycler.visibility = visibility
     }
 

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverViewState.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverViewState.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.ui.maneuver.view
+
+/**
+ * The class informs the user about the state of [MapboxManeuverView].
+ */
+sealed class MapboxManeuverViewState {
+    /**
+     * Notifies the user that [MapboxManeuverView] is in `Expanded` state
+     */
+    object EXPANDED : MapboxManeuverViewState()
+
+    /**
+     * Notifies the user that [MapboxManeuverView] is in `Collapsed` state
+     */
+    object COLLAPSED : MapboxManeuverViewState()
+}

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponentTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponentTest.kt
@@ -25,11 +25,11 @@ import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverViewState
 import com.mapbox.navigation.ui.shield.model.RouteShieldCallback
 import com.mapbox.navigation.ui.shield.model.RouteShieldError
 import com.mapbox.navigation.ui.shield.model.RouteShieldResult
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.just
-import io.mockk.Runs
 import io.mockk.slot
 import io.mockk.unmockkStatic
 import io.mockk.verify

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverViewTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverViewTest.kt
@@ -123,6 +123,18 @@ class MapboxManeuverViewTest {
     }
 
     @Test
+    fun `change maneuver state to expanded on click`() {
+        val view = MapboxManeuverView(ctx)
+        val expected = MapboxManeuverViewState.EXPANDED
+        view.findViewById<RecyclerView>(R.id.upcomingManeuverRecycler).visibility = GONE
+
+        view.performClick()
+        val actual = view.maneuverViewState.value
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `hide maneuver list on click`() {
         val view = MapboxManeuverView(ctx)
         val expected = GONE
@@ -130,6 +142,18 @@ class MapboxManeuverViewTest {
 
         view.performClick()
         val actual = view.findViewById<RecyclerView>(R.id.upcomingManeuverRecycler).visibility
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `change maneuver state to collapsed on click`() {
+        val view = MapboxManeuverView(ctx)
+        val expected = MapboxManeuverViewState.COLLAPSED
+        view.findViewById<RecyclerView>(R.id.upcomingManeuverRecycler).visibility = VISIBLE
+
+        view.performClick()
+        val actual = view.maneuverViewState.value
 
         assertEquals(expected, actual)
     }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/LoggingNavigationViewListener.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/LoggingNavigationViewListener.kt
@@ -98,6 +98,14 @@ class LoggingNavigationViewListener(
         log("listener onInfoPanelSettling")
     }
 
+    override fun onManeuverCollapsed() {
+        log("listener onManeuverCollapsed")
+    }
+
+    override fun onManeuverExpanded() {
+        log("listener onManeuverExpanded")
+    }
+
     private fun log(message: String) {
         logD(message, tag)
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes #6277 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
