### PR TITLE
refresh durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed an issue where step distance in `MapboxManeuverView` could have been cut off. [#6296](https://github.com/mapbox/mapbox-navigation-android/pull/6296)
 - Fixed an issue where trip progress in `MapboxTripProgressView` could have been cut off if large font size is used. [#6296](https://github.com/mapbox/mapbox-navigation-android/pull/6296)
 - Added Experimental API `NavigationRoute#hasUnexpectedClosures` to check if a route has unexpected closures that might require a re-route. [#6295](https://github.com/mapbox/mapbox-navigation-android/pull/6295)
+- Improved route refresh. Now Navigation SDK recalculates `DirectionsRoute#duration`, `RouteLeg#duration`, `LegStep#duration` after route refresh based on `LegAnnotation#duration`. [#6287](https://github.com/mapbox/mapbox-navigation-android/pull/6287) 
 
 ## Mapbox Navigation SDK 2.8.0-beta.2 - 01 September, 2022
 ### Changelog

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -204,16 +204,48 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                 requestedRoutes[0].getDurationAnnotationsFromLeg(0),
                 initialRoutes[0].getDurationAnnotationsFromLeg(0)
             )
-            assertEquals(227.918, initialRoutes[0].getDurationOfLeg(0), 0.0001)
-            assertEquals(287.063, refreshedRoutes[0].getDurationOfLeg(0), 0.0001)
+            assertEquals(
+                227.918,
+                initialRoutes[0].getSumOfDurationAnnotationsFromLeg(0),
+                0.0001
+            )
+            assertEquals(
+                287.063,
+                refreshedRoutes[0].getSumOfDurationAnnotationsFromLeg(0),
+                0.0001
+            )
+            assertEquals(
+                287.063,
+                refreshedRoutes[0].directionsRoute.duration(),
+                0.0001
+            )
+            assertEquals(
+                287.063,
+                refreshedRoutes[0].directionsRoute.legs()!!.first().duration()!!,
+                0.0001
+            )
 
             assertEquals(
-                requestedRoutes[1].getDurationOfLeg(0),
-                initialRoutes[1].getDurationOfLeg(0),
+                requestedRoutes[1].getSumOfDurationAnnotationsFromLeg(0),
+                initialRoutes[1].getSumOfDurationAnnotationsFromLeg(0),
                 0.0
             )
-            assertEquals(224.2239, initialRoutes[1].getDurationOfLeg(0), 0.0001)
-            assertEquals(258.767, refreshedRoutes[1].getDurationOfLeg(0), 0.0001)
+            assertEquals(
+                224.2239,
+                initialRoutes[1].getSumOfDurationAnnotationsFromLeg(0),
+                0.0001
+            )
+            assertEquals(
+                258.767,
+                refreshedRoutes[1].getSumOfDurationAnnotationsFromLeg(0),
+                0.0001
+            )
+            assertEquals(258.767, refreshedRoutes[1].directionsRoute.duration(), 0.0001)
+            assertEquals(
+                258.767,
+                refreshedRoutes[1].directionsRoute.legs()!!.first().duration()!!,
+                0.0001
+            )
         }
 
     @Test
@@ -319,11 +351,11 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                 .first()
                 .navigationRoutes
 
-            assertEquals(224.224, requestedRoutes[0].getDurationOfLeg(0), 0.0001)
-            assertEquals(169.582, refreshedRoutes[0].getDurationOfLeg(0), 0.0001)
+            assertEquals(224.224, requestedRoutes[0].getSumOfDurationAnnotationsFromLeg(0), 0.0001)
+            assertEquals(169.582, refreshedRoutes[0].getSumOfDurationAnnotationsFromLeg(0), 0.0001)
 
-            assertEquals(227.918, requestedRoutes[1].getDurationOfLeg(0), 0.0001)
-            assertEquals(234.024, refreshedRoutes[1].getDurationOfLeg(0), 0.0001)
+            assertEquals(227.918, requestedRoutes[1].getSumOfDurationAnnotationsFromLeg(0), 0.0001)
+            assertEquals(234.024, refreshedRoutes[1].getSumOfDurationAnnotationsFromLeg(0), 0.0001)
         }
 
     @Test
@@ -355,8 +387,8 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                 .first()
                 .navigationRoutes
 
-            assertEquals(201.673, requestedRoutes[0].getDurationOfLeg(1), 0.0001)
-            assertEquals(189.086, refreshedRoutes[0].getDurationOfLeg(1), 0.0001)
+            assertEquals(201.673, requestedRoutes[0].getSumOfDurationAnnotationsFromLeg(1), 0.0001)
+            assertEquals(189.086, refreshedRoutes[0].getSumOfDurationAnnotationsFromLeg(1), 0.0001)
         }
 
     private fun stayOnInitialPosition() {
@@ -432,7 +464,7 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
     }
 }
 
-private fun NavigationRoute.getDurationOfLeg(legIndex: Int): Double =
+private fun NavigationRoute.getSumOfDurationAnnotationsFromLeg(legIndex: Int): Double =
     getDurationAnnotationsFromLeg(legIndex)
         ?.sum()!!
 

--- a/libnavigation-base/build.gradle
+++ b/libnavigation-base/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation dependenciesList.kotlinStdLib
 
     testImplementation project(':libtesting-utils')
+    testImplementation project(':libtesting-navigation-base')
     apply from: "${rootDir}/gradle/unit-testing-dependencies.gradle"
 }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
@@ -3,19 +3,26 @@
 package com.mapbox.navigation.base.internal.route
 
 import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
 import com.mapbox.api.directions.v5.models.Closure
 import com.mapbox.api.directions.v5.models.DirectionsResponse
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.api.directions.v5.models.Incident
 import com.mapbox.api.directions.v5.models.LegAnnotation
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.internal.SDKRouteParser
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.toNavigationRoute
+import com.mapbox.navigation.base.utils.DecodeUtils.stepGeometryToPoints
+import com.mapbox.navigation.utils.internal.logE
 import com.mapbox.navigator.Navigator
 import com.mapbox.navigator.RouteInterface
 import com.mapbox.navigator.RouterOrigin
 import org.jetbrains.annotations.TestOnly
+
+private const val ROUTE_REFRESH_LOG_CATEGORY = "RouteRefresh"
 
 val NavigationRoute.routerOrigin: RouterOrigin get() = nativeRoute.routerOrigin
 
@@ -27,7 +34,9 @@ fun NavigationRoute.nativeRoute(): RouteInterface = this.nativeRoute
 /**
  * Updates route's annotations, incidents, and closures in place while keeping the Native peer as is.
  * The peer should later be updated through [Navigator.refreshRoute].
+ * Call from a worker thread as the function contains geometry parsing under the hood.
  */
+@WorkerThread
 fun NavigationRoute.refreshRoute(
     initialLegIndex: Int,
     currentLegGeometryIndex: Int?,
@@ -55,14 +64,19 @@ fun NavigationRoute.refreshRoute(
                     )
                 }
             routeLeg.toBuilder()
+                .duration(mergedAnnotation?.duration()?.sumOf { it } ?: routeLeg.duration())
                 .annotation(mergedAnnotation)
                 .incidents(incidents?.getOrNull(index))
                 .closures(closures?.getOrNull(index))
+                .steps(routeLeg.steps()?.updateSteps(directionsRoute, mergedAnnotation))
                 .build()
         }
     }
     return updateDirectionsRouteOnly {
-        toBuilder().legs(updateLegs).build()
+        toBuilder()
+            .legs(updateLegs)
+            .updateRouteDurationBasedOnLegsDuration(updateLegs)
+            .build()
     }
 }
 
@@ -110,4 +124,43 @@ fun createNavigationRoutes(
  */
 fun RouteInterface.toNavigationRoute(): NavigationRoute {
     return this.toNavigationRoute()
+}
+
+private fun List<LegStep>.updateSteps(
+    route: DirectionsRoute,
+    mergedAnnotation: LegAnnotation?
+): List<LegStep> {
+    val mergedDurations = mergedAnnotation?.duration() ?: return this
+    val result = mutableListOf<LegStep>()
+    var previousStepsAnnotationsCount = 0
+    forEachIndexed { index, step ->
+        val stepPointsSize = route.stepGeometryToPoints(step).size
+        if (stepPointsSize < 2) {
+            logE(
+                "step at $index has less than 2 points, unable to update duration",
+                ROUTE_REFRESH_LOG_CATEGORY
+            )
+            return this
+        }
+        val stepAnnotationsCount = stepPointsSize - 1
+        val updatedDuration = mergedDurations
+            .drop(previousStepsAnnotationsCount)
+            .take(stepAnnotationsCount)
+            .sum()
+        result.add(step.toBuilder().duration(updatedDuration).build())
+        previousStepsAnnotationsCount += stepAnnotationsCount
+    }
+    return result
+}
+
+private fun DirectionsRoute.Builder.updateRouteDurationBasedOnLegsDuration(
+    updateLegs: List<RouteLeg>?
+): DirectionsRoute.Builder {
+    updateLegs ?: return this
+    var result = 0.0
+    for (leg in updateLegs) {
+        result += leg.duration() ?: return this
+    }
+    duration(result)
+    return this
 }

--- a/libnavigation-base/src/test/resources/3-steps-route-directions-request-url.txt
+++ b/libnavigation-base/src/test/resources/3-steps-route-directions-request-url.txt
@@ -1,0 +1,1 @@
+https://api.mapbox.com/directions/v5/mapbox/driving-traffic/18.576643884351938,54.410360746511714;18.576223679158517,54.41205221865337.json?steps=true&overview=full&geometries=polyline6&roundabout_exits=true&voice_units=imperial&voice_instructions=true&banner_instructions=true&annotations=duration&enable_refresh=true

--- a/libnavigation-base/src/test/resources/3-steps-route-directions-response.json
+++ b/libnavigation-base/src/test/resources/3-steps-route-directions-response.json
@@ -1,0 +1,295 @@
+{
+  "routes": [
+    {
+      "country_crossed": false,
+      "weight_typical": 50.638,
+      "duration_typical": 41.882,
+      "weight_name": "auto",
+      "weight": 50.638,
+      "duration": 41.882,
+      "distance": 234.423,
+      "legs": [
+        {
+          "via_waypoints": [],
+          "admins": [
+            {
+              "iso_3166_1_alpha3": "POL",
+              "iso_3166_1": "PL"
+            }
+          ],
+          "annotation": {
+            "duration": [
+              4.565,
+              4.555,
+              4.512,
+              3.841,
+              15.415,
+              1.507,
+              6.295
+            ]
+          },
+          "weight_typical": 50.638,
+          "duration_typical": 41.882,
+          "weight": 50.638,
+          "duration": 41.882,
+          "steps": [
+            {
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Bolesława Krzywoustego"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right",
+                    "text": "Bolesława Krzywoustego"
+                  },
+                  "distanceAlongGeometry": 190.709
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive northwest on <say-as interpret-as=\"address\">Świętopełka</say-as>. Then Turn right onto <say-as interpret-as=\"address\">Bolesława Krzywoustego</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "Drive northwest on Świętopełka. Then Turn right onto Bolesława Krzywoustego.",
+                  "distanceAlongGeometry": 190.709
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Bolesława Krzywoustego</say-as>. Then Your destination will be on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "Turn right onto Bolesława Krzywoustego. Then Your destination will be on the left.",
+                  "distanceAlongGeometry": 65.833
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true
+                  ],
+                  "bearings": [
+                    321
+                  ],
+                  "duration": 32.888,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 33.71,
+                  "geometry_index": 0,
+                  "location": [
+                    18.576644,
+                    54.410361
+                  ]
+                },
+                {
+                  "bearings": [
+                    77,
+                    166,
+                    258,
+                    356
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "turn_weight": 2,
+                  "turn_duration": 0.014,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 3,
+                  "geometry_index": 5,
+                  "location": [
+                    18.575589,
+                    54.411858
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "depart",
+                "instruction": "Drive northwest on Świętopełka.",
+                "bearing_after": 321,
+                "bearing_before": 0,
+                "location": [
+                  18.576644,
+                  54.410361
+                ]
+              },
+              "name": "Świętopełka",
+              "weight_typical": 37.186,
+              "duration_typical": 34.341,
+              "duration": 34.341,
+              "distance": 190.709,
+              "driving_side": "right",
+              "weight": 37.186,
+              "mode": "driving",
+              "geometry": "qf}wfBgoylb@aJjNyJpLsKtImJbEsm@dSuCR"
+            },
+            {
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Your destination will be on the left"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left",
+                    "text": "Your destination will be on the left"
+                  },
+                  "distanceAlongGeometry": 43.713
+                },
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Your destination is on the left"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left",
+                    "text": "Your destination is on the left"
+                  },
+                  "distanceAlongGeometry": 41.667
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Your destination is on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "Your destination is on the left.",
+                  "distanceAlongGeometry": 41.667
+                }
+              ],
+              "intersections": [
+                {
+                  "bearings": [
+                    0,
+                    76,
+                    176,
+                    256
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 2,
+                  "turn_weight": 7,
+                  "turn_duration": 1.246,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "geometry_index": 6,
+                  "location": [
+                    18.575579,
+                    54.411933
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "turn",
+                "instruction": "Turn right onto Bolesława Krzywoustego.",
+                "modifier": "right",
+                "bearing_after": 76,
+                "bearing_before": 356,
+                "location": [
+                  18.575579,
+                  54.411933
+                ]
+              },
+              "name": "Bolesława Krzywoustego",
+              "weight_typical": 13.452,
+              "duration_typical": 7.541,
+              "duration": 7.541,
+              "distance": 43.713,
+              "driving_side": "right",
+              "weight": 13.452,
+              "mode": "driving",
+              "geometry": "yh`xfBulwlb@wD_h@"
+            },
+            {
+              "bannerInstructions": [],
+              "voiceInstructions": [],
+              "intersections": [
+                {
+                  "bearings": [
+                    256
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "admin_index": 0,
+                  "geometry_index": 7,
+                  "location": [
+                    18.576235,
+                    54.412025
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "arrive",
+                "instruction": "Your destination is on the left.",
+                "modifier": "left",
+                "bearing_after": 0,
+                "bearing_before": 76,
+                "location": [
+                  18.576235,
+                  54.412025
+                ]
+              },
+              "name": "Bolesława Krzywoustego",
+              "weight_typical": 0,
+              "duration_typical": 0,
+              "duration": 0,
+              "distance": 0,
+              "driving_side": "right",
+              "weight": 0,
+              "mode": "driving",
+              "geometry": "qn`xfBuuxlb@??"
+            }
+          ],
+          "distance": 234.423,
+          "summary": "Świętopełka, Bolesława Krzywoustego"
+        }
+      ],
+      "geometry": "qf}wfBgoylb@aJjNyJpLsKtImJbEsm@dSuCRwD_h@",
+      "voiceLocale": "en-US"
+    }
+  ],
+  "waypoints": [
+    {
+      "distance": 0.031,
+      "name": "Świętopełka",
+      "location": [
+        18.576644,
+        54.410361
+      ]
+    },
+    {
+      "distance": 3.084,
+      "name": "Bolesława Krzywoustego",
+      "location": [
+        18.576235,
+        54.412025
+      ]
+    }
+  ],
+  "code": "Ok",
+  "uuid": "vQH1uGFOQJ5rSpxlRrNEM3jrLhJE3IPhcMD_JTHLcDvm5bZUIxvjKA=="
+}

--- a/libnavigation-base/src/test/resources/6-steps-3-waypoints-directions-request-url.txt
+++ b/libnavigation-base/src/test/resources/6-steps-3-waypoints-directions-request-url.txt
@@ -1,0 +1,1 @@
+https://api.mapbox.com/directions/v5/mapbox/driving-traffic/18.576643884351938,54.410360746511714;18.576223679158517,54.41205221865337;18.576850672299827,54.41140274810573.json?steps=true&overview=full&geometries=polyline&roundabout_exits=true&voice_units=imperial&voice_instructions=true&banner_instructions=true&annotations=duration&enable_refresh=true

--- a/libnavigation-base/src/test/resources/6-steps-3-waypoints-directions-response.json
+++ b/libnavigation-base/src/test/resources/6-steps-3-waypoints-directions-response.json
@@ -1,0 +1,581 @@
+{
+  "routes": [
+    {
+      "country_crossed": false,
+      "weight_typical": 80.738,
+      "duration_typical": 63.833,
+      "weight_name": "auto",
+      "weight": 80.738,
+      "duration": 63.833,
+      "distance": 334.476,
+      "legs": [
+        {
+          "via_waypoints": [],
+          "admins": [
+            {
+              "iso_3166_1_alpha3": "POL",
+              "iso_3166_1": "PL"
+            }
+          ],
+          "annotation": {
+            "duration": [
+              4.565,
+              4.555,
+              4.512,
+              3.841,
+              15.415,
+              1.507,
+              6.295
+            ]
+          },
+          "weight_typical": 50.638,
+          "duration_typical": 41.882,
+          "weight": 50.638,
+          "duration": 41.882,
+          "steps": [
+            {
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Bolesława Krzywoustego"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right",
+                    "text": "Bolesława Krzywoustego"
+                  },
+                  "distanceAlongGeometry": 190.709
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive northwest on <say-as interpret-as=\"address\">Świętopełka</say-as>. Then Turn right onto <say-as interpret-as=\"address\">Bolesława Krzywoustego</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "Drive northwest on Świętopełka. Then Turn right onto Bolesława Krzywoustego.",
+                  "distanceAlongGeometry": 190.709
+                },
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Bolesława Krzywoustego</say-as>. Then Your destination will be on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "Turn right onto Bolesława Krzywoustego. Then Your destination will be on the left.",
+                  "distanceAlongGeometry": 65.833
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true
+                  ],
+                  "bearings": [
+                    321
+                  ],
+                  "duration": 32.888,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "weight": 33.71,
+                  "geometry_index": 0,
+                  "location": [
+                    18.576644,
+                    54.410361
+                  ]
+                },
+                {
+                  "bearings": [
+                    77,
+                    166,
+                    258,
+                    356
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "turn_weight": 2,
+                  "turn_duration": 0.014,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 3,
+                  "geometry_index": 5,
+                  "location": [
+                    18.575589,
+                    54.411858
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "depart",
+                "instruction": "Drive northwest on Świętopełka.",
+                "bearing_after": 321,
+                "bearing_before": 0,
+                "location": [
+                  18.576644,
+                  54.410361
+                ]
+              },
+              "name": "Świętopełka",
+              "weight_typical": 37.186,
+              "duration_typical": 34.341,
+              "duration": 34.341,
+              "distance": 190.709,
+              "driving_side": "right",
+              "weight": 37.186,
+              "mode": "driving",
+              "geometry": "w_bkI_gkpBc@n@e@j@g@`@c@RuC~@M@"
+            },
+            {
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Your destination will be on the left"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left",
+                    "text": "Your destination will be on the left"
+                  },
+                  "distanceAlongGeometry": 43.713
+                },
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Your destination is on the left"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "left",
+                    "text": "Your destination is on the left"
+                  },
+                  "distanceAlongGeometry": 41.667
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Your destination is on the left.</prosody></amazon:effect></speak>",
+                  "announcement": "Your destination is on the left.",
+                  "distanceAlongGeometry": 41.667
+                }
+              ],
+              "intersections": [
+                {
+                  "bearings": [
+                    0,
+                    76,
+                    176,
+                    256
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 2,
+                  "turn_weight": 7,
+                  "turn_duration": 1.246,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "geometry_index": 6,
+                  "location": [
+                    18.575579,
+                    54.411933
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "turn",
+                "instruction": "Turn right onto Bolesława Krzywoustego.",
+                "modifier": "right",
+                "bearing_after": 76,
+                "bearing_before": 356,
+                "location": [
+                  18.575579,
+                  54.411933
+                ]
+              },
+              "name": "Bolesława Krzywoustego",
+              "weight_typical": 13.452,
+              "duration_typical": 7.541,
+              "duration": 7.541,
+              "distance": 43.713,
+              "driving_side": "right",
+              "weight": 13.452,
+              "mode": "driving",
+              "geometry": "qibkIk`kpBScC"
+            },
+            {
+              "bannerInstructions": [],
+              "voiceInstructions": [],
+              "intersections": [
+                {
+                  "bearings": [
+                    256
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "admin_index": 0,
+                  "geometry_index": 7,
+                  "location": [
+                    18.576235,
+                    54.412025
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "arrive",
+                "instruction": "Your destination is on the left.",
+                "modifier": "left",
+                "bearing_after": 0,
+                "bearing_before": 76,
+                "location": [
+                  18.576235,
+                  54.412025
+                ]
+              },
+              "name": "Bolesława Krzywoustego",
+              "weight_typical": 0,
+              "duration_typical": 0,
+              "duration": 0,
+              "distance": 0,
+              "driving_side": "right",
+              "weight": 0,
+              "mode": "driving",
+              "geometry": "ejbkIodkpB??"
+            }
+          ],
+          "distance": 234.423,
+          "summary": "Świętopełka, Bolesława Krzywoustego"
+        },
+        {
+          "via_waypoints": [],
+          "admins": [
+            {
+              "iso_3166_1_alpha3": "POL",
+              "iso_3166_1": "PL"
+            }
+          ],
+          "annotation": {
+            "duration": [
+              3.322,
+              2.077,
+              7.232,
+              6.939
+            ]
+          },
+          "weight_typical": 30.1,
+          "duration_typical": 21.951,
+          "weight": 30.1,
+          "duration": 21.951,
+          "steps": [
+            {
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Maurycego Beniowskiego"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right",
+                    "text": "Maurycego Beniowskiego"
+                  },
+                  "distanceAlongGeometry": 23.286
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive east on <say-as interpret-as=\"address\">Bolesława Krzywoustego</say-as>. Then Turn right onto <say-as interpret-as=\"address\">Maurycego Beniowskiego</say-as>.</prosody></amazon:effect></speak>",
+                  "announcement": "Drive east on Bolesława Krzywoustego. Then Turn right onto Maurycego Beniowskiego.",
+                  "distanceAlongGeometry": 23.286
+                }
+              ],
+              "intersections": [
+                {
+                  "bearings": [
+                    76
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 0,
+                  "geometry_index": 0,
+                  "location": [
+                    18.576235,
+                    54.412025
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "depart",
+                "instruction": "Drive east on Bolesława Krzywoustego.",
+                "bearing_after": 76,
+                "bearing_before": 0,
+                "location": [
+                  18.576235,
+                  54.412025
+                ]
+              },
+              "name": "Bolesława Krzywoustego",
+              "weight_typical": 3.437,
+              "duration_typical": 3.353,
+              "duration": 3.353,
+              "distance": 23.286,
+              "driving_side": "right",
+              "weight": 3.437,
+              "mode": "driving",
+              "geometry": "ejbkIodkpBGcA"
+            },
+            {
+              "bannerInstructions": [
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Your destination will be on the right"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "right",
+                    "text": "Your destination will be on the right"
+                  },
+                  "distanceAlongGeometry": 76.766
+                },
+                {
+                  "primary": {
+                    "components": [
+                      {
+                        "type": "text",
+                        "text": "Your destination is on the right"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "right",
+                    "text": "Your destination is on the right"
+                  },
+                  "distanceAlongGeometry": 34.722
+                }
+              ],
+              "voiceInstructions": [
+                {
+                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Your destination is on the right.</prosody></amazon:effect></speak>",
+                  "announcement": "Your destination is on the right.",
+                  "distanceAlongGeometry": 34.722
+                }
+              ],
+              "intersections": [
+                {
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 2,
+                  "bearings": [
+                    76,
+                    167,
+                    256,
+                    346
+                  ],
+                  "duration": 4.432,
+                  "turn_weight": 7,
+                  "turn_duration": 2.315,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 9.171,
+                  "geometry_index": 1,
+                  "location": [
+                    18.576581,
+                    54.412074
+                  ]
+                },
+                {
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "bearings": [
+                    76,
+                    165,
+                    260,
+                    347
+                  ],
+                  "duration": 7.219,
+                  "turn_weight": 2,
+                  "turn_duration": 0.019,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "weight": 9.38,
+                  "geometry_index": 2,
+                  "location": [
+                    18.576614,
+                    54.411988
+                  ]
+                },
+                {
+                  "bearings": [
+                    76,
+                    166,
+                    345
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "turn_weight": 1,
+                  "turn_duration": 0.007,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  },
+                  "is_urban": false,
+                  "admin_index": 0,
+                  "out": 1,
+                  "geometry_index": 3,
+                  "location": [
+                    18.576746,
+                    54.411691
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "turn",
+                "instruction": "Turn right onto Maurycego Beniowskiego.",
+                "modifier": "right",
+                "bearing_after": 167,
+                "bearing_before": 76,
+                "location": [
+                  18.576581,
+                  54.412074
+                ]
+              },
+              "name": "Maurycego Beniowskiego",
+              "weight_typical": 26.663,
+              "duration_typical": 18.598,
+              "duration": 18.598,
+              "distance": 76.766,
+              "driving_side": "right",
+              "weight": 26.663,
+              "mode": "driving",
+              "geometry": "mjbkIsfkpBNEz@[v@W"
+            },
+            {
+              "bannerInstructions": [],
+              "voiceInstructions": [],
+              "intersections": [
+                {
+                  "bearings": [
+                    346
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "admin_index": 0,
+                  "geometry_index": 4,
+                  "location": [
+                    18.576872,
+                    54.411406
+                  ]
+                }
+              ],
+              "maneuver": {
+                "type": "arrive",
+                "instruction": "Your destination is on the right.",
+                "modifier": "right",
+                "bearing_after": 0,
+                "bearing_before": 166,
+                "location": [
+                  18.576872,
+                  54.411406
+                ]
+              },
+              "name": "Maurycego Beniowskiego",
+              "weight_typical": 0,
+              "duration_typical": 0,
+              "duration": 0,
+              "distance": 0,
+              "driving_side": "right",
+              "weight": 0,
+              "mode": "driving",
+              "geometry": "ifbkImhkpB??"
+            }
+          ],
+          "distance": 100.053,
+          "summary": "Bolesława Krzywoustego, Maurycego Beniowskiego"
+        }
+      ],
+      "geometry": "w_bkI_gkpBc@n@e@j@g@`@c@RuC~@M@ScCGcANEz@[v@W",
+      "voiceLocale": "en-US"
+    }
+  ],
+  "waypoints": [
+    {
+      "distance": 0.031,
+      "name": "Świętopełka",
+      "location": [
+        18.576644,
+        54.410361
+      ]
+    },
+    {
+      "distance": 3.084,
+      "name": "Bolesława Krzywoustego",
+      "location": [
+        18.576235,
+        54.412025
+      ]
+    },
+    {
+      "distance": 1.412,
+      "name": "Maurycego Beniowskiego",
+      "location": [
+        18.576872,
+        54.411406
+      ]
+    }
+  ],
+  "code": "Ok",
+  "uuid": "-WWFCoqSnPqZTdqUjymqe-AoO8HAWTLYibicjxyRI57l3OKkf-od3A=="
+}

--- a/libnavigation-router/src/test/resources/multi_leg_route_refreshed.json
+++ b/libnavigation-router/src/test/resources/multi_leg_route_refreshed.json
@@ -2,21 +2,1995 @@
   "routes": [
     {
       "weight_typical": 1511.56,
-      "duration_typical": 654.54,
-      "weight_name": "auto",
-      "weight": 1500.996,
-      "duration": 645.353,
+      "routeIndex": "0",
       "distance": 2839.016,
+      "duration": 615.8249999999998,
+      "duration_typical": 654.54,
+      "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvDdCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaAj@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GMKdE??CxA@x@Ar@]vCWtA{Mfv@uGd_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeEdCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArITjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD",
+      "weight": 1500.996,
+      "weight_name": "auto",
       "legs": [
         {
+          "weight_typical": 315.701,
+          "weight": 315.701,
           "via_waypoints": [],
+          "distance": 1035.017,
+          "duration": 208.44599999999997,
+          "duration_typical": 217.243,
+          "summary": "Trzebnicka, Bolesława Drobnera",
           "admins": [
             {
-              "iso_3166_1_alpha3": "POL",
-              "iso_3166_1": "PL"
+              "iso_3166_1": "PL",
+              "iso_3166_1_alpha3": "POL"
+            }
+          ],
+          "steps": [
+            {
+              "weight_typical": 106.481,
+              "distance": 434.017,
+              "duration": 71.14699999999999,
+              "duration_typical": 71.855,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvD",
+              "name": "Trzebnicka",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.035996,
+                  51.123076
+                ],
+                "bearing_before": 0.0,
+                "bearing_after": 172.0,
+                "instruction": "Drive south on Trzebnicka.",
+                "type": "depart"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 434.017,
+                  "announcement": "Drive south on Trzebnicka. Then, in a quarter mile, Turn left onto Henryka Probusa.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive south on \u003csay-as interpret-as\u003d\"address\"\u003eTrzebnicka\u003c/say-as\u003e. Then, in a quarter mile, Turn left onto \u003csay-as interpret-as\u003d\"address\"\u003eHenryka Probusa\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 83.333,
+                  "announcement": "Turn left onto Henryka Probusa.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto \u003csay-as interpret-as\u003d\"address\"\u003eHenryka Probusa\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 434.017,
+                  "primary": {
+                    "text": "Henryka Probusa",
+                    "components": [
+                      {
+                        "text": "Henryka Probusa",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "left"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 106.481,
+              "intersections": [
+                {
+                  "duration": 1.069,
+                  "weight": 1.203,
+                  "location": [
+                    17.035996,
+                    51.123076
+                  ],
+                  "bearings": [
+                    172
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "out": 0,
+                  "geometry_index": 0,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.874,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 4.1,
+                  "location": [
+                    17.036012,
+                    51.123005
+                  ],
+                  "bearings": [
+                    82,
+                    172,
+                    263,
+                    352
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 2,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.257,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 4.531,
+                  "location": [
+                    17.036039,
+                    51.122883
+                  ],
+                  "bearings": [
+                    59,
+                    172,
+                    263,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 4,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.707,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 5.038,
+                  "location": [
+                    17.036068,
+                    51.12275
+                  ],
+                  "bearings": [
+                    82,
+                    172,
+                    260,
+                    352
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 6,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 6.894,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 8.248,
+                  "location": [
+                    17.036103,
+                    51.122592
+                  ],
+                  "bearings": [
+                    35,
+                    172,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 1,
+                  "geometry_index": 9,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 8.459,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 10.009,
+                  "location": [
+                    17.036188,
+                    51.122196
+                  ],
+                  "bearings": [
+                    172,
+                    263,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 12,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.661,
+                  "turn_weight": 0.5,
+                  "weight": 3.493,
+                  "location": [
+                    17.036291,
+                    51.121719
+                  ],
+                  "bearings": [
+                    172,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 14,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.461,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 4.761,
+                  "location": [
+                    17.036324,
+                    51.121566
+                  ],
+                  "bearings": [
+                    82,
+                    172,
+                    260,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 17,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 0.348,
+                  "turn_weight": 2,
+                  "turn_duration": 0.021,
+                  "weight": 2.368,
+                  "location": [
+                    17.036353,
+                    51.121436
+                  ],
+                  "bearings": [
+                    84,
+                    171,
+                    265,
+                    352
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 19,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 11.945,
+                  "turn_weight": 0.5,
+                  "weight": 13.939,
+                  "location": [
+                    17.036358,
+                    51.121416
+                  ],
+                  "bearings": [
+                    172,
+                    351
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 20,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.291,
+                  "turn_weight": 0.5,
+                  "weight": 3.077,
+                  "location": [
+                    17.036504,
+                    51.120769
+                  ],
+                  "bearings": [
+                    171,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 21,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.895,
+                  "turn_weight": 7,
+                  "turn_duration": 0.009,
+                  "weight": 9.121,
+                  "location": [
+                    17.036536,
+                    51.120645
+                  ],
+                  "bearings": [
+                    87,
+                    174,
+                    260,
+                    351
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 24,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.378,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 3.543,
+                  "location": [
+                    17.036551,
+                    51.120548
+                  ],
+                  "bearings": [
+                    82,
+                    173,
+                    263,
+                    354
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 26,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 11.143,
+                  "turn_weight": 0.5,
+                  "weight": 13.036,
+                  "location": [
+                    17.036564,
+                    51.120479
+                  ],
+                  "bearings": [
+                    173,
+                    353
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 28,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 4.464,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 5.514,
+                  "location": [
+                    17.036686,
+                    51.119903
+                  ],
+                  "bearings": [
+                    82,
+                    172,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 1,
+                  "geometry_index": 31,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.4,
+                  "turn_weight": 0.5,
+                  "weight": 3.2,
+                  "location": [
+                    17.036738,
+                    51.119671
+                  ],
+                  "bearings": [
+                    173,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 32,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 0.408,
+                  "turn_weight": 2,
+                  "turn_duration": 0.008,
+                  "weight": 2.45,
+                  "location": [
+                    17.036758,
+                    51.119567
+                  ],
+                  "bearings": [
+                    84,
+                    176,
+                    263,
+                    353
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 34,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 0.75,
+                  "location": [
+                    17.03676,
+                    51.119547
+                  ],
+                  "bearings": [
+                    197,
+                    356
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 35,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 61.02,
+              "distance": 151.0,
+              "duration": 37.312999999999995,
+              "duration_typical": 40.404,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "qhao`Bioyn_@dCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaA",
+              "name": "Henryka Probusa",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.036549,
+                  51.119257
+                ],
+                "bearing_before": 214.0,
+                "bearing_after": 133.0,
+                "instruction": "Turn left onto Henryka Probusa.",
+                "type": "turn",
+                "modifier": "left"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 141.0,
+                  "announcement": "In 500 feet, Turn right onto Bolesława Drobnera.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 500 feet, Turn right onto \u003csay-as interpret-as\u003d\"address\"\u003eBolesława Drobnera\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 83.333,
+                  "announcement": "Turn right onto Bolesława Drobnera.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto \u003csay-as interpret-as\u003d\"address\"\u003eBolesława Drobnera\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 151.0,
+                  "primary": {
+                    "text": "Bolesława Drobnera",
+                    "components": [
+                      {
+                        "text": "Bolesława Drobnera",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 61.02,
+              "intersections": [
+                {
+                  "duration": 6.82,
+                  "turn_weight": 12.5,
+                  "turn_duration": 4.345,
+                  "weight": 15.284,
+                  "location": [
+                    17.036549,
+                    51.119257
+                  ],
+                  "bearings": [
+                    34,
+                    133,
+                    251
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 42,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 19.8,
+                  "turn_weight": 0.5,
+                  "weight": 22.775,
+                  "location": [
+                    17.036662,
+                    51.11919
+                  ],
+                  "bearings": [
+                    133,
+                    313
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 43,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.944,
+                  "turn_weight": 2,
+                  "turn_duration": 0.019,
+                  "weight": 5.291,
+                  "location": [
+                    17.037589,
+                    51.118656
+                  ],
+                  "bearings": [
+                    44,
+                    132,
+                    222,
+                    313
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 44,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.669,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 3.911,
+                  "location": [
+                    17.037728,
+                    51.118577
+                  ],
+                  "bearings": [
+                    46,
+                    134,
+                    176,
+                    227,
+                    253,
+                    312
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 5,
+                  "out": 1,
+                  "geometry_index": 47,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.785,
+                  "turn_weight": 0.75,
+                  "turn_duration": 0.015,
+                  "weight": 3.935,
+                  "location": [
+                    17.03779,
+                    51.118539
+                  ],
+                  "bearings": [
+                    117,
+                    146,
+                    314
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 1,
+                  "geometry_index": 48,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.769,
+                  "turn_weight": 0.5,
+                  "weight": 3.685,
+                  "location": [
+                    17.037866,
+                    51.118467
+                  ],
+                  "bearings": [
+                    153,
+                    326
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 50,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 2,
+                  "turn_duration": 0.018,
+                  "location": [
+                    17.037931,
+                    51.118387
+                  ],
+                  "bearings": [
+                    37,
+                    77,
+                    167,
+                    259,
+                    333
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 4,
+                  "out": 2,
+                  "geometry_index": 52,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 136.979,
+              "distance": 443.0,
+              "duration": 97.20599999999997,
+              "duration_typical": 99.535,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "ek_o`Bih|n_@j@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GM",
+              "name": "Bolesława Drobnera",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.037973,
+                  51.118275
+                ],
+                "bearing_before": 167.0,
+                "bearing_after": 255.0,
+                "instruction": "Turn right onto Bolesława Drobnera.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 426.333,
+                  "announcement": "In a quarter mile, Turn right onto Wojciecha Cybulskiego.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn right onto \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 105.556,
+                  "announcement": "Turn right onto Wojciecha Cybulskiego. Then You will arrive at your destination.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e. Then You will arrive at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 443.0,
+                  "primary": {
+                    "text": "Wojciecha Cybulskiego",
+                    "components": [
+                      {
+                        "text": "Wojciecha Cybulskiego",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 136.979,
+              "intersections": [
+                {
+                  "duration": 20.405,
+                  "turn_weight": 8,
+                  "turn_duration": 2.005,
+                  "weight": 29.16,
+                  "location": [
+                    17.037973,
+                    51.118275
+                  ],
+                  "bearings": [
+                    82,
+                    191,
+                    255,
+                    347
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 2,
+                  "geometry_index": 54,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.687,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 2.432,
+                  "location": [
+                    17.036702,
+                    51.118056
+                  ],
+                  "bearings": [
+                    75,
+                    256,
+                    342
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 59,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 19.92,
+                  "turn_weight": 0.5,
+                  "weight": 23.408,
+                  "location": [
+                    17.036599,
+                    51.11804
+                  ],
+                  "bearings": [
+                    76,
+                    255
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 60,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 1.88,
+                  "turn_duration": 0.021,
+                  "turn_weight": 0.5,
+                  "duration": 1.221,
+                  "location": [
+                    17.035451,
+                    51.117852
+                  ],
+                  "bearings": [
+                    39,
+                    75,
+                    254
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 61,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.127,
+                  "turn_duration": 0.007,
+                  "turn_weight": 0.5,
+                  "duration": 4.031,
+                  "location": [
+                    17.035383,
+                    51.11784
+                  ],
+                  "bearings": [
+                    74,
+                    256,
+                    294
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 63,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.896,
+                  "turn_duration": 0.022,
+                  "turn_weight": 2,
+                  "duration": 3.411,
+                  "location": [
+                    17.03512,
+                    51.117798
+                  ],
+                  "bearings": [
+                    76,
+                    163,
+                    253,
+                    345
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 66,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.364,
+                  "turn_duration": 0.03,
+                  "turn_weight": 2,
+                  "duration": 2.955,
+                  "location": [
+                    17.034895,
+                    51.117754
+                  ],
+                  "bearings": [
+                    23,
+                    73,
+                    204,
+                    247
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "out": 3,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 68,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 13.86,
+                  "turn_duration": 0.052,
+                  "turn_weight": 0.75,
+                  "duration": 11.452,
+                  "location": [
+                    17.034722,
+                    51.117707
+                  ],
+                  "bearings": [
+                    67,
+                    234,
+                    304
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 69,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 2.57,
+                  "turn_duration": 0.03,
+                  "turn_weight": 0.5,
+                  "duration": 1.83,
+                  "location": [
+                    17.034316,
+                    51.117486
+                  ],
+                  "bearings": [
+                    44,
+                    217,
+                    263,
+                    313
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 74,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 20.334,
+                  "turn_duration": 0.024,
+                  "turn_weight": 2,
+                  "duration": 15.967,
+                  "location": [
+                    17.03426,
+                    51.117439
+                  ],
+                  "bearings": [
+                    37,
+                    122,
+                    212,
+                    300
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 76,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 2.887,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 0.779,
+                  "location": [
+                    17.033783,
+                    51.116966
+                  ],
+                  "bearings": [
+                    32,
+                    121,
+                    212,
+                    303
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 80,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 2.296,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 0.265,
+                  "location": [
+                    17.033763,
+                    51.116946
+                  ],
+                  "bearings": [
+                    32,
+                    122,
+                    212,
+                    301
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 81,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.029,
+                  "turn_weight": 0.5,
+                  "weight": 1.683,
+                  "location": [
+                    17.033755,
+                    51.116938
+                  ],
+                  "bearings": [
+                    32,
+                    211
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 82,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 3.49,
+                  "turn_duration": 0.009,
+                  "turn_weight": 0.5,
+                  "duration": 2.609,
+                  "location": [
+                    17.033723,
+                    51.116905
+                  ],
+                  "bearings": [
+                    31,
+                    215,
+                    304,
+                    353
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 83,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.4,
+                  "turn_weight": 0.5,
+                  "weight": 2.11,
+                  "location": [
+                    17.033617,
+                    51.11681
+                  ],
+                  "bearings": [
+                    35,
+                    214
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 84,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 4.192,
+                  "turn_weight": 2,
+                  "turn_duration": 0.142,
+                  "weight": 6.658,
+                  "location": [
+                    17.033558,
+                    51.116755
+                  ],
+                  "bearings": [
+                    34,
+                    101,
+                    187,
+                    304
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 85,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.014,
+                  "location": [
+                    17.033516,
+                    51.116519
+                  ],
+                  "bearings": [
+                    5,
+                    46,
+                    196
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 87,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 11.22,
+              "distance": 7.0,
+              "duration": 2.78,
+              "duration_typical": 5.449,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "id{n`B{ksn_@KdE",
+              "name": "Wojciecha Cybulskiego",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.033422,
+                  51.116117
+                ],
+                "bearing_before": 181.0,
+                "bearing_after": 276.0,
+                "instruction": "Turn right onto Wojciecha Cybulskiego.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 7.0,
+                  "announcement": "You have arrived at your destination.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYou have arrived at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 7.0,
+                  "primary": {
+                    "text": "You have arrived at your destination",
+                    "components": [
+                      {
+                        "text": "You have arrived at your destination",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 11.22,
+              "intersections": [
+                {
+                  "turn_weight": 8,
+                  "turn_duration": 2.649,
+                  "location": [
+                    17.033422,
+                    51.116117
+                  ],
+                  "bearings": [
+                    1,
+                    125,
+                    169,
+                    276
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 3,
+                  "geometry_index": 91,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 0,
+              "distance": 0.0,
+              "duration": 0.0,
+              "duration_typical": 0.0,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "ud{n`Buesn_@??",
+              "name": "Wojciecha Cybulskiego",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.033323,
+                  51.116123
+                ],
+                "bearing_before": 276.0,
+                "bearing_after": 0.0,
+                "instruction": "You have arrived at your destination.",
+                "type": "arrive"
+              },
+              "voiceInstructions": [],
+              "bannerInstructions": [],
+              "driving_side": "right",
+              "weight": 0.0,
+              "intersections": [
+                {
+                  "location": [
+                    17.033323,
+                    51.116123
+                  ],
+                  "bearings": [
+                    96
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "geometry_index": 92,
+                  "admin_index": 0
+                }
+              ]
             }
           ],
           "annotation": {
+            "distance": [
+              4.3,
+              3.7,
+              2.4,
+              11.3,
+              12.0,
+              2.9,
+              2.7,
+              2.7,
+              12.4,
+              2.0,
+              38.1,
+              4.4,
+              5.2,
+              48.4,
+              5.7,
+              2.9,
+              8.5,
+              12.5,
+              2.1,
+              2.3,
+              72.7,
+              4.5,
+              0.7,
+              8.8,
+              8.6,
+              2.2,
+              1.8,
+              5.9,
+              5.8,
+              50.9,
+              8.0,
+              26.1,
+              9.8,
+              1.9,
+              2.2,
+              3.3,
+              3.5,
+              4.8,
+              5.5,
+              7.4,
+              1.3,
+              10.5,
+              10.9,
+              87.9,
+              3.6,
+              3.8,
+              5.7,
+              6.1,
+              5.2,
+              4.4,
+              5.8,
+              4.2,
+              2.2,
+              10.6,
+              9.9,
+              11.6,
+              37.7,
+              26.2,
+              6.7,
+              7.4,
+              82.9,
+              2.5,
+              2.5,
+              12.4,
+              3.7,
+              2.9,
+              3.1,
+              13.3,
+              13.2,
+              6.9,
+              7.1,
+              2.3,
+              12.4,
+              9.1,
+              3.5,
+              3.0,
+              2.9,
+              50.7,
+              6.2,
+              2.5,
+              2.6,
+              1.0,
+              4.3,
+              12.9,
+              7.4,
+              7.1,
+              19.4,
+              7.3,
+              12.3,
+              11.7,
+              14.4,
+              7.0
+            ],
+            "duration": [
+              0.573,
+              0.496,
+              0.317,
+              1.512,
+              1.804,
+              0.437,
+              0.405,
+              0.404,
+              1.854,
+              0.315,
+              5.96,
+              0.687,
+              0.775,
+              7.263,
+              0.859,
+              0.438,
+              1.28,
+              2.044,
+              0.348,
+              0.369,
+              11.903,
+              0.741,
+              0.112,
+              1.436,
+              1.476,
+              0.383,
+              0.307,
+              1.019,
+              0.995,
+              8.729,
+              1.367,
+              4.471,
+              1.951,
+              0.381,
+              0.446,
+              0.668,
+              0.691,
+              0.965,
+              1.109,
+              1.487,
+              0.263,
+              2.107,
+              2.607,
+              21.1,
+              0.813,
+              0.853,
+              1.283,
+              1.677,
+              1.441,
+              1.222,
+              1.615,
+              1.154,
+              0.611,
+              2.937,
+              1.976,
+              2.329,
+              7.536,
+              5.238,
+              1.342,
+              1.779,
+              19.897,
+              0.592,
+              0.592,
+              2.624,
+              0.778,
+              0.615,
+              0.664,
+              2.824,
+              2.964,
+              2.06,
+              2.134,
+              0.693,
+              3.732,
+              2.717,
+              0.908,
+              0.777,
+              0.753,
+              13.041,
+              1.598,
+              0.633,
+              0.676,
+              0.27,
+              1.105,
+              2.582,
+              1.476,
+              1.063,
+              2.912,
+              1.014,
+              1.71,
+              1.613,
+              1.989,
+              2.78
+            ],
+            "speed": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              6.4,
+              6.4,
+              6.7,
+              6.7,
+              6.7,
+              6.7,
+              6.7,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              5.8,
+              5.8,
+              5.8,
+              5.8,
+              5.8,
+              5.8,
+              5.8,
+              5.8,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              4.2,
+              4.2,
+              4.4,
+              4.4,
+              4.4,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              5.0,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.4,
+              3.3,
+              3.3,
+              3.3,
+              3.3,
+              3.3,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              3.9,
+              5.0,
+              5.0,
+              6.7,
+              6.7,
+              7.2,
+              7.2,
+              7.2,
+              7.2,
+              2.5
+            ],
             "maxspeed": [
               {
                 "speed": 50,
@@ -480,1868 +2454,456 @@
               33,
               33,
               null
-            ],
-            "speed": [
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              6.4,
-              6.4,
-              6.7,
-              6.7,
-              6.7,
-              6.7,
-              6.7,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              5.8,
-              5.8,
-              5.8,
-              5.8,
-              5.8,
-              5.8,
-              5.8,
-              5.8,
-              5,
-              5,
-              5,
-              5,
-              5,
-              5,
-              5,
-              5,
-              5,
-              5,
-              4.2,
-              4.2,
-              4.4,
-              4.4,
-              4.4,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              5,
-              5,
-              5,
-              5,
-              5,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.4,
-              3.3,
-              3.3,
-              3.3,
-              3.3,
-              3.3,
-              3.9,
-              3.9,
-              3.9,
-              3.9,
-              3.9,
-              3.9,
-              3.9,
-              3.9,
-              3.9,
-              5,
-              5,
-              6.7,
-              6.7,
-              7.2,
-              7.2,
-              7.2,
-              7.2,
-              2.5
-            ],
-            "distance": [
-              4.3,
-              3.7,
-              2.4,
-              11.3,
-              12,
-              2.9,
-              2.7,
-              2.7,
-              12.4,
-              2,
-              38.1,
-              4.4,
-              5.2,
-              48.4,
-              5.7,
-              2.9,
-              8.5,
-              12.5,
-              2.1,
-              2.3,
-              72.7,
-              4.5,
-              0.7,
-              8.8,
-              8.6,
-              2.2,
-              1.8,
-              5.9,
-              5.8,
-              50.9,
-              8,
-              26.1,
-              9.8,
-              1.9,
-              2.2,
-              3.3,
-              3.5,
-              4.8,
-              5.5,
-              7.4,
-              1.3,
-              10.5,
-              10.9,
-              87.9,
-              3.6,
-              3.8,
-              5.7,
-              6.1,
-              5.2,
-              4.4,
-              5.8,
-              4.2,
-              2.2,
-              10.6,
-              9.9,
-              11.6,
-              37.7,
-              26.2,
-              6.7,
-              7.4,
-              82.9,
-              2.5,
-              2.5,
-              12.4,
-              3.7,
-              2.9,
-              3.1,
-              13.3,
-              13.2,
-              6.9,
-              7.1,
-              2.3,
-              12.4,
-              9.1,
-              3.5,
-              3,
-              2.9,
-              50.7,
-              6.2,
-              2.5,
-              2.6,
-              1,
-              4.3,
-              12.9,
-              7.4,
-              7.1,
-              19.4,
-              7.3,
-              12.3,
-              11.7,
-              14.4,
-              7
-            ],
-            "duration": [
-              0.573,
-              0.496,
-              0.317,
-              1.512,
-              1.804,
-              0.437,
-              0.405,
-              0.404,
-              1.854,
-              0.315,
-              5.96,
-              0.687,
-              0.775,
-              7.263,
-              0.859,
-              0.438,
-              1.28,
-              2.044,
-              0.348,
-              0.369,
-              11.903,
-              0.741,
-              0.112,
-              1.436,
-              1.476,
-              0.383,
-              0.307,
-              1.019,
-              0.995,
-              8.729,
-              1.367,
-              4.471,
-              1.951,
-              0.381,
-              0.446,
-              0.668,
-              0.691,
-              0.965,
-              1.109,
-              1.487,
-              0.263,
-              2.107,
-              2.607,
-              21.1,
-              0.813,
-              0.853,
-              1.283,
-              1.677,
-              1.441,
-              1.222,
-              1.615,
-              1.154,
-              0.611,
-              2.937,
-              1.976,
-              2.329,
-              7.536,
-              5.238,
-              1.342,
-              1.779,
-              19.897,
-              0.592,
-              0.592,
-              2.624,
-              0.778,
-              0.615,
-              0.664,
-              2.824,
-              2.964,
-              2.06,
-              2.134,
-              0.693,
-              3.732,
-              2.717,
-              0.908,
-              0.777,
-              0.753,
-              13.041,
-              1.598,
-              0.633,
-              0.676,
-              0.27,
-              1.105,
-              2.582,
-              1.476,
-              1.063,
-              2.912,
-              1.014,
-              1.71,
-              1.613,
-              1.989,
-              2.78
             ]
-          },
-          "weight_typical": 315.701,
-          "duration_typical": 217.243,
-          "weight": 315.701,
-          "duration": 217.243,
+          }
+        },
+        {
+          "weight_typical": 884.532,
+          "weight": 884.532,
+          "via_waypoints": [],
+          "distance": 754.545,
+          "duration": 172.132,
+          "duration_typical": 201.157,
+          "summary": "Wojciecha Cybulskiego, Grodzka",
+          "admins": [
+            {
+              "iso_3166_1": "PL",
+              "iso_3166_1_alpha3": "POL"
+            }
+          ],
           "steps": [
             {
+              "weight_typical": 38.924,
+              "distance": 122.0,
+              "duration": 39.78,
+              "duration_typical": 30.839,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "ud{n`Buesn_@??CxA@x@Ar@]vCWtA{Mfv@uGd_@",
+              "name": "Wojciecha Cybulskiego",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.033323,
+                  51.116123
+                ],
+                "bearing_before": 0.0,
+                "bearing_after": 180.0,
+                "instruction": "Drive south on Wojciecha Cybulskiego.",
+                "type": "depart"
+              },
               "voiceInstructions": [
                 {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive south on <say-as interpret-as=\"address\">Trzebnicka</say-as>. Then, in a quarter mile, Turn left onto <say-as interpret-as=\"address\">Henryka Probusa</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Drive south on Trzebnicka. Then, in a quarter mile, Turn left onto Henryka Probusa.",
-                  "distanceAlongGeometry": 434.017
+                  "distanceAlongGeometry": 122.0,
+                  "announcement": "Drive south on Wojciecha Cybulskiego. Then, in 400 feet, Make a left U-turn to stay on Wojciecha Cybulskiego.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive south on \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e. Then, in 400 feet, Make a left U-turn to stay on \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
                 },
                 {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn left onto <say-as interpret-as=\"address\">Henryka Probusa</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn left onto Henryka Probusa.",
-                  "distanceAlongGeometry": 83.333
+                  "distanceAlongGeometry": 66.667,
+                  "announcement": "Make a left U-turn to stay on Wojciecha Cybulskiego.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eMake a left U-turn to stay on \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
                 }
               ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 122.0,
+                  "primary": {
+                    "text": "Wojciecha Cybulskiego",
+                    "components": [
+                      {
+                        "text": "Wojciecha Cybulskiego",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "uturn",
+                    "driving_side": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 38.924,
               "intersections": [
                 {
+                  "location": [
+                    17.033323,
+                    51.116123
+                  ],
+                  "bearings": [
+                    180
+                  ],
                   "entry": [
                     true
                   ],
-                  "bearings": [
-                    172
-                  ],
-                  "duration": 1.069,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
                   "out": 0,
-                  "weight": 1.203,
                   "geometry_index": 0,
-                  "location": [
-                    17.035996,
-                    51.123076
-                  ]
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
                 },
                 {
+                  "duration": 2,
+                  "turn_weight": 0.5,
+                  "weight": 2.8,
+                  "location": [
+                    17.033323,
+                    51.116123
+                  ],
+                  "bearings": [
+                    0,
+                    271
+                  ],
                   "entry": [
                     false,
-                    true,
-                    false,
-                    false
+                    true
                   ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    172,
-                    263,
-                    352
-                  ],
-                  "duration": 1.874,
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 1,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "duration": 2.815,
                   "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 4.1,
-                  "geometry_index": 2,
+                  "turn_duration": 0.015,
+                  "weight": 5.22,
                   "location": [
-                    17.036012,
-                    51.123005
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    true,
-                    false
+                    17.033249,
+                    51.116124
                   ],
-                  "in": 3,
                   "bearings": [
-                    59,
-                    172,
-                    263,
-                    352
-                  ],
-                  "duration": 2.257,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 4.531,
-                  "geometry_index": 4,
-                  "location": [
-                    17.036039,
-                    51.122883
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    172,
-                    260,
-                    352
-                  ],
-                  "duration": 2.707,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.038,
-                  "geometry_index": 6,
-                  "location": [
-                    17.036068,
-                    51.12275
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    35,
-                    172,
-                    352
-                  ],
-                  "duration": 6.894,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 8.248,
-                  "geometry_index": 9,
-                  "location": [
-                    17.036103,
-                    51.122592
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    172,
-                    263,
-                    352
-                  ],
-                  "duration": 8.459,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 10.009,
-                  "geometry_index": 12,
-                  "location": [
-                    17.036188,
-                    51.122196
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    172,
-                    352
-                  ],
-                  "duration": 2.661,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.493,
-                  "geometry_index": 14,
-                  "location": [
-                    17.036291,
-                    51.121719
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    172,
-                    260,
-                    352
-                  ],
-                  "duration": 2.461,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 4.761,
-                  "geometry_index": 17,
-                  "location": [
-                    17.036324,
-                    51.121566
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    84,
-                    171,
-                    265,
-                    352
-                  ],
-                  "duration": 0.348,
-                  "turn_weight": 2,
-                  "turn_duration": 0.021,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.368,
-                  "geometry_index": 19,
-                  "location": [
-                    17.036353,
-                    51.121436
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    172,
-                    351
-                  ],
-                  "duration": 11.945,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 13.939,
-                  "geometry_index": 20,
-                  "location": [
-                    17.036358,
-                    51.121416
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    171,
-                    352
-                  ],
-                  "duration": 2.291,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.077,
-                  "geometry_index": 21,
-                  "location": [
-                    17.036504,
-                    51.120769
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    87,
-                    174,
-                    260,
-                    351
-                  ],
-                  "duration": 1.895,
-                  "turn_weight": 7,
-                  "turn_duration": 0.009,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 9.121,
-                  "geometry_index": 24,
-                  "location": [
-                    17.036536,
-                    51.120645
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    173,
-                    263,
-                    354
-                  ],
-                  "duration": 1.378,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 3.543,
-                  "geometry_index": 26,
-                  "location": [
-                    17.036551,
-                    51.120548
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    173,
-                    353
-                  ],
-                  "duration": 11.143,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 13.036,
-                  "geometry_index": 28,
-                  "location": [
-                    17.036564,
-                    51.120479
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    82,
-                    172,
-                    352
-                  ],
-                  "duration": 4.464,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.514,
-                  "geometry_index": 31,
-                  "location": [
-                    17.036686,
-                    51.119903
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    173,
-                    352
-                  ],
-                  "duration": 2.4,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.2,
-                  "geometry_index": 32,
-                  "location": [
-                    17.036738,
-                    51.119671
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    84,
+                    91,
                     176,
-                    263,
-                    353
+                    284,
+                    356
                   ],
-                  "duration": 0.408,
-                  "turn_weight": 2,
-                  "turn_duration": 0.008,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 3,
                   "is_urban": true,
                   "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.45,
-                  "geometry_index": 34,
-                  "location": [
-                    17.036758,
-                    51.119567
-                  ]
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
                 },
                 {
+                  "duration": 15.988,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.013,
+                  "weight": 18.871,
+                  "location": [
+                    17.033147,
+                    51.11614
+                  ],
                   "bearings": [
-                    197,
+                    104,
+                    199,
+                    293
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 5,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "location": [
+                    17.03222,
+                    51.11639
+                  ],
+                  "bearings": [
+                    24,
+                    113,
+                    293
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "out": 2,
+                  "geometry_index": 7,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 670.295,
+              "distance": 129.0,
+              "duration": 25.893,
+              "duration_typical": 60.842,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "a~{n`Bq`pn_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeE",
+              "name": "Wojciecha Cybulskiego",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.031705,
+                  51.116529
+                ],
+                "bearing_before": 293.0,
+                "bearing_after": 113.0,
+                "instruction": "Make a left U-turn to stay on Wojciecha Cybulskiego.",
+                "type": "continue",
+                "modifier": "uturn"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 119.0,
+                  "announcement": "In 400 feet, Turn right onto Most Uniwersytecki.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 400 feet, Turn right onto \u003csay-as interpret-as\u003d\"address\"\u003eMost Uniwersytecki\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 50.0,
+                  "announcement": "Turn right onto Most Uniwersytecki.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto \u003csay-as interpret-as\u003d\"address\"\u003eMost Uniwersytecki\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 129.0,
+                  "primary": {
+                    "text": "Most Uniwersytecki",
+                    "components": [
+                      {
+                        "text": "Most Uniwersytecki",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 670.295,
+              "intersections": [
+                {
+                  "duration": 36.23,
+                  "turn_weight": 628.5,
+                  "turn_duration": 27.455,
+                  "weight": 638.591,
+                  "location": [
+                    17.031705,
+                    51.116529
+                  ],
+                  "bearings": [
+                    113,
+                    113
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 8,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "duration": 15.982,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 18.871,
+                  "location": [
+                    17.03222,
+                    51.11639
+                  ],
+                  "bearings": [
+                    24,
+                    113,
+                    293
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 1,
+                  "geometry_index": 9,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "duration": 3.186,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.036,
+                  "weight": 4.122,
+                  "location": [
+                    17.033147,
+                    51.11614
+                  ],
+                  "bearings": [
+                    104,
+                    199,
+                    293
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 11,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "duration": 2.295,
+                  "turn_weight": 2,
+                  "turn_duration": 0.045,
+                  "weight": 4.588,
+                  "location": [
+                    17.033249,
+                    51.116124
+                  ],
+                  "bearings": [
+                    91,
+                    176,
+                    284,
                     356
                   ],
                   "entry": [
                     true,
-                    false
-                  ],
-                  "in": 1,
-                  "turn_weight": 0.75,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "geometry_index": 35,
-                  "location": [
-                    17.03676,
-                    51.119547
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Henryka Probusa"
-                      }
-                    ],
-                    "type": "turn",
-                    "modifier": "left",
-                    "text": "Henryka Probusa"
-                  },
-                  "distanceAlongGeometry": 434.017
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "depart",
-                "instruction": "Drive south on Trzebnicka.",
-                "bearing_after": 172,
-                "bearing_before": 0,
-                "location": [
-                  17.035996,
-                  51.123076
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Trzebnicka",
-              "weight_typical": 106.481,
-              "duration_typical": 71.855,
-              "duration": 71.855,
-              "distance": 434.017,
-              "driving_side": "right",
-              "weight": 106.481,
-              "mode": "driving",
-              "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvD"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 500 feet, Turn right onto <say-as interpret-as=\"address\">Bolesława Drobnera</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "In 500 feet, Turn right onto Bolesława Drobnera.",
-                  "distanceAlongGeometry": 141
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Bolesława Drobnera</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn right onto Bolesława Drobnera.",
-                  "distanceAlongGeometry": 83.333
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
                     false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    34,
-                    133,
-                    251
-                  ],
-                  "duration": 6.82,
-                  "turn_weight": 12.5,
-                  "turn_duration": 4.345,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 15.284,
-                  "geometry_index": 42,
-                  "location": [
-                    17.036549,
-                    51.119257
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    133,
-                    313
-                  ],
-                  "duration": 19.8,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 22.775,
-                  "geometry_index": 43,
-                  "location": [
-                    17.036662,
-                    51.11919
-                  ]
-                },
-                {
-                  "entry": [
                     false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    44,
-                    132,
-                    222,
-                    313
-                  ],
-                  "duration": 2.944,
-                  "turn_weight": 2,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.291,
-                  "geometry_index": 44,
-                  "location": [
-                    17.037589,
-                    51.118656
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 5,
-                  "bearings": [
-                    46,
-                    134,
-                    176,
-                    227,
-                    253,
-                    312
-                  ],
-                  "duration": 1.669,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 3.911,
-                  "geometry_index": 47,
-                  "location": [
-                    17.037728,
-                    51.118577
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
                     false
                   ],
                   "in": 2,
-                  "bearings": [
-                    117,
-                    146,
-                    314
-                  ],
-                  "duration": 2.785,
-                  "turn_weight": 0.75,
-                  "turn_duration": 0.015,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 3.935,
-                  "geometry_index": 48,
-                  "location": [
-                    17.03779,
-                    51.118539
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    153,
-                    326
-                  ],
-                  "duration": 2.769,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
                   "out": 0,
-                  "weight": 3.685,
-                  "geometry_index": 50,
-                  "location": [
-                    17.037866,
-                    51.118467
-                  ]
-                },
-                {
-                  "bearings": [
-                    37,
-                    77,
-                    167,
-                    259,
-                    333
-                  ],
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 4,
-                  "turn_weight": 2,
-                  "turn_duration": 0.018,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
+                  "geometry_index": 13,
                   "is_urban": true,
                   "admin_index": 0,
-                  "out": 2,
-                  "geometry_index": 52,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "turn_weight": 0.5,
                   "location": [
-                    17.037931,
-                    51.118387
-                  ]
+                    17.033323,
+                    51.116123
+                  ],
+                  "bearings": [
+                    96,
+                    271
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 15,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 83.165,
+              "distance": 213.0,
+              "duration": 42.78799999999999,
+              "duration_typical": 42.749,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "id{n`B{ksn_@dCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM",
+              "name": "Most Uniwersytecki",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.033422,
+                  51.116117
+                ],
+                "bearing_before": 96.0,
+                "bearing_after": 169.0,
+                "instruction": "Turn right onto Most Uniwersytecki.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 196.333,
+                  "announcement": "In 700 feet, Turn right onto Grodzka.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 700 feet, Turn right onto \u003csay-as interpret-as\u003d\"address\"\u003eGrodzka\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 77.778,
+                  "announcement": "Turn right onto Grodzka.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto \u003csay-as interpret-as\u003d\"address\"\u003eGrodzka\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
                 }
               ],
               "bannerInstructions": [
                 {
+                  "distanceAlongGeometry": 213.0,
                   "primary": {
+                    "text": "Grodzka",
                     "components": [
                       {
-                        "type": "text",
-                        "text": "Bolesława Drobnera"
+                        "text": "Grodzka",
+                        "type": "text"
                       }
                     ],
                     "type": "turn",
-                    "modifier": "right",
-                    "text": "Bolesława Drobnera"
-                  },
-                  "distanceAlongGeometry": 151
+                    "modifier": "right"
+                  }
                 }
               ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn left onto Henryka Probusa.",
-                "modifier": "left",
-                "bearing_after": 133,
-                "bearing_before": 214,
-                "location": [
-                  17.036549,
-                  51.119257
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Henryka Probusa",
-              "weight_typical": 61.02,
-              "duration_typical": 40.404,
-              "duration": 40.404,
-              "distance": 151,
               "driving_side": "right",
-              "weight": 61.02,
-              "mode": "driving",
-              "geometry": "qhao`Bioyn_@dCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaA"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In a quarter mile, Turn right onto <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "In a quarter mile, Turn right onto Wojciecha Cybulskiego.",
-                  "distanceAlongGeometry": 426.333
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>. Then You will arrive at your destination.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn right onto Wojciecha Cybulskiego. Then You will arrive at your destination.",
-                  "distanceAlongGeometry": 105.556
-                }
-              ],
+              "weight": 83.165,
               "intersections": [
                 {
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    191,
-                    255,
-                    347
-                  ],
-                  "duration": 20.405,
-                  "turn_weight": 8,
-                  "turn_duration": 2.005,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 29.16,
-                  "geometry_index": 54,
+                  "duration": 2.14,
+                  "turn_weight": 9,
+                  "turn_duration": 0.831,
+                  "weight": 10.505,
                   "location": [
-                    17.037973,
-                    51.118275
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true
+                    17.033422,
+                    51.116117
                   ],
-                  "in": 0,
-                  "bearings": [
-                    75,
-                    256,
-                    342
-                  ],
-                  "duration": 1.687,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.432,
-                  "geometry_index": 59,
-                  "location": [
-                    17.036702,
-                    51.118056
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    76,
-                    255
-                  ],
-                  "duration": 19.92,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 23.408,
-                  "geometry_index": 60,
-                  "location": [
-                    17.036599,
-                    51.11804
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.035451,
-                    51.117852
-                  ],
-                  "geometry_index": 61,
-                  "admin_index": 0,
-                  "weight": 1.88,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.021,
-                  "turn_weight": 0.5,
-                  "duration": 1.221,
-                  "bearings": [
-                    39,
-                    75,
-                    254
-                  ],
-                  "out": 2,
-                  "in": 1,
-                  "entry": [
-                    false,
-                    false,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.035383,
-                    51.11784
-                  ],
-                  "geometry_index": 63,
-                  "admin_index": 0,
-                  "weight": 5.127,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 0.5,
-                  "duration": 4.031,
-                  "bearings": [
-                    74,
-                    256,
-                    294
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.03512,
-                    51.117798
-                  ],
-                  "geometry_index": 66,
-                  "admin_index": 0,
-                  "weight": 5.896,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.022,
-                  "turn_weight": 2,
-                  "duration": 3.411,
-                  "bearings": [
-                    76,
-                    163,
-                    253,
-                    345
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.034895,
-                    51.117754
-                  ],
-                  "geometry_index": 68,
-                  "admin_index": 0,
-                  "weight": 5.364,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.03,
-                  "turn_weight": 2,
-                  "duration": 2.955,
-                  "bearings": [
-                    23,
-                    73,
-                    204,
-                    247
-                  ],
-                  "out": 3,
-                  "in": 1,
-                  "entry": [
-                    true,
-                    false,
-                    false,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.034722,
-                    51.117707
-                  ],
-                  "geometry_index": 69,
-                  "admin_index": 0,
-                  "weight": 13.86,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.052,
-                  "turn_weight": 0.75,
-                  "duration": 11.452,
-                  "bearings": [
-                    67,
-                    234,
-                    304
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.034316,
-                    51.117486
-                  ],
-                  "geometry_index": 74,
-                  "admin_index": 0,
-                  "weight": 2.57,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.03,
-                  "turn_weight": 0.5,
-                  "duration": 1.83,
-                  "bearings": [
-                    44,
-                    217,
-                    263,
-                    313
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.03426,
-                    51.117439
-                  ],
-                  "geometry_index": 76,
-                  "admin_index": 0,
-                  "weight": 20.334,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.024,
-                  "turn_weight": 2,
-                  "duration": 15.967,
-                  "bearings": [
-                    37,
-                    122,
-                    212,
-                    300
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.033783,
-                    51.116966
-                  ],
-                  "geometry_index": 80,
-                  "admin_index": 0,
-                  "weight": 2.887,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 0.779,
-                  "bearings": [
-                    32,
-                    121,
-                    212,
-                    303
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.033763,
-                    51.116946
-                  ],
-                  "geometry_index": 81,
-                  "admin_index": 0,
-                  "weight": 2.296,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 0.265,
-                  "bearings": [
-                    32,
-                    122,
-                    212,
-                    301
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    32,
-                    211
-                  ],
-                  "duration": 1.029,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 1.683,
-                  "geometry_index": 82,
-                  "location": [
-                    17.033755,
-                    51.116938
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.033723,
-                    51.116905
-                  ],
-                  "geometry_index": 83,
-                  "admin_index": 0,
-                  "weight": 3.49,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.009,
-                  "turn_weight": 0.5,
-                  "duration": 2.609,
-                  "bearings": [
-                    31,
-                    215,
-                    304,
-                    353
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    35,
-                    214
-                  ],
-                  "duration": 1.4,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.11,
-                  "geometry_index": 84,
-                  "location": [
-                    17.033617,
-                    51.11681
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    34,
-                    101,
-                    187,
-                    304
-                  ],
-                  "duration": 4.192,
-                  "turn_weight": 2,
-                  "turn_duration": 0.142,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 6.658,
-                  "geometry_index": 85,
-                  "location": [
-                    17.033558,
-                    51.116755
-                  ]
-                },
-                {
-                  "bearings": [
-                    5,
-                    46,
-                    196
-                  ],
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.014,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "geometry_index": 87,
-                  "location": [
-                    17.033516,
-                    51.116519
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Wojciecha Cybulskiego"
-                      }
-                    ],
-                    "type": "turn",
-                    "modifier": "right",
-                    "text": "Wojciecha Cybulskiego"
-                  },
-                  "distanceAlongGeometry": 443
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn right onto Bolesława Drobnera.",
-                "modifier": "right",
-                "bearing_after": 255,
-                "bearing_before": 167,
-                "location": [
-                  17.037973,
-                  51.118275
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Bolesława Drobnera",
-              "weight_typical": 136.979,
-              "duration_typical": 99.535,
-              "duration": 99.535,
-              "distance": 443,
-              "driving_side": "right",
-              "weight": 136.979,
-              "mode": "driving",
-              "geometry": "ek_o`Bih|n_@j@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GM"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">You have arrived at your destination.</prosody></amazon:effect></speak>",
-                  "announcement": "You have arrived at your destination.",
-                  "distanceAlongGeometry": 7
-                }
-              ],
-              "intersections": [
-                {
                   "bearings": [
                     1,
                     125,
@@ -2349,121 +2911,888 @@
                     276
                   ],
                   "entry": [
+                    true,
                     false,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 2,
+                  "geometry_index": 16,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.146,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.019,
+                  "weight": 2.946,
+                  "location": [
+                    17.033443,
+                    51.11605
+                  ],
+                  "bearings": [
+                    168,
+                    218,
+                    349
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 17,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 11.077,
+                  "turn_weight": 5.5,
+                  "weight": 18.238,
+                  "location": [
+                    17.033481,
+                    51.115936
+                  ],
+                  "bearings": [
+                    168,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 19,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 4.32,
+                  "turn_weight": 5.5,
+                  "weight": 10.468,
+                  "location": [
+                    17.033724,
+                    51.115236
+                  ],
+                  "bearings": [
+                    168,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 20,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.68,
+                  "turn_weight": 0.5,
+                  "weight": 2.432,
+                  "location": [
+                    17.033777,
+                    51.115081
+                  ],
+                  "bearings": [
+                    168,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 21,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.222,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 3.048,
+                  "location": [
+                    17.033798,
+                    51.115018
+                  ],
+                  "bearings": [
+                    168,
+                    259,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 22,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 0.277,
+                  "turn_weight": 5.5,
+                  "weight": 5.818,
+                  "location": [
+                    17.033823,
+                    51.114946
+                  ],
+                  "bearings": [
+                    173,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 23,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 13.371,
+                  "turn_weight": 0.5,
+                  "weight": 15.877,
+                  "location": [
+                    17.033824,
+                    51.114941
+                  ],
+                  "bearings": [
+                    168,
+                    353
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 24,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.059,
+                  "turn_weight": 5.5,
+                  "weight": 6.718,
+                  "location": [
+                    17.033985,
+                    51.114481
+                  ],
+                  "bearings": [
+                    163,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 26,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 2,
+                  "turn_duration": 0.009,
+                  "location": [
+                    17.034006,
+                    51.114437
+                  ],
+                  "bearings": [
+                    70,
+                    167,
+                    253,
+                    343
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 29,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 92.148,
+              "distance": 290.545,
+              "duration": 63.67100000000001,
+              "duration_typical": 66.728,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "uown`Byttn_@\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArI",
+              "name": "Grodzka",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.034077,
+                  51.114251
+                ],
+                "bearing_before": 167.0,
+                "bearing_after": 250.0,
+                "instruction": "Turn right onto Grodzka.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 273.879,
+                  "announcement": "In 1,000 feet, Your destination will be on the right.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 1,000 feet, Your destination will be on the right.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 69.444,
+                  "announcement": "Your destination is on the right.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYour destination is on the right.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 290.545,
+                  "primary": {
+                    "text": "Your destination will be on the right",
+                    "components": [
+                      {
+                        "text": "Your destination will be on the right",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "right"
+                  }
+                },
+                {
+                  "distanceAlongGeometry": 69.444,
+                  "primary": {
+                    "text": "Your destination is on the right",
+                    "components": [
+                      {
+                        "text": "Your destination is on the right",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 92.148,
+              "intersections": [
+                {
+                  "duration": 4.906,
+                  "turn_weight": 8,
+                  "turn_duration": 3.636,
+                  "weight": 9.461,
+                  "location": [
+                    17.034077,
+                    51.114251
+                  ],
+                  "bearings": [
+                    68,
+                    170,
+                    250,
+                    347
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 2,
+                  "geometry_index": 33,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.777,
+                  "turn_weight": 2,
+                  "turn_duration": 0.024,
+                  "weight": 5.166,
+                  "location": [
+                    17.033999,
+                    51.114233
+                  ],
+                  "bearings": [
+                    70,
+                    132,
+                    246,
+                    329
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 35,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 18.024,
+                  "turn_weight": 2,
+                  "turn_duration": 0.024,
+                  "weight": 22.7,
+                  "location": [
+                    17.033826,
+                    51.114184
+                  ],
+                  "bearings": [
+                    66,
+                    151,
+                    242,
+                    327
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 38,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 3.176,
+                  "turn_weight": 0.5,
+                  "weight": 4.153,
+                  "location": [
+                    17.032758,
+                    51.113826
+                  ],
+                  "bearings": [
+                    60,
+                    241
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 41,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 0.776,
+                  "turn_duration": 0.009,
+                  "turn_weight": 0.5,
+                  "duration": 0.249,
+                  "location": [
+                    17.03257,
+                    51.113761
+                  ],
+                  "bearings": [
+                    61,
+                    159,
+                    245
+                  ],
+                  "entry": [
                     false,
                     true,
                     true
                   ],
                   "in": 0,
-                  "turn_weight": 8,
-                  "turn_duration": 2.649,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 43,
                   "is_urban": true,
                   "admin_index": 0,
-                  "out": 3,
-                  "geometry_index": 91,
-                  "location": [
-                    17.033422,
-                    51.116117
-                  ]
-                }
-              ],
-              "bannerInstructions": [
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
                 {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "You have arrived at your destination"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "straight",
-                    "text": "You have arrived at your destination"
-                  },
-                  "distanceAlongGeometry": 7
+                  "duration": 1.2,
+                  "turn_weight": 0.5,
+                  "weight": 1.88,
+                  "location": [
+                    17.032553,
+                    51.113756
+                  ],
+                  "bearings": [
+                    65,
+                    245
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 44,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 16.16,
+                  "turn_weight": 0.5,
+                  "turn_duration": 2,
+                  "weight": 16.784,
+                  "location": [
+                    17.032489,
+                    51.113737
+                  ],
+                  "bearings": [
+                    65,
+                    243
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 45,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 6.692,
+                  "turn_duration": 0.022,
+                  "turn_weight": 2,
+                  "duration": 4.102,
+                  "location": [
+                    17.031735,
+                    51.113492
+                  ],
+                  "bearings": [
+                    62,
+                    153,
+                    240,
+                    334
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 51,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.707,
+                  "turn_duration": 0.007,
+                  "turn_weight": 5.5,
+                  "duration": 0.187,
+                  "location": [
+                    17.031523,
+                    51.113416
+                  ],
+                  "bearings": [
+                    60,
+                    155,
+                    242
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 53,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "location": [
+                    17.031517,
+                    51.113414
+                  ],
+                  "bearings": [
+                    62,
+                    242,
+                    259
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 54,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
                 }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn right onto Wojciecha Cybulskiego.",
-                "modifier": "right",
-                "bearing_after": 276,
-                "bearing_before": 181,
-                "location": [
-                  17.033422,
-                  51.116117
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Wojciecha Cybulskiego",
-              "weight_typical": 11.22,
-              "duration_typical": 5.449,
-              "duration": 5.449,
-              "distance": 7,
-              "driving_side": "right",
-              "weight": 11.22,
-              "mode": "driving",
-              "geometry": "id{n`B{ksn_@KdE"
+              ]
             },
             {
+              "weight_typical": 0,
+              "distance": 0.0,
+              "duration": 0.0,
+              "duration_typical": 0.0,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "}eun`Bommn_@??",
+              "name": "Grodzka",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.030376,
+                  51.113071
+                ],
+                "bearing_before": 249.0,
+                "bearing_after": 0.0,
+                "instruction": "Your destination is on the right.",
+                "type": "arrive",
+                "modifier": "right"
+              },
               "voiceInstructions": [],
+              "bannerInstructions": [],
+              "driving_side": "right",
+              "weight": 0.0,
               "intersections": [
                 {
+                  "location": [
+                    17.030376,
+                    51.113071
+                  ],
                   "bearings": [
-                    96
+                    69
                   ],
                   "entry": [
                     true
                   ],
                   "in": 0,
-                  "admin_index": 0,
-                  "geometry_index": 92,
-                  "location": [
-                    17.033323,
-                    51.116123
-                  ]
+                  "geometry_index": 60,
+                  "admin_index": 0
                 }
-              ],
-              "bannerInstructions": [],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "arrive",
-                "instruction": "You have arrived at your destination.",
-                "bearing_after": 0,
-                "bearing_before": 276,
-                "location": [
-                  17.033323,
-                  51.116123
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Wojciecha Cybulskiego",
-              "weight_typical": 0,
-              "duration_typical": 0,
-              "duration": 0,
-              "distance": 0,
-              "driving_side": "right",
-              "weight": 0,
-              "mode": "driving",
-              "geometry": "ud{n`Buesn_@??"
-            }
-          ],
-          "distance": 1035.017,
-          "summary": "Trzebnicka, Bolesława Drobnera"
-        },
-        {
-          "via_waypoints": [],
-          "admins": [
-            {
-              "iso_3166_1_alpha3": "POL",
-              "iso_3166_1": "PL"
+              ]
             }
           ],
           "annotation": {
+            "distance": [
+              3.2,
+              2.0,
+              1.8,
+              5.6,
+              3.3,
+              67.2,
+              39.2,
+              39.2,
+              67.2,
+              3.3,
+              5.6,
+              1.8,
+              2.0,
+              3.2,
+              7.0,
+              7.6,
+              10.9,
+              2.0,
+              79.8,
+              17.6,
+              7.2,
+              8.2,
+              0.6,
+              8.4,
+              44.0,
+              0.8,
+              0.7,
+              3.6,
+              2.1,
+              9.0,
+              8.6,
+              1.6,
+              5.0,
+              0.8,
+              9.2,
+              1.8,
+              2.3,
+              2.4,
+              63.4,
+              18.8,
+              11.6,
+              3.4,
+              1.3,
+              4.9,
+              21.9,
+              3.2,
+              11.6,
+              0.5,
+              17.7,
+              4.4,
+              5.1,
+              12.0,
+              0.5,
+              2.1,
+              30.9,
+              8.4,
+              20.4,
+              14.1,
+              12.3,
+              12.6
+            ],
+            "duration": [
+              1.261,
+              0.812,
+              0.729,
+              2.227,
+              0.74,
+              15.124,
+              10.073,
+              8.814,
+              15.124,
+              0.74,
+              2.506,
+              0.82,
+              0.913,
+              1.418,
+              3.128,
+              1.244,
+              1.787,
+              0.335,
+              11.043,
+              4.235,
+              1.72,
+              2.272,
+              0.158,
+              2.332,
+              12.187,
+              0.175,
+              0.144,
+              0.764,
+              0.445,
+              1.914,
+              1.812,
+              0.346,
+              1.119,
+              0.189,
+              2.06,
+              0.402,
+              0.523,
+              0.547,
+              14.258,
+              4.237,
+              2.613,
+              0.762,
+              0.314,
+              1.187,
+              5.267,
+              0.768,
+              2.782,
+              0.112,
+              4.245,
+              1.066,
+              1.222,
+              2.872,
+              0.086,
+              0.373,
+              5.556,
+              1.518,
+              3.68,
+              2.545,
+              2.222,
+              2.265
+            ],
+            "speed": [
+              2.5,
+              2.5,
+              2.5,
+              2.5,
+              4.4,
+              4.4,
+              3.9,
+              4.4,
+              4.4,
+              4.4,
+              2.2,
+              2.2,
+              2.2,
+              2.2,
+              2.2,
+              6.1,
+              6.1,
+              6.1,
+              7.2,
+              4.2,
+              4.2,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              0.0
+            ],
             "maxspeed": [
               {
                 "speed": 30,
@@ -2767,1345 +4096,1785 @@
               43,
               43,
               null
-            ],
-            "speed": [
-              2.5,
-              2.5,
-              2.5,
-              2.5,
-              4.4,
-              4.4,
-              3.9,
-              4.4,
-              4.4,
-              4.4,
-              2.2,
-              2.2,
-              2.2,
-              2.2,
-              2.2,
-              6.1,
-              6.1,
-              6.1,
-              7.2,
-              4.2,
-              4.2,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              0
-            ],
-            "distance": [
-              3.2,
-              2,
-              1.8,
-              5.6,
-              3.3,
-              67.2,
-              39.2,
-              39.2,
-              67.2,
-              3.3,
-              5.6,
-              1.8,
-              2,
-              3.2,
-              7,
-              7.6,
-              10.9,
-              2,
-              79.8,
-              17.6,
-              7.2,
-              8.2,
-              0.6,
-              8.4,
-              44,
-              0.8,
-              0.7,
-              3.6,
-              2.1,
-              9,
-              8.6,
-              1.6,
-              5,
-              0.8,
-              9.2,
-              1.8,
-              2.3,
-              2.4,
-              63.4,
-              18.8,
-              11.6,
-              3.4,
-              1.3,
-              4.9,
-              21.9,
-              3.2,
-              11.6,
-              0.5,
-              17.7,
-              4.4,
-              5.1,
-              12,
-              0.5,
-              2.1,
-              30.9,
-              8.4,
-              20.4,
-              14.1,
-              12.3,
-              12.6
-            ],
-            "duration": [
-              1.261,
-              0.812,
-              0.729,
-              2.227,
-              0.74,
-              15.124,
-              10.073,
-              8.814,
-              15.124,
-              0.74,
-              2.506,
-              0.82,
-              0.913,
-              1.418,
-              3.128,
-              1.244,
-              1.787,
-              0.335,
-              11.043,
-              4.235,
-              1.72,
-              2.272,
-              0.158,
-              2.332,
-              12.187,
-              0.175,
-              0.144,
-              0.764,
-              0.445,
-              1.914,
-              1.812,
-              0.346,
-              1.119,
-              0.189,
-              2.06,
-              0.402,
-              0.523,
-              0.547,
-              14.258,
-              4.237,
-              2.613,
-              0.762,
-              0.314,
-              1.187,
-              5.267,
-              0.768,
-              2.782,
-              0.112,
-              4.245,
-              1.066,
-              1.222,
-              2.872,
-              0.086,
-              0.373,
-              5.556,
-              1.518,
-              3.68,
-              2.545,
-              2.222,
-              2.265
             ]
-          },
-          "weight_typical": 884.532,
-          "duration_typical": 201.157,
-          "weight": 884.532,
-          "duration": 201.157,
+          }
+        },
+        {
+          "weight_typical": 311.327,
+          "weight": 300.763,
+          "via_waypoints": [],
+          "distance": 1049.454,
+          "duration": 235.2469999999999,
+          "duration_typical": 236.14,
+          "summary": "Nowy Świat",
+          "admins": [
+            {
+              "iso_3166_1": "PL",
+              "iso_3166_1_alpha3": "POL"
+            }
+          ],
           "steps": [
             {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive south on <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>. Then, in 400 feet, Make a left U-turn to stay on <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Drive south on Wojciecha Cybulskiego. Then, in 400 feet, Make a left U-turn to stay on Wojciecha Cybulskiego.",
-                  "distanceAlongGeometry": 122
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Make a left U-turn to stay on <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Make a left U-turn to stay on Wojciecha Cybulskiego.",
-                  "distanceAlongGeometry": 66.667
-                }
-              ],
-              "intersections": [
-                {
-                  "bearings": [
-                    180
-                  ],
-                  "entry": [
-                    true
-                  ],
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "geometry_index": 0,
-                  "location": [
-                    17.033323,
-                    51.116123
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    0,
-                    271
-                  ],
-                  "duration": 2,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.8,
-                  "geometry_index": 1,
-                  "location": [
-                    17.033323,
-                    51.116123
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    91,
-                    176,
-                    284,
-                    356
-                  ],
-                  "duration": 2.815,
-                  "turn_weight": 2,
-                  "turn_duration": 0.015,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 5.22,
-                  "geometry_index": 3,
-                  "location": [
-                    17.033249,
-                    51.116124
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    104,
-                    199,
-                    293
-                  ],
-                  "duration": 15.988,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.013,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 18.871,
-                  "geometry_index": 5,
-                  "location": [
-                    17.033147,
-                    51.11614
-                  ]
-                },
-                {
-                  "bearings": [
-                    24,
-                    113,
-                    293
-                  ],
-                  "entry": [
-                    true,
-                    false,
-                    true
-                  ],
-                  "in": 1,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "geometry_index": 7,
-                  "location": [
-                    17.03222,
-                    51.11639
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Wojciecha Cybulskiego"
-                      }
-                    ],
-                    "driving_side": "right",
-                    "type": "turn",
-                    "modifier": "uturn",
-                    "text": "Wojciecha Cybulskiego"
-                  },
-                  "distanceAlongGeometry": 122
-                }
-              ],
+              "weight_typical": 311.327,
+              "distance": 1049.454,
+              "duration": 235.2469999999999,
+              "duration_typical": 236.14,
               "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "depart",
-                "instruction": "Drive south on Wojciecha Cybulskiego.",
-                "bearing_after": 180,
-                "bearing_before": 0,
-                "location": [
-                  17.033323,
-                  51.116123
-                ]
-              },
               "speedLimitSign": "vienna",
-              "name": "Wojciecha Cybulskiego",
-              "weight_typical": 38.924,
-              "duration_typical": 30.839,
-              "duration": 30.839,
-              "distance": 122,
-              "driving_side": "right",
-              "weight": 38.924,
+              "geometry": "}eun`Bommn_@TjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD",
+              "name": "Nowy Świat",
               "mode": "driving",
-              "geometry": "ud{n`Buesn_@??CxA@x@Ar@]vCWtA{Mfv@uGd_@"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 feet, Turn right onto <say-as interpret-as=\"address\">Most Uniwersytecki</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "In 400 feet, Turn right onto Most Uniwersytecki.",
-                  "distanceAlongGeometry": 119
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Most Uniwersytecki</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn right onto Most Uniwersytecki.",
-                  "distanceAlongGeometry": 50
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    113,
-                    113
-                  ],
-                  "duration": 36.23,
-                  "turn_weight": 628.5,
-                  "turn_duration": 27.455,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 638.591,
-                  "geometry_index": 8,
-                  "location": [
-                    17.031705,
-                    51.116529
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    24,
-                    113,
-                    293
-                  ],
-                  "duration": 15.982,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 18.871,
-                  "geometry_index": 9,
-                  "location": [
-                    17.03222,
-                    51.11639
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    104,
-                    199,
-                    293
-                  ],
-                  "duration": 3.186,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.036,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 4.122,
-                  "geometry_index": 11,
-                  "location": [
-                    17.033147,
-                    51.11614
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false,
-                    false,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    91,
-                    176,
-                    284,
-                    356
-                  ],
-                  "duration": 2.295,
-                  "turn_weight": 2,
-                  "turn_duration": 0.045,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 4.588,
-                  "geometry_index": 13,
-                  "location": [
-                    17.033249,
-                    51.116124
-                  ]
-                },
-                {
-                  "bearings": [
-                    96,
-                    271
-                  ],
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "geometry_index": 15,
-                  "location": [
-                    17.033323,
-                    51.116123
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Most Uniwersytecki"
-                      }
-                    ],
-                    "type": "turn",
-                    "modifier": "right",
-                    "text": "Most Uniwersytecki"
-                  },
-                  "distanceAlongGeometry": 129
-                }
-              ],
-              "speedLimitUnit": "km/h",
               "maneuver": {
-                "type": "continue",
-                "instruction": "Make a left U-turn to stay on Wojciecha Cybulskiego.",
-                "modifier": "uturn",
-                "bearing_after": 113,
-                "bearing_before": 293,
-                "location": [
-                  17.031705,
-                  51.116529
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Wojciecha Cybulskiego",
-              "weight_typical": 670.295,
-              "duration_typical": 60.842,
-              "duration": 60.842,
-              "distance": 129,
-              "driving_side": "right",
-              "weight": 670.295,
-              "mode": "driving",
-              "geometry": "a~{n`Bq`pn_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeE"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 700 feet, Turn right onto <say-as interpret-as=\"address\">Grodzka</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "In 700 feet, Turn right onto Grodzka.",
-                  "distanceAlongGeometry": 196.333
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Grodzka</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn right onto Grodzka.",
-                  "distanceAlongGeometry": 77.778
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
-                    true,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    1,
-                    125,
-                    169,
-                    276
-                  ],
-                  "duration": 2.14,
-                  "turn_weight": 9,
-                  "turn_duration": 0.831,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 10.505,
-                  "geometry_index": 16,
-                  "location": [
-                    17.033422,
-                    51.116117
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    168,
-                    218,
-                    349
-                  ],
-                  "duration": 2.146,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 2.946,
-                  "geometry_index": 17,
-                  "location": [
-                    17.033443,
-                    51.11605
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    348
-                  ],
-                  "duration": 11.077,
-                  "turn_weight": 5.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 18.238,
-                  "geometry_index": 19,
-                  "location": [
-                    17.033481,
-                    51.115936
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    348
-                  ],
-                  "duration": 4.32,
-                  "turn_weight": 5.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 10.468,
-                  "geometry_index": 20,
-                  "location": [
-                    17.033724,
-                    51.115236
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    348
-                  ],
-                  "duration": 1.68,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 2.432,
-                  "geometry_index": 21,
-                  "location": [
-                    17.033777,
-                    51.115081
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    168,
-                    259,
-                    348
-                  ],
-                  "duration": 2.222,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.048,
-                  "geometry_index": 22,
-                  "location": [
-                    17.033798,
-                    51.115018
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    173,
-                    348
-                  ],
-                  "duration": 0.277,
-                  "turn_weight": 5.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 5.818,
-                  "geometry_index": 23,
-                  "location": [
-                    17.033823,
-                    51.114946
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    353
-                  ],
-                  "duration": 13.371,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 15.877,
-                  "geometry_index": 24,
-                  "location": [
-                    17.033824,
-                    51.114941
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    163,
-                    348
-                  ],
-                  "duration": 1.059,
-                  "turn_weight": 5.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 6.718,
-                  "geometry_index": 26,
-                  "location": [
-                    17.033985,
-                    51.114481
-                  ]
-                },
-                {
-                  "bearings": [
-                    70,
-                    167,
-                    253,
-                    343
-                  ],
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "turn_weight": 2,
-                  "turn_duration": 0.009,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "geometry_index": 29,
-                  "location": [
-                    17.034006,
-                    51.114437
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Grodzka"
-                      }
-                    ],
-                    "type": "turn",
-                    "modifier": "right",
-                    "text": "Grodzka"
-                  },
-                  "distanceAlongGeometry": 213
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn right onto Most Uniwersytecki.",
-                "modifier": "right",
-                "bearing_after": 169,
-                "bearing_before": 96,
-                "location": [
-                  17.033422,
-                  51.116117
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Most Uniwersytecki",
-              "weight_typical": 83.165,
-              "duration_typical": 42.749,
-              "duration": 42.749,
-              "distance": 213,
-              "driving_side": "right",
-              "weight": 83.165,
-              "mode": "driving",
-              "geometry": "id{n`B{ksn_@dCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1,000 feet, Your destination will be on the right.</prosody></amazon:effect></speak>",
-                  "announcement": "In 1,000 feet, Your destination will be on the right.",
-                  "distanceAlongGeometry": 273.879
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Your destination is on the right.</prosody></amazon:effect></speak>",
-                  "announcement": "Your destination is on the right.",
-                  "distanceAlongGeometry": 69.444
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    68,
-                    170,
-                    250,
-                    347
-                  ],
-                  "duration": 4.906,
-                  "turn_weight": 8,
-                  "turn_duration": 3.636,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 9.461,
-                  "geometry_index": 33,
-                  "location": [
-                    17.034077,
-                    51.114251
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    70,
-                    132,
-                    246,
-                    329
-                  ],
-                  "duration": 2.777,
-                  "turn_weight": 2,
-                  "turn_duration": 0.024,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 5.166,
-                  "geometry_index": 35,
-                  "location": [
-                    17.033999,
-                    51.114233
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    66,
-                    151,
-                    242,
-                    327
-                  ],
-                  "duration": 18.024,
-                  "turn_weight": 2,
-                  "turn_duration": 0.024,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 22.7,
-                  "geometry_index": 38,
-                  "location": [
-                    17.033826,
-                    51.114184
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    60,
-                    241
-                  ],
-                  "duration": 3.176,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 4.153,
-                  "geometry_index": 41,
-                  "location": [
-                    17.032758,
-                    51.113826
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "left"
-                      ],
-                      "valid": false,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.03257,
-                    51.113761
-                  ],
-                  "geometry_index": 43,
-                  "admin_index": 0,
-                  "weight": 0.776,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.009,
-                  "turn_weight": 0.5,
-                  "duration": 0.249,
-                  "bearings": [
-                    61,
-                    159,
-                    245
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    65,
-                    245
-                  ],
-                  "duration": 1.2,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 1.88,
-                  "geometry_index": 44,
-                  "location": [
-                    17.032553,
-                    51.113756
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    65,
-                    243
-                  ],
-                  "duration": 16.16,
-                  "turn_weight": 0.5,
-                  "turn_duration": 2,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 16.784,
-                  "geometry_index": 45,
-                  "location": [
-                    17.032489,
-                    51.113737
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.031735,
-                    51.113492
-                  ],
-                  "geometry_index": 51,
-                  "admin_index": 0,
-                  "weight": 6.692,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.022,
-                  "turn_weight": 2,
-                  "duration": 4.102,
-                  "bearings": [
-                    62,
-                    153,
-                    240,
-                    334
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.031523,
-                    51.113416
-                  ],
-                  "geometry_index": 53,
-                  "admin_index": 0,
-                  "weight": 5.707,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 5.5,
-                  "duration": 0.187,
-                  "bearings": [
-                    60,
-                    155,
-                    242
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true
-                  ]
-                },
-                {
-                  "bearings": [
-                    62,
-                    242,
-                    259
-                  ],
-                  "entry": [
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 0,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "geometry_index": 54,
-                  "location": [
-                    17.031517,
-                    51.113414
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Your destination will be on the right"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "right",
-                    "text": "Your destination will be on the right"
-                  },
-                  "distanceAlongGeometry": 290.545
-                },
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Your destination is on the right"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "right",
-                    "text": "Your destination is on the right"
-                  },
-                  "distanceAlongGeometry": 69.444
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn right onto Grodzka.",
-                "modifier": "right",
-                "bearing_after": 250,
-                "bearing_before": 167,
-                "location": [
-                  17.034077,
-                  51.114251
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Grodzka",
-              "weight_typical": 92.148,
-              "duration_typical": 66.728,
-              "duration": 66.728,
-              "distance": 290.545,
-              "driving_side": "right",
-              "weight": 92.148,
-              "mode": "driving",
-              "geometry": "uown`Byttn_@\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArI"
-            },
-            {
-              "voiceInstructions": [],
-              "intersections": [
-                {
-                  "bearings": [
-                    69
-                  ],
-                  "entry": [
-                    true
-                  ],
-                  "in": 0,
-                  "admin_index": 0,
-                  "geometry_index": 60,
-                  "location": [
-                    17.030376,
-                    51.113071
-                  ]
-                }
-              ],
-              "bannerInstructions": [],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "arrive",
-                "instruction": "Your destination is on the right.",
-                "modifier": "right",
-                "bearing_after": 0,
-                "bearing_before": 249,
                 "location": [
                   17.030376,
                   51.113071
-                ]
+                ],
+                "bearing_before": 0.0,
+                "bearing_after": 252.0,
+                "instruction": "Drive west on Nowy Świat.",
+                "type": "depart"
               },
-              "speedLimitSign": "vienna",
-              "name": "Grodzka",
-              "weight_typical": 0,
-              "duration_typical": 0,
-              "duration": 0,
-              "distance": 0,
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 1049.454,
+                  "announcement": "Drive west on Nowy Świat for a half mile.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive west on \u003csay-as interpret-as\u003d\"address\"\u003eNowy Świat\u003c/say-as\u003e for a half mile.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 402.336,
+                  "announcement": "In a quarter mile, You will arrive at your destination.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, You will arrive at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 69.444,
+                  "announcement": "You have arrived at your destination.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYou have arrived at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 1049.454,
+                  "primary": {
+                    "text": "You will arrive at your destination",
+                    "components": [
+                      {
+                        "text": "You will arrive at your destination",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight"
+                  }
+                },
+                {
+                  "distanceAlongGeometry": 69.444,
+                  "primary": {
+                    "text": "You have arrived at your destination",
+                    "components": [
+                      {
+                        "text": "You have arrived at your destination",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight"
+                  }
+                }
+              ],
               "driving_side": "right",
-              "weight": 0,
-              "mode": "driving",
-              "geometry": "}eun`Bommn_@??"
-            }
-          ],
-          "distance": 754.545,
-          "summary": "Wojciecha Cybulskiego, Grodzka"
-        },
-        {
-          "via_waypoints": [],
-          "admins": [
+              "weight": 300.763,
+              "intersections": [
+                {
+                  "duration": 1.882,
+                  "weight": 2.164,
+                  "location": [
+                    17.030376,
+                    51.113071
+                  ],
+                  "bearings": [
+                    252
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "out": 0,
+                  "geometry_index": 0,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 10.987,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 13.127,
+                  "location": [
+                    17.030229,
+                    51.113042
+                  ],
+                  "bearings": [
+                    72,
+                    254,
+                    341
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 2,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.999,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.019,
+                  "weight": 2.777,
+                  "location": [
+                    17.02938,
+                    51.112899
+                  ],
+                  "bearings": [
+                    51,
+                    77,
+                    256
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "out": 2,
+                  "geometry_index": 6,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 7.874,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.019,
+                  "weight": 9.533,
+                  "location": [
+                    17.029225,
+                    51.112874
+                  ],
+                  "bearings": [
+                    76,
+                    221,
+                    255
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 8,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 21.934,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 25.716,
+                  "location": [
+                    17.028887,
+                    51.112818
+                  ],
+                  "bearings": [
+                    75,
+                    237,
+                    255
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 12,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 10.473,
+                  "turn_weight": 0.5,
+                  "weight": 12.544,
+                  "location": [
+                    17.027979,
+                    51.112643
+                  ],
+                  "bearings": [
+                    68,
+                    239
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 16,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 34.246,
+                  "turn_duration": 0.041,
+                  "turn_weight": 0.75,
+                  "duration": 29.169,
+                  "location": [
+                    17.027597,
+                    51.112484
+                  ],
+                  "bearings": [
+                    54,
+                    222,
+                    310
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 19,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 6.516,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 3.935,
+                  "location": [
+                    17.027004,
+                    51.111793
+                  ],
+                  "bearings": [
+                    19,
+                    96,
+                    198,
+                    275
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 26,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 3.505,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 1.316,
+                  "location": [
+                    17.02695,
+                    51.111689
+                  ],
+                  "bearings": [
+                    18,
+                    86,
+                    198,
+                    260
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 28,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 3.505,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 1.316,
+                  "location": [
+                    17.026933,
+                    51.111657
+                  ],
+                  "bearings": [
+                    18,
+                    63,
+                    198,
+                    255
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 29,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 13.332,
+                  "turn_duration": 0.021,
+                  "turn_weight": 7,
+                  "duration": 5.527,
+                  "location": [
+                    17.026913,
+                    51.111619
+                  ],
+                  "bearings": [
+                    18,
+                    122,
+                    195,
+                    277,
+                    314
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 30,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 11.254,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 8.054,
+                  "location": [
+                    17.026816,
+                    51.111393
+                  ],
+                  "bearings": [
+                    15,
+                    104,
+                    195,
+                    283
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 33,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 6.565,
+                  "turn_weight": 0.5,
+                  "weight": 8.049,
+                  "location": [
+                    17.02668,
+                    51.111064
+                  ],
+                  "bearings": [
+                    15,
+                    194
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 35,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 2.205,
+                  "turn_duration": 0.009,
+                  "turn_weight": 0.5,
+                  "duration": 1.491,
+                  "location": [
+                    17.026569,
+                    51.110798
+                  ],
+                  "bearings": [
+                    15,
+                    198,
+                    283
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 37,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 6.588,
+                  "turn_duration": 0.021,
+                  "turn_weight": 0.5,
+                  "duration": 5.315,
+                  "location": [
+                    17.02654,
+                    51.110741
+                  ],
+                  "bearings": [
+                    18,
+                    195,
+                    284
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 38,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.653,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 3.184,
+                  "location": [
+                    17.026447,
+                    51.110523
+                  ],
+                  "bearings": [
+                    15,
+                    104,
+                    195,
+                    289
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 41,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 6.14,
+                  "turn_duration": 0.071,
+                  "turn_weight": 2,
+                  "duration": 3.671,
+                  "location": [
+                    17.026392,
+                    51.110395
+                  ],
+                  "bearings": [
+                    15,
+                    86,
+                    107,
+                    177,
+                    277
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 3,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 44,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 14.102,
+                  "turn_duration": 0.028,
+                  "turn_weight": 2,
+                  "duration": 10.551,
+                  "location": [
+                    17.026401,
+                    51.110277
+                  ],
+                  "bearings": [
+                    101,
+                    172,
+                    282,
+                    357
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 47,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.354,
+                  "turn_duration": 0.019,
+                  "turn_weight": 0.5,
+                  "duration": 4.24,
+                  "location": [
+                    17.026479,
+                    51.10994
+                  ],
+                  "bearings": [
+                    171,
+                    338,
+                    351
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 50,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 3.972,
+                  "turn_weight": 0.5,
+                  "weight": 5.068,
+                  "location": [
+                    17.026559,
+                    51.109637
+                  ],
+                  "bearings": [
+                    168,
+                    351
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 52,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 15.628,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.028,
+                  "weight": 18.44,
+                  "location": [
+                    17.026652,
+                    51.109355
+                  ],
+                  "bearings": [
+                    162,
+                    177,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 55,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 2.664,
+                  "turn_weight": 2,
+                  "turn_duration": 0.024,
+                  "weight": 5.036,
+                  "location": [
+                    17.026986,
+                    51.108814
+                  ],
+                  "bearings": [
+                    66,
+                    150,
+                    242,
+                    335
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 60,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 7.466,
+                  "turn_weight": 2,
+                  "turn_duration": 0.026,
+                  "weight": 10.556,
+                  "location": [
+                    17.027068,
+                    51.108726
+                  ],
+                  "bearings": [
+                    58,
+                    144,
+                    237,
+                    330
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 63,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 4.215,
+                  "turn_weight": 2,
+                  "turn_duration": 0.061,
+                  "weight": 6.777,
+                  "location": [
+                    17.027326,
+                    51.108502
+                  ],
+                  "bearings": [
+                    66,
+                    128,
+                    232,
+                    324
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 68,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 4.459,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.028,
+                  "weight": 5.595,
+                  "location": [
+                    17.027677,
+                    51.10834
+                  ],
+                  "bearings": [
+                    119,
+                    220,
+                    305
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 72,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 0.438,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.022,
+                  "weight": 0.978,
+                  "location": [
+                    17.028079,
+                    51.108207
+                  ],
+                  "bearings": [
+                    114,
+                    206,
+                    297
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 76,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 2.492,
+                  "turn_weight": 0.5,
+                  "weight": 3.366,
+                  "location": [
+                    17.028119,
+                    51.108196
+                  ],
+                  "bearings": [
+                    110,
+                    294
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 77,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 1.267,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.021,
+                  "weight": 1.933,
+                  "location": [
+                    17.028364,
+                    51.10814
+                  ],
+                  "bearings": [
+                    109,
+                    206,
+                    290
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 79,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 6.516,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.008,
+                  "weight": 7.984,
+                  "location": [
+                    17.028483,
+                    51.108114
+                  ],
+                  "bearings": [
+                    111,
+                    199,
+                    289
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 80,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 1.819,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.019,
+                  "weight": 2.57,
+                  "location": [
+                    17.029114,
+                    51.107963
+                  ],
+                  "bearings": [
+                    110,
+                    200,
+                    291
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 83,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 2.222,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 3.048,
+                  "location": [
+                    17.029285,
+                    51.107924
+                  ],
+                  "bearings": [
+                    110,
+                    199,
+                    290
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 85,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 3.468,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 5.981,
+                  "location": [
+                    17.029496,
+                    51.107876
+                  ],
+                  "bearings": [
+                    18,
+                    110,
+                    197,
+                    290
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 87,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 20.312,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.021,
+                  "weight": 23.835,
+                  "location": [
+                    17.029839,
+                    51.107799
+                  ],
+                  "bearings": [
+                    109,
+                    203,
+                    290
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 90,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 4.091,
+                  "turn_weight": 0.5,
+                  "weight": 5.205,
+                  "location": [
+                    17.031499,
+                    51.10742
+                  ],
+                  "bearings": [
+                    115,
+                    293
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 97,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 2.455,
+                  "turn_weight": 0.5,
+                  "weight": 3.323,
+                  "location": [
+                    17.031825,
+                    51.107323
+                  ],
+                  "bearings": [
+                    117,
+                    295
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 98,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "weight": 1.253,
+                  "turn_duration": 2,
+                  "turn_weight": 0.5,
+                  "duration": 2.655,
+                  "location": [
+                    17.032023,
+                    51.107261
+                  ],
+                  "bearings": [
+                    112,
+                    297
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "uturn",
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 99,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "turn_weight": 2,
+                  "turn_duration": 0.022,
+                  "location": [
+                    17.032075,
+                    51.107248
+                  ],
+                  "bearings": [
+                    18,
+                    109,
+                    197,
+                    292
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "uturn",
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 101,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                }
+              ]
+            },
             {
-              "iso_3166_1_alpha3": "POL",
-              "iso_3166_1": "PL"
+              "weight_typical": 0,
+              "distance": 0.0,
+              "duration": 0.0,
+              "duration_typical": 0.0,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "oxin`Bo~pn_@??",
+              "name": "Nowy Świat",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.032184,
+                  51.107224
+                ],
+                "bearing_before": 109.0,
+                "bearing_after": 0.0,
+                "instruction": "You have arrived at your destination.",
+                "type": "arrive"
+              },
+              "voiceInstructions": [],
+              "bannerInstructions": [],
+              "driving_side": "right",
+              "weight": 0.0,
+              "intersections": [
+                {
+                  "location": [
+                    17.032184,
+                    51.107224
+                  ],
+                  "bearings": [
+                    289
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "geometry_index": 103,
+                  "admin_index": 0
+                }
+              ]
             }
           ],
           "annotation": {
+            "distance": [
+              4.2,
+              6.8,
+              4.1,
+              5.2,
+              32.2,
+              19.9,
+              8.8,
+              2.4,
+              8.2,
+              0.4,
+              11.5,
+              4.3,
+              15.5,
+              34.0,
+              9.1,
+              8.0,
+              17.4,
+              8.9,
+              5.9,
+              4.2,
+              11.9,
+              17.7,
+              19.6,
+              29.2,
+              3.2,
+              2.8,
+              3.4,
+              8.8,
+              3.8,
+              4.5,
+              11.2,
+              11.7,
+              3.2,
+              2.3,
+              35.5,
+              26.1,
+              4.5,
+              6.7,
+              2.7,
+              19.4,
+              3.1,
+              3.0,
+              6.0,
+              5.7,
+              7.0,
+              3.1,
+              3.0,
+              4.4,
+              3.0,
+              30.5,
+              2.1,
+              32.0,
+              8.6,
+              15.9,
+              7.5,
+              24.0,
+              7.0,
+              24.5,
+              7.6,
+              1.5,
+              1.8,
+              5.8,
+              3.7,
+              1.6,
+              2.1,
+              12.9,
+              13.3,
+              0.8,
+              13.9,
+              3.6,
+              9.8,
+              3.2,
+              4.9,
+              11.3,
+              11.0,
+              4.6,
+              3.1,
+              15.7,
+              2.6,
+              8.8,
+              4.1,
+              37.7,
+              5.4,
+              9.2,
+              3.5,
+              8.3,
+              7.4,
+              4.7,
+              13.2,
+              7.6,
+              12.5,
+              3.9,
+              20.0,
+              19.7,
+              25.0,
+              35.0,
+              7.4,
+              25.2,
+              15.5,
+              2.3,
+              1.6,
+              1.6,
+              6.5
+            ],
+            "duration": [
+              0.755,
+              1.224,
+              0.745,
+              0.93,
+              5.804,
+              3.583,
+              1.581,
+              0.432,
+              2.676,
+              0.146,
+              3.758,
+              1.42,
+              5.058,
+              11.141,
+              2.975,
+              2.608,
+              5.681,
+              2.901,
+              1.93,
+              1.375,
+              3.893,
+              5.799,
+              6.415,
+              9.548,
+              1.034,
+              0.923,
+              1.118,
+              2.867,
+              1.229,
+              1.458,
+              2.514,
+              2.623,
+              0.726,
+              0.516,
+              7.997,
+              5.871,
+              1.017,
+              1.499,
+              0.597,
+              4.358,
+              0.698,
+              0.683,
+              1.348,
+              1.291,
+              1.943,
+              0.864,
+              0.836,
+              1.21,
+              0.838,
+              8.451,
+              0.643,
+              9.614,
+              2.588,
+              4.778,
+              2.252,
+              5.769,
+              1.685,
+              5.889,
+              1.817,
+              0.37,
+              0.433,
+              1.402,
+              0.889,
+              0.388,
+              0.502,
+              3.097,
+              3.201,
+              0.199,
+              1.724,
+              0.452,
+              1.212,
+              0.397,
+              0.603,
+              1.405,
+              1.366,
+              0.569,
+              0.379,
+              1.944,
+              0.318,
+              1.093,
+              0.51,
+              4.682,
+              0.667,
+              1.148,
+              0.431,
+              1.027,
+              0.921,
+              0.58,
+              1.64,
+              0.94,
+              2.052,
+              0.634,
+              3.273,
+              3.219,
+              4.093,
+              5.732,
+              1.214,
+              4.126,
+              2.531,
+              0.373,
+              0.268,
+              0.257,
+              1.064
+            ],
+            "speed": [
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              3.3,
+              3.3,
+              3.3,
+              3.3,
+              3.3,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1
+            ],
             "maxspeed": [
               {
                 "speed": 50,
@@ -4624,1815 +6393,59 @@
               3,
               3,
               3
-            ],
-            "speed": [
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              3.3,
-              3.3,
-              3.3,
-              3.3,
-              3.3,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1
-            ],
-            "distance": [
-              4.2,
-              6.8,
-              4.1,
-              5.2,
-              32.2,
-              19.9,
-              8.8,
-              2.4,
-              8.2,
-              0.4,
-              11.5,
-              4.3,
-              15.5,
-              34,
-              9.1,
-              8,
-              17.4,
-              8.9,
-              5.9,
-              4.2,
-              11.9,
-              17.7,
-              19.6,
-              29.2,
-              3.2,
-              2.8,
-              3.4,
-              8.8,
-              3.8,
-              4.5,
-              11.2,
-              11.7,
-              3.2,
-              2.3,
-              35.5,
-              26.1,
-              4.5,
-              6.7,
-              2.7,
-              19.4,
-              3.1,
-              3,
-              6,
-              5.7,
-              7,
-              3.1,
-              3,
-              4.4,
-              3,
-              30.5,
-              2.1,
-              32,
-              8.6,
-              15.9,
-              7.5,
-              24,
-              7,
-              24.5,
-              7.6,
-              1.5,
-              1.8,
-              5.8,
-              3.7,
-              1.6,
-              2.1,
-              12.9,
-              13.3,
-              0.8,
-              13.9,
-              3.6,
-              9.8,
-              3.2,
-              4.9,
-              11.3,
-              11,
-              4.6,
-              3.1,
-              15.7,
-              2.6,
-              8.8,
-              4.1,
-              37.7,
-              5.4,
-              9.2,
-              3.5,
-              8.3,
-              7.4,
-              4.7,
-              13.2,
-              7.6,
-              12.5,
-              3.9,
-              20,
-              19.7,
-              25,
-              35,
-              7.4,
-              25.2,
-              15.5,
-              2.3,
-              1.6,
-              1.6,
-              6.5
-            ],
-            "duration": [
-              0.755,
-              1.224,
-              0.745,
-              0.93,
-              5.804,
-              3.583,
-              1.581,
-              0.432,
-              2.676,
-              0.146,
-              3.758,
-              1.42,
-              5.058,
-              11.141,
-              2.975,
-              2.608,
-              5.681,
-              2.901,
-              1.93,
-              1.375,
-              3.893,
-              5.799,
-              6.415,
-              9.548,
-              1.034,
-              0.923,
-              1.118,
-              2.867,
-              1.229,
-              1.458,
-              2.514,
-              2.623,
-              0.726,
-              0.516,
-              7.997,
-              5.871,
-              1.017,
-              1.499,
-              0.597,
-              4.358,
-              0.698,
-              0.683,
-              1.348,
-              1.291,
-              1.943,
-              0.864,
-              0.836,
-              1.21,
-              0.838,
-              8.451,
-              0.643,
-              9.614,
-              2.588,
-              4.778,
-              2.252,
-              5.769,
-              1.685,
-              5.889,
-              1.817,
-              0.37,
-              0.433,
-              1.402,
-              0.889,
-              0.388,
-              0.502,
-              3.097,
-              3.201,
-              0.199,
-              1.724,
-              0.452,
-              1.212,
-              0.397,
-              0.603,
-              1.405,
-              1.366,
-              0.569,
-              0.379,
-              1.944,
-              0.318,
-              1.093,
-              0.51,
-              4.682,
-              0.667,
-              1.148,
-              0.431,
-              1.027,
-              0.921,
-              0.58,
-              1.64,
-              0.94,
-              2.052,
-              0.634,
-              3.273,
-              3.219,
-              4.093,
-              5.732,
-              1.214,
-              4.126,
-              2.531,
-              0.373,
-              0.268,
-              0.257,
-              1.064
             ]
-          },
-          "weight_typical": 311.327,
-          "duration_typical": 236.14,
-          "weight": 300.763,
-          "duration": 226.953,
-          "steps": [
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive west on <say-as interpret-as=\"address\">Nowy Świat</say-as> for a half mile.</prosody></amazon:effect></speak>",
-                  "announcement": "Drive west on Nowy Świat for a half mile.",
-                  "distanceAlongGeometry": 1049.454
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In a quarter mile, You will arrive at your destination.</prosody></amazon:effect></speak>",
-                  "announcement": "In a quarter mile, You will arrive at your destination.",
-                  "distanceAlongGeometry": 402.336
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">You have arrived at your destination.</prosody></amazon:effect></speak>",
-                  "announcement": "You have arrived at your destination.",
-                  "distanceAlongGeometry": 69.444
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
-                    true
-                  ],
-                  "bearings": [
-                    252
-                  ],
-                  "duration": 1.882,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 2.164,
-                  "geometry_index": 0,
-                  "location": [
-                    17.030376,
-                    51.113071
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    72,
-                    254,
-                    341
-                  ],
-                  "duration": 10.987,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 13.127,
-                  "geometry_index": 2,
-                  "location": [
-                    17.030229,
-                    51.113042
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    51,
-                    77,
-                    256
-                  ],
-                  "duration": 1.999,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 2.777,
-                  "geometry_index": 6,
-                  "location": [
-                    17.02938,
-                    51.112899
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    76,
-                    221,
-                    255
-                  ],
-                  "duration": 7.874,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 9.533,
-                  "geometry_index": 8,
-                  "location": [
-                    17.029225,
-                    51.112874
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    75,
-                    237,
-                    255
-                  ],
-                  "duration": 21.934,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 25.716,
-                  "geometry_index": 12,
-                  "location": [
-                    17.028887,
-                    51.112818
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    68,
-                    239
-                  ],
-                  "duration": 10.473,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 12.544,
-                  "geometry_index": 16,
-                  "location": [
-                    17.027979,
-                    51.112643
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.027597,
-                    51.112484
-                  ],
-                  "geometry_index": 19,
-                  "admin_index": 0,
-                  "weight": 34.246,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.041,
-                  "turn_weight": 0.75,
-                  "duration": 29.169,
-                  "bearings": [
-                    54,
-                    222,
-                    310
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.027004,
-                    51.111793
-                  ],
-                  "geometry_index": 26,
-                  "admin_index": 0,
-                  "weight": 6.516,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 3.935,
-                  "bearings": [
-                    19,
-                    96,
-                    198,
-                    275
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.02695,
-                    51.111689
-                  ],
-                  "geometry_index": 28,
-                  "admin_index": 0,
-                  "weight": 3.505,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 1.316,
-                  "bearings": [
-                    18,
-                    86,
-                    198,
-                    260
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026933,
-                    51.111657
-                  ],
-                  "geometry_index": 29,
-                  "admin_index": 0,
-                  "weight": 3.505,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 1.316,
-                  "bearings": [
-                    18,
-                    63,
-                    198,
-                    255
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026913,
-                    51.111619
-                  ],
-                  "geometry_index": 30,
-                  "admin_index": 0,
-                  "weight": 13.332,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.021,
-                  "turn_weight": 7,
-                  "duration": 5.527,
-                  "bearings": [
-                    18,
-                    122,
-                    195,
-                    277,
-                    314
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026816,
-                    51.111393
-                  ],
-                  "geometry_index": 33,
-                  "admin_index": 0,
-                  "weight": 11.254,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 8.054,
-                  "bearings": [
-                    15,
-                    104,
-                    195,
-                    283
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    15,
-                    194
-                  ],
-                  "duration": 6.565,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 8.049,
-                  "geometry_index": 35,
-                  "location": [
-                    17.02668,
-                    51.111064
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026569,
-                    51.110798
-                  ],
-                  "geometry_index": 37,
-                  "admin_index": 0,
-                  "weight": 2.205,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.009,
-                  "turn_weight": 0.5,
-                  "duration": 1.491,
-                  "bearings": [
-                    15,
-                    198,
-                    283
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.02654,
-                    51.110741
-                  ],
-                  "geometry_index": 38,
-                  "admin_index": 0,
-                  "weight": 6.588,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.021,
-                  "turn_weight": 0.5,
-                  "duration": 5.315,
-                  "bearings": [
-                    18,
-                    195,
-                    284
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026447,
-                    51.110523
-                  ],
-                  "geometry_index": 41,
-                  "admin_index": 0,
-                  "weight": 5.653,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 3.184,
-                  "bearings": [
-                    15,
-                    104,
-                    195,
-                    289
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026392,
-                    51.110395
-                  ],
-                  "geometry_index": 44,
-                  "admin_index": 0,
-                  "weight": 6.14,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.071,
-                  "turn_weight": 2,
-                  "duration": 3.671,
-                  "bearings": [
-                    15,
-                    86,
-                    107,
-                    177,
-                    277
-                  ],
-                  "out": 3,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026401,
-                    51.110277
-                  ],
-                  "geometry_index": 47,
-                  "admin_index": 0,
-                  "weight": 14.102,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.028,
-                  "turn_weight": 2,
-                  "duration": 10.551,
-                  "bearings": [
-                    101,
-                    172,
-                    282,
-                    357
-                  ],
-                  "out": 1,
-                  "in": 3,
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026479,
-                    51.10994
-                  ],
-                  "geometry_index": 50,
-                  "admin_index": 0,
-                  "weight": 5.354,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "turn_duration": 0.019,
-                  "turn_weight": 0.5,
-                  "duration": 4.24,
-                  "bearings": [
-                    171,
-                    338,
-                    351
-                  ],
-                  "out": 0,
-                  "in": 2,
-                  "entry": [
-                    true,
-                    false,
-                    false
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    351
-                  ],
-                  "duration": 3.972,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 5.068,
-                  "geometry_index": 52,
-                  "location": [
-                    17.026559,
-                    51.109637
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    162,
-                    177,
-                    348
-                  ],
-                  "duration": 15.628,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.028,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 18.44,
-                  "geometry_index": 55,
-                  "location": [
-                    17.026652,
-                    51.109355
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    66,
-                    150,
-                    242,
-                    335
-                  ],
-                  "duration": 2.664,
-                  "turn_weight": 2,
-                  "turn_duration": 0.024,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.036,
-                  "geometry_index": 60,
-                  "location": [
-                    17.026986,
-                    51.108814
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    58,
-                    144,
-                    237,
-                    330
-                  ],
-                  "duration": 7.466,
-                  "turn_weight": 2,
-                  "turn_duration": 0.026,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 10.556,
-                  "geometry_index": 63,
-                  "location": [
-                    17.027068,
-                    51.108726
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    66,
-                    128,
-                    232,
-                    324
-                  ],
-                  "duration": 4.215,
-                  "turn_weight": 2,
-                  "turn_duration": 0.061,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 6.777,
-                  "geometry_index": 68,
-                  "location": [
-                    17.027326,
-                    51.108502
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    119,
-                    220,
-                    305
-                  ],
-                  "duration": 4.459,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.028,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 5.595,
-                  "geometry_index": 72,
-                  "location": [
-                    17.027677,
-                    51.10834
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    114,
-                    206,
-                    297
-                  ],
-                  "duration": 0.438,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.022,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 0.978,
-                  "geometry_index": 76,
-                  "location": [
-                    17.028079,
-                    51.108207
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    110,
-                    294
-                  ],
-                  "duration": 2.492,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.366,
-                  "geometry_index": 77,
-                  "location": [
-                    17.028119,
-                    51.108196
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    109,
-                    206,
-                    290
-                  ],
-                  "duration": 1.267,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.021,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 1.933,
-                  "geometry_index": 79,
-                  "location": [
-                    17.028364,
-                    51.10814
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    111,
-                    199,
-                    289
-                  ],
-                  "duration": 6.516,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.008,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 7.984,
-                  "geometry_index": 80,
-                  "location": [
-                    17.028483,
-                    51.108114
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    110,
-                    200,
-                    291
-                  ],
-                  "duration": 1.819,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 2.57,
-                  "geometry_index": 83,
-                  "location": [
-                    17.029114,
-                    51.107963
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    110,
-                    199,
-                    290
-                  ],
-                  "duration": 2.222,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.048,
-                  "geometry_index": 85,
-                  "location": [
-                    17.029285,
-                    51.107924
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    18,
-                    110,
-                    197,
-                    290
-                  ],
-                  "duration": 3.468,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.981,
-                  "geometry_index": 87,
-                  "location": [
-                    17.029496,
-                    51.107876
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    109,
-                    203,
-                    290
-                  ],
-                  "duration": 20.312,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.021,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 23.835,
-                  "geometry_index": 90,
-                  "location": [
-                    17.029839,
-                    51.107799
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    115,
-                    293
-                  ],
-                  "duration": 4.091,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 5.205,
-                  "geometry_index": 97,
-                  "location": [
-                    17.031499,
-                    51.10742
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    117,
-                    295
-                  ],
-                  "duration": 2.455,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.323,
-                  "geometry_index": 98,
-                  "location": [
-                    17.031825,
-                    51.107323
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "uturn",
-                        "left"
-                      ],
-                      "valid": false,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.032023,
-                    51.107261
-                  ],
-                  "geometry_index": 99,
-                  "admin_index": 0,
-                  "weight": 1.253,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "turn_duration": 2,
-                  "turn_weight": 0.5,
-                  "duration": 2.655,
-                  "bearings": [
-                    112,
-                    297
-                  ],
-                  "out": 0,
-                  "in": 1,
-                  "entry": [
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "bearings": [
-                    18,
-                    109,
-                    197,
-                    292
-                  ],
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "turn_weight": 2,
-                  "lanes": [
-                    {
-                      "indications": [
-                        "uturn",
-                        "left"
-                      ],
-                      "valid": false,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "turn_duration": 0.022,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "geometry_index": 101,
-                  "location": [
-                    17.032075,
-                    51.107248
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "You will arrive at your destination"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "straight",
-                    "text": "You will arrive at your destination"
-                  },
-                  "distanceAlongGeometry": 1049.454
-                },
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "You have arrived at your destination"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "straight",
-                    "text": "You have arrived at your destination"
-                  },
-                  "distanceAlongGeometry": 69.444
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "depart",
-                "instruction": "Drive west on Nowy Świat.",
-                "bearing_after": 252,
-                "bearing_before": 0,
-                "location": [
-                  17.030376,
-                  51.113071
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Nowy Świat",
-              "weight_typical": 311.327,
-              "duration_typical": 236.14,
-              "duration": 226.953,
-              "distance": 1049.454,
-              "driving_side": "right",
-              "weight": 300.763,
-              "mode": "driving",
-              "geometry": "}eun`Bommn_@TjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD"
-            },
-            {
-              "voiceInstructions": [],
-              "intersections": [
-                {
-                  "bearings": [
-                    289
-                  ],
-                  "entry": [
-                    true
-                  ],
-                  "in": 0,
-                  "admin_index": 0,
-                  "geometry_index": 103,
-                  "location": [
-                    17.032184,
-                    51.107224
-                  ]
-                }
-              ],
-              "bannerInstructions": [],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "arrive",
-                "instruction": "You have arrived at your destination.",
-                "bearing_after": 0,
-                "bearing_before": 109,
-                "location": [
-                  17.032184,
-                  51.107224
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Nowy Świat",
-              "weight_typical": 0,
-              "duration_typical": 0,
-              "duration": 0,
-              "distance": 0,
-              "driving_side": "right",
-              "weight": 0,
-              "mode": "driving",
-              "geometry": "oxin`Bo~pn_@??"
-            }
-          ],
-          "distance": 1049.454,
-          "summary": "Nowy Świat"
+          }
         }
       ],
-      "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvDdCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaAj@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GMKdE??CxA@x@Ar@]vCWtA{Mfv@uGd_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeEdCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArITjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD",
-      "voiceLocale": "en-US"
+      "routeOptions": {
+        "baseUrl": "https://api.mapbox.com",
+        "user": "mapbox",
+        "profile": "driving-traffic",
+        "coordinates": "17.0359582,51.1230732;17.0333423,51.1160887;17.0303647,51.1130915;17.0321327,51.1072076",
+        "continue_straight": true,
+        "roundabout_exits": true,
+        "geometries": "polyline6",
+        "overview": "full",
+        "steps": true,
+        "annotations": "congestion_numeric,maxspeed,closure,speed,duration,distance",
+        "voice_instructions": true,
+        "banner_instructions": true,
+        "enable_refresh": true
+      },
+      "voiceLocale": "en-US",
+      "requestUuid": "pmzkNPXknULJwETblENCKWMNIHAUDtN8LGwlbbeyydAACiKP_nLYog\u003d\u003d"
     }
   ],
+  "uuid": "pmzkNPXknULJwETblENCKWMNIHAUDtN8LGwlbbeyydAACiKP_nLYog\u003d\u003d",
+  "code": "Ok",
   "waypoints": [
     {
-      "distance": 2.663,
-      "name": "Trzebnicka",
+      "name": "",
       "location": [
         17.035996,
         51.123076
       ]
     },
     {
-      "distance": 4.049,
-      "name": "Wojciecha Cybulskiego",
+      "name": "",
       "location": [
         17.033323,
         51.116123
       ]
     },
     {
-      "distance": 2.355,
-      "name": "Nowy Świat",
+      "name": "",
       "location": [
         17.030376,
         51.113071
       ]
     },
     {
-      "distance": 4.023,
-      "name": "Kazimierza Wielkiego",
+      "name": "",
       "location": [
         17.032184,
         51.107224
       ]
     }
-  ],
-  "code": "Ok",
-  "uuid": "pmzkNPXknULJwETblENCKWMNIHAUDtN8LGwlbbeyydAACiKP_nLYog=="
+  ]
 }

--- a/libnavigation-router/src/test/resources/multi_leg_route_refreshed_second_leg.json
+++ b/libnavigation-router/src/test/resources/multi_leg_route_refreshed_second_leg.json
@@ -1,591 +1,1756 @@
 {
+  "code": "Ok",
+  "waypoints": [
+    {
+      "name": "",
+      "location": [
+        17.035996,
+        51.123076
+      ]
+    },
+    {
+      "name": "",
+      "location": [
+        17.033323,
+        51.116123
+      ]
+    },
+    {
+      "name": "",
+      "location": [
+        17.030376,
+        51.113071
+      ]
+    },
+    {
+      "name": "",
+      "location": [
+        17.032184,
+        51.107224
+      ]
+    }
+  ],
   "routes": [
     {
       "weight_typical": 1511.56,
-      "duration_typical": 654.54,
-      "weight_name": "auto",
-      "weight": 1500.996,
-      "duration": 645.353,
+      "routeIndex": "0",
       "distance": 2839.016,
+      "duration": 623.8819999999998,
+      "duration_typical": 654.54,
+      "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvDdCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaAj@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GMKdE??CxA@x@Ar@]vCWtA{Mfv@uGd_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeEdCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArITjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD",
+      "weight": 1500.996,
+      "weight_name": "auto",
       "legs": [
         {
+          "weight_typical": 315.701,
+          "weight": 315.701,
           "via_waypoints": [],
+          "distance": 1035.017,
+          "duration": 217.243,
+          "duration_typical": 217.243,
+          "summary": "Trzebnicka, Bolesława Drobnera",
           "admins": [
             {
-              "iso_3166_1_alpha3": "POL",
-              "iso_3166_1": "PL"
+              "iso_3166_1": "PL",
+              "iso_3166_1_alpha3": "POL"
+            }
+          ],
+          "steps": [
+            {
+              "weight_typical": 106.481,
+              "distance": 434.017,
+              "duration": 71.855,
+              "duration_typical": 71.855,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvD",
+              "name": "Trzebnicka",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.035996,
+                  51.123076
+                ],
+                "bearing_before": 0.0,
+                "bearing_after": 172.0,
+                "instruction": "Drive south on Trzebnicka.",
+                "type": "depart"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 434.017,
+                  "announcement": "Drive south on Trzebnicka. Then, in a quarter mile, Turn left onto Henryka Probusa.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive south on \u003csay-as interpret-as\u003d\"address\"\u003eTrzebnicka\u003c/say-as\u003e. Then, in a quarter mile, Turn left onto \u003csay-as interpret-as\u003d\"address\"\u003eHenryka Probusa\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 83.333,
+                  "announcement": "Turn left onto Henryka Probusa.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto \u003csay-as interpret-as\u003d\"address\"\u003eHenryka Probusa\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 434.017,
+                  "primary": {
+                    "text": "Henryka Probusa",
+                    "components": [
+                      {
+                        "text": "Henryka Probusa",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "left"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 106.481,
+              "intersections": [
+                {
+                  "duration": 1.069,
+                  "weight": 1.203,
+                  "location": [
+                    17.035996,
+                    51.123076
+                  ],
+                  "bearings": [
+                    172
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "out": 0,
+                  "geometry_index": 0,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.874,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 4.1,
+                  "location": [
+                    17.036012,
+                    51.123005
+                  ],
+                  "bearings": [
+                    82,
+                    172,
+                    263,
+                    352
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 2,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.257,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 4.531,
+                  "location": [
+                    17.036039,
+                    51.122883
+                  ],
+                  "bearings": [
+                    59,
+                    172,
+                    263,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 4,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.707,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 5.038,
+                  "location": [
+                    17.036068,
+                    51.12275
+                  ],
+                  "bearings": [
+                    82,
+                    172,
+                    260,
+                    352
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 6,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 6.894,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 8.248,
+                  "location": [
+                    17.036103,
+                    51.122592
+                  ],
+                  "bearings": [
+                    35,
+                    172,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 1,
+                  "geometry_index": 9,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 8.459,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 10.009,
+                  "location": [
+                    17.036188,
+                    51.122196
+                  ],
+                  "bearings": [
+                    172,
+                    263,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 12,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.661,
+                  "turn_weight": 0.5,
+                  "weight": 3.493,
+                  "location": [
+                    17.036291,
+                    51.121719
+                  ],
+                  "bearings": [
+                    172,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 14,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.461,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 4.761,
+                  "location": [
+                    17.036324,
+                    51.121566
+                  ],
+                  "bearings": [
+                    82,
+                    172,
+                    260,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 17,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 0.348,
+                  "turn_weight": 2,
+                  "turn_duration": 0.021,
+                  "weight": 2.368,
+                  "location": [
+                    17.036353,
+                    51.121436
+                  ],
+                  "bearings": [
+                    84,
+                    171,
+                    265,
+                    352
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 19,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 11.945,
+                  "turn_weight": 0.5,
+                  "weight": 13.939,
+                  "location": [
+                    17.036358,
+                    51.121416
+                  ],
+                  "bearings": [
+                    172,
+                    351
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 20,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.291,
+                  "turn_weight": 0.5,
+                  "weight": 3.077,
+                  "location": [
+                    17.036504,
+                    51.120769
+                  ],
+                  "bearings": [
+                    171,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 21,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.895,
+                  "turn_weight": 7,
+                  "turn_duration": 0.009,
+                  "weight": 9.121,
+                  "location": [
+                    17.036536,
+                    51.120645
+                  ],
+                  "bearings": [
+                    87,
+                    174,
+                    260,
+                    351
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 24,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.378,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 3.543,
+                  "location": [
+                    17.036551,
+                    51.120548
+                  ],
+                  "bearings": [
+                    82,
+                    173,
+                    263,
+                    354
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 26,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 11.143,
+                  "turn_weight": 0.5,
+                  "weight": 13.036,
+                  "location": [
+                    17.036564,
+                    51.120479
+                  ],
+                  "bearings": [
+                    173,
+                    353
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 28,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 4.464,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 5.514,
+                  "location": [
+                    17.036686,
+                    51.119903
+                  ],
+                  "bearings": [
+                    82,
+                    172,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 1,
+                  "geometry_index": 31,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.4,
+                  "turn_weight": 0.5,
+                  "weight": 3.2,
+                  "location": [
+                    17.036738,
+                    51.119671
+                  ],
+                  "bearings": [
+                    173,
+                    352
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 32,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 0.408,
+                  "turn_weight": 2,
+                  "turn_duration": 0.008,
+                  "weight": 2.45,
+                  "location": [
+                    17.036758,
+                    51.119567
+                  ],
+                  "bearings": [
+                    84,
+                    176,
+                    263,
+                    353
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 34,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 0.75,
+                  "location": [
+                    17.03676,
+                    51.119547
+                  ],
+                  "bearings": [
+                    197,
+                    356
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 35,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 61.02,
+              "distance": 151.0,
+              "duration": 40.404,
+              "duration_typical": 40.404,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "qhao`Bioyn_@dCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaA",
+              "name": "Henryka Probusa",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.036549,
+                  51.119257
+                ],
+                "bearing_before": 214.0,
+                "bearing_after": 133.0,
+                "instruction": "Turn left onto Henryka Probusa.",
+                "type": "turn",
+                "modifier": "left"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 141.0,
+                  "announcement": "In 500 feet, Turn right onto Bolesława Drobnera.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 500 feet, Turn right onto \u003csay-as interpret-as\u003d\"address\"\u003eBolesława Drobnera\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 83.333,
+                  "announcement": "Turn right onto Bolesława Drobnera.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto \u003csay-as interpret-as\u003d\"address\"\u003eBolesława Drobnera\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 151.0,
+                  "primary": {
+                    "text": "Bolesława Drobnera",
+                    "components": [
+                      {
+                        "text": "Bolesława Drobnera",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 61.02,
+              "intersections": [
+                {
+                  "duration": 6.82,
+                  "turn_weight": 12.5,
+                  "turn_duration": 4.345,
+                  "weight": 15.284,
+                  "location": [
+                    17.036549,
+                    51.119257
+                  ],
+                  "bearings": [
+                    34,
+                    133,
+                    251
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 42,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 19.8,
+                  "turn_weight": 0.5,
+                  "weight": 22.775,
+                  "location": [
+                    17.036662,
+                    51.11919
+                  ],
+                  "bearings": [
+                    133,
+                    313
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 43,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.944,
+                  "turn_weight": 2,
+                  "turn_duration": 0.019,
+                  "weight": 5.291,
+                  "location": [
+                    17.037589,
+                    51.118656
+                  ],
+                  "bearings": [
+                    44,
+                    132,
+                    222,
+                    313
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 44,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.669,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 3.911,
+                  "location": [
+                    17.037728,
+                    51.118577
+                  ],
+                  "bearings": [
+                    46,
+                    134,
+                    176,
+                    227,
+                    253,
+                    312
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 5,
+                  "out": 1,
+                  "geometry_index": 47,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.785,
+                  "turn_weight": 0.75,
+                  "turn_duration": 0.015,
+                  "weight": 3.935,
+                  "location": [
+                    17.03779,
+                    51.118539
+                  ],
+                  "bearings": [
+                    117,
+                    146,
+                    314
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 1,
+                  "geometry_index": 48,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.769,
+                  "turn_weight": 0.5,
+                  "weight": 3.685,
+                  "location": [
+                    17.037866,
+                    51.118467
+                  ],
+                  "bearings": [
+                    153,
+                    326
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 50,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 2,
+                  "turn_duration": 0.018,
+                  "location": [
+                    17.037931,
+                    51.118387
+                  ],
+                  "bearings": [
+                    37,
+                    77,
+                    167,
+                    259,
+                    333
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 4,
+                  "out": 2,
+                  "geometry_index": 52,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 136.979,
+              "distance": 443.0,
+              "duration": 99.535,
+              "duration_typical": 99.535,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "ek_o`Bih|n_@j@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GM",
+              "name": "Bolesława Drobnera",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.037973,
+                  51.118275
+                ],
+                "bearing_before": 167.0,
+                "bearing_after": 255.0,
+                "instruction": "Turn right onto Bolesława Drobnera.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 426.333,
+                  "announcement": "In a quarter mile, Turn right onto Wojciecha Cybulskiego.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn right onto \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 105.556,
+                  "announcement": "Turn right onto Wojciecha Cybulskiego. Then You will arrive at your destination.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e. Then You will arrive at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 443.0,
+                  "primary": {
+                    "text": "Wojciecha Cybulskiego",
+                    "components": [
+                      {
+                        "text": "Wojciecha Cybulskiego",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 136.979,
+              "intersections": [
+                {
+                  "duration": 20.405,
+                  "turn_weight": 8,
+                  "turn_duration": 2.005,
+                  "weight": 29.16,
+                  "location": [
+                    17.037973,
+                    51.118275
+                  ],
+                  "bearings": [
+                    82,
+                    191,
+                    255,
+                    347
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 2,
+                  "geometry_index": 54,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.687,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 2.432,
+                  "location": [
+                    17.036702,
+                    51.118056
+                  ],
+                  "bearings": [
+                    75,
+                    256,
+                    342
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 59,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 19.92,
+                  "turn_weight": 0.5,
+                  "weight": 23.408,
+                  "location": [
+                    17.036599,
+                    51.11804
+                  ],
+                  "bearings": [
+                    76,
+                    255
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 60,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 1.88,
+                  "turn_duration": 0.021,
+                  "turn_weight": 0.5,
+                  "duration": 1.221,
+                  "location": [
+                    17.035451,
+                    51.117852
+                  ],
+                  "bearings": [
+                    39,
+                    75,
+                    254
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 61,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.127,
+                  "turn_duration": 0.007,
+                  "turn_weight": 0.5,
+                  "duration": 4.031,
+                  "location": [
+                    17.035383,
+                    51.11784
+                  ],
+                  "bearings": [
+                    74,
+                    256,
+                    294
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 63,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.896,
+                  "turn_duration": 0.022,
+                  "turn_weight": 2,
+                  "duration": 3.411,
+                  "location": [
+                    17.03512,
+                    51.117798
+                  ],
+                  "bearings": [
+                    76,
+                    163,
+                    253,
+                    345
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 66,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.364,
+                  "turn_duration": 0.03,
+                  "turn_weight": 2,
+                  "duration": 2.955,
+                  "location": [
+                    17.034895,
+                    51.117754
+                  ],
+                  "bearings": [
+                    23,
+                    73,
+                    204,
+                    247
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "out": 3,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 68,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 13.86,
+                  "turn_duration": 0.052,
+                  "turn_weight": 0.75,
+                  "duration": 11.452,
+                  "location": [
+                    17.034722,
+                    51.117707
+                  ],
+                  "bearings": [
+                    67,
+                    234,
+                    304
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 69,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 2.57,
+                  "turn_duration": 0.03,
+                  "turn_weight": 0.5,
+                  "duration": 1.83,
+                  "location": [
+                    17.034316,
+                    51.117486
+                  ],
+                  "bearings": [
+                    44,
+                    217,
+                    263,
+                    313
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 74,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 20.334,
+                  "turn_duration": 0.024,
+                  "turn_weight": 2,
+                  "duration": 15.967,
+                  "location": [
+                    17.03426,
+                    51.117439
+                  ],
+                  "bearings": [
+                    37,
+                    122,
+                    212,
+                    300
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 76,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 2.887,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 0.779,
+                  "location": [
+                    17.033783,
+                    51.116966
+                  ],
+                  "bearings": [
+                    32,
+                    121,
+                    212,
+                    303
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 80,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 2.296,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 0.265,
+                  "location": [
+                    17.033763,
+                    51.116946
+                  ],
+                  "bearings": [
+                    32,
+                    122,
+                    212,
+                    301
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 81,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.029,
+                  "turn_weight": 0.5,
+                  "weight": 1.683,
+                  "location": [
+                    17.033755,
+                    51.116938
+                  ],
+                  "bearings": [
+                    32,
+                    211
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 82,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 3.49,
+                  "turn_duration": 0.009,
+                  "turn_weight": 0.5,
+                  "duration": 2.609,
+                  "location": [
+                    17.033723,
+                    51.116905
+                  ],
+                  "bearings": [
+                    31,
+                    215,
+                    304,
+                    353
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 83,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.4,
+                  "turn_weight": 0.5,
+                  "weight": 2.11,
+                  "location": [
+                    17.033617,
+                    51.11681
+                  ],
+                  "bearings": [
+                    35,
+                    214
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 84,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 4.192,
+                  "turn_weight": 2,
+                  "turn_duration": 0.142,
+                  "weight": 6.658,
+                  "location": [
+                    17.033558,
+                    51.116755
+                  ],
+                  "bearings": [
+                    34,
+                    101,
+                    187,
+                    304
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 85,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.014,
+                  "location": [
+                    17.033516,
+                    51.116519
+                  ],
+                  "bearings": [
+                    5,
+                    46,
+                    196
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 87,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 11.22,
+              "distance": 7.0,
+              "duration": 5.449,
+              "duration_typical": 5.449,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "id{n`B{ksn_@KdE",
+              "name": "Wojciecha Cybulskiego",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.033422,
+                  51.116117
+                ],
+                "bearing_before": 181.0,
+                "bearing_after": 276.0,
+                "instruction": "Turn right onto Wojciecha Cybulskiego.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 7.0,
+                  "announcement": "You have arrived at your destination.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYou have arrived at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 7.0,
+                  "primary": {
+                    "text": "You have arrived at your destination",
+                    "components": [
+                      {
+                        "text": "You have arrived at your destination",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 11.22,
+              "intersections": [
+                {
+                  "turn_weight": 8,
+                  "turn_duration": 2.649,
+                  "location": [
+                    17.033422,
+                    51.116117
+                  ],
+                  "bearings": [
+                    1,
+                    125,
+                    169,
+                    276
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 3,
+                  "geometry_index": 91,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 0,
+              "distance": 0.0,
+              "duration": 0.0,
+              "duration_typical": 0.0,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "ud{n`Buesn_@??",
+              "name": "Wojciecha Cybulskiego",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.033323,
+                  51.116123
+                ],
+                "bearing_before": 276.0,
+                "bearing_after": 0.0,
+                "instruction": "You have arrived at your destination.",
+                "type": "arrive"
+              },
+              "voiceInstructions": [],
+              "bannerInstructions": [],
+              "driving_side": "right",
+              "weight": 0.0,
+              "intersections": [
+                {
+                  "location": [
+                    17.033323,
+                    51.116123
+                  ],
+                  "bearings": [
+                    96
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "geometry_index": 92,
+                  "admin_index": 0
+                }
+              ]
             }
           ],
           "annotation": {
-            "maxspeed": [
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 40,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 30,
-                "unit": "km/h"
-              },
-              {
-                "speed": 30,
-                "unit": "km/h"
-              },
-              {
-                "speed": 30,
-                "unit": "km/h"
-              },
-              {
-                "speed": 30,
-                "unit": "km/h"
-              },
-              {
-                "speed": 30,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 50,
-                "unit": "km/h"
-              },
-              {
-                "speed": 30,
-                "unit": "km/h"
-              }
-            ],
-            "congestion_numeric": [
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null,
-              null
-            ],
-            "speed": [
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0,
-              0
-            ],
             "distance": [
               4.3,
               3.7,
               2.4,
               11.3,
-              12,
+              12.0,
               2.9,
               2.7,
               2.7,
               12.4,
-              2,
+              2.0,
               38.1,
               4.4,
               5.2,
@@ -606,7 +1771,7 @@
               5.9,
               5.8,
               50.9,
-              8,
+              8.0,
               26.1,
               9.8,
               1.9,
@@ -651,13 +1816,13 @@
               12.4,
               9.1,
               3.5,
-              3,
+              3.0,
               2.9,
               50.7,
               6.2,
               2.5,
               2.6,
-              1,
+              1.0,
               4.3,
               12.9,
               7.4,
@@ -762,1586 +1927,1014 @@
               1.613,
               1.989,
               2.78
+            ],
+            "speed": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0
+            ],
+            "maxspeed": [
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 40,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 30,
+                "unit": "km/h"
+              },
+              {
+                "speed": 30,
+                "unit": "km/h"
+              },
+              {
+                "speed": 30,
+                "unit": "km/h"
+              },
+              {
+                "speed": 30,
+                "unit": "km/h"
+              },
+              {
+                "speed": 30,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 50,
+                "unit": "km/h"
+              },
+              {
+                "speed": 30,
+                "unit": "km/h"
+              }
+            ],
+            "congestion_numeric": [
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null
             ]
-          },
-          "weight_typical": 315.701,
-          "duration_typical": 217.243,
-          "weight": 315.701,
-          "duration": 217.243,
+          }
+        },
+        {
+          "weight_typical": 884.532,
+          "weight": 884.532,
+          "via_waypoints": [],
+          "distance": 754.545,
+          "duration": 171.392,
+          "duration_typical": 201.157,
+          "summary": "Wojciecha Cybulskiego, Grodzka",
+          "admins": [
+            {
+              "iso_3166_1": "PL",
+              "iso_3166_1_alpha3": "POL"
+            }
+          ],
           "steps": [
             {
+              "weight_typical": 38.924,
+              "distance": 122.0,
+              "duration": 30.966,
+              "duration_typical": 30.839,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "ud{n`Buesn_@??CxA@x@Ar@]vCWtA{Mfv@uGd_@",
+              "name": "Wojciecha Cybulskiego",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.033323,
+                  51.116123
+                ],
+                "bearing_before": 0.0,
+                "bearing_after": 180.0,
+                "instruction": "Drive south on Wojciecha Cybulskiego.",
+                "type": "depart"
+              },
               "voiceInstructions": [
                 {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive south on <say-as interpret-as=\"address\">Trzebnicka</say-as>. Then, in a quarter mile, Turn left onto <say-as interpret-as=\"address\">Henryka Probusa</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Drive south on Trzebnicka. Then, in a quarter mile, Turn left onto Henryka Probusa.",
-                  "distanceAlongGeometry": 434.017
+                  "distanceAlongGeometry": 122.0,
+                  "announcement": "Drive south on Wojciecha Cybulskiego. Then, in 400 feet, Make a left U-turn to stay on Wojciecha Cybulskiego.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive south on \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e. Then, in 400 feet, Make a left U-turn to stay on \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
                 },
                 {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn left onto <say-as interpret-as=\"address\">Henryka Probusa</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn left onto Henryka Probusa.",
-                  "distanceAlongGeometry": 83.333
+                  "distanceAlongGeometry": 66.667,
+                  "announcement": "Make a left U-turn to stay on Wojciecha Cybulskiego.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eMake a left U-turn to stay on \u003csay-as interpret-as\u003d\"address\"\u003eWojciecha Cybulskiego\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
                 }
               ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 122.0,
+                  "primary": {
+                    "text": "Wojciecha Cybulskiego",
+                    "components": [
+                      {
+                        "text": "Wojciecha Cybulskiego",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "uturn",
+                    "driving_side": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 38.924,
               "intersections": [
                 {
+                  "location": [
+                    17.033323,
+                    51.116123
+                  ],
+                  "bearings": [
+                    180
+                  ],
                   "entry": [
                     true
                   ],
-                  "bearings": [
-                    172
-                  ],
-                  "duration": 1.069,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
                   "out": 0,
-                  "weight": 1.203,
                   "geometry_index": 0,
-                  "location": [
-                    17.035996,
-                    51.123076
-                  ]
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
                 },
                 {
+                  "duration": 2,
+                  "turn_weight": 0.5,
+                  "weight": 2.8,
+                  "location": [
+                    17.033323,
+                    51.116123
+                  ],
+                  "bearings": [
+                    0,
+                    271
+                  ],
                   "entry": [
                     false,
-                    true,
-                    false,
-                    false
+                    true
                   ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    172,
-                    263,
-                    352
-                  ],
-                  "duration": 1.874,
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 1,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "duration": 2.815,
                   "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 4.1,
-                  "geometry_index": 2,
+                  "turn_duration": 0.015,
+                  "weight": 5.22,
                   "location": [
-                    17.036012,
-                    51.123005
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    true,
-                    false
+                    17.033249,
+                    51.116124
                   ],
-                  "in": 3,
                   "bearings": [
-                    59,
-                    172,
-                    263,
-                    352
-                  ],
-                  "duration": 2.257,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 4.531,
-                  "geometry_index": 4,
-                  "location": [
-                    17.036039,
-                    51.122883
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    172,
-                    260,
-                    352
-                  ],
-                  "duration": 2.707,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.038,
-                  "geometry_index": 6,
-                  "location": [
-                    17.036068,
-                    51.12275
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    35,
-                    172,
-                    352
-                  ],
-                  "duration": 6.894,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 8.248,
-                  "geometry_index": 9,
-                  "location": [
-                    17.036103,
-                    51.122592
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    172,
-                    263,
-                    352
-                  ],
-                  "duration": 8.459,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 10.009,
-                  "geometry_index": 12,
-                  "location": [
-                    17.036188,
-                    51.122196
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    172,
-                    352
-                  ],
-                  "duration": 2.661,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.493,
-                  "geometry_index": 14,
-                  "location": [
-                    17.036291,
-                    51.121719
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    172,
-                    260,
-                    352
-                  ],
-                  "duration": 2.461,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 4.761,
-                  "geometry_index": 17,
-                  "location": [
-                    17.036324,
-                    51.121566
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    84,
-                    171,
-                    265,
-                    352
-                  ],
-                  "duration": 0.348,
-                  "turn_weight": 2,
-                  "turn_duration": 0.021,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.368,
-                  "geometry_index": 19,
-                  "location": [
-                    17.036353,
-                    51.121436
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    172,
-                    351
-                  ],
-                  "duration": 11.945,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 13.939,
-                  "geometry_index": 20,
-                  "location": [
-                    17.036358,
-                    51.121416
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    171,
-                    352
-                  ],
-                  "duration": 2.291,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.077,
-                  "geometry_index": 21,
-                  "location": [
-                    17.036504,
-                    51.120769
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    87,
-                    174,
-                    260,
-                    351
-                  ],
-                  "duration": 1.895,
-                  "turn_weight": 7,
-                  "turn_duration": 0.009,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 9.121,
-                  "geometry_index": 24,
-                  "location": [
-                    17.036536,
-                    51.120645
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    173,
-                    263,
-                    354
-                  ],
-                  "duration": 1.378,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 3.543,
-                  "geometry_index": 26,
-                  "location": [
-                    17.036551,
-                    51.120548
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    173,
-                    353
-                  ],
-                  "duration": 11.143,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 13.036,
-                  "geometry_index": 28,
-                  "location": [
-                    17.036564,
-                    51.120479
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    82,
-                    172,
-                    352
-                  ],
-                  "duration": 4.464,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.514,
-                  "geometry_index": 31,
-                  "location": [
-                    17.036686,
-                    51.119903
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    173,
-                    352
-                  ],
-                  "duration": 2.4,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.2,
-                  "geometry_index": 32,
-                  "location": [
-                    17.036738,
-                    51.119671
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    84,
+                    91,
                     176,
-                    263,
-                    353
+                    284,
+                    356
                   ],
-                  "duration": 0.408,
-                  "turn_weight": 2,
-                  "turn_duration": 0.008,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 3,
                   "is_urban": true,
                   "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.45,
-                  "geometry_index": 34,
-                  "location": [
-                    17.036758,
-                    51.119567
-                  ]
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
                 },
                 {
+                  "duration": 15.988,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.013,
+                  "weight": 18.871,
+                  "location": [
+                    17.033147,
+                    51.11614
+                  ],
                   "bearings": [
-                    197,
+                    104,
+                    199,
+                    293
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 5,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "location": [
+                    17.03222,
+                    51.11639
+                  ],
+                  "bearings": [
+                    24,
+                    113,
+                    293
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "out": 2,
+                  "geometry_index": 7,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 670.295,
+              "distance": 129.0,
+              "duration": 33.967,
+              "duration_typical": 60.842,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "a~{n`Bq`pn_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeE",
+              "name": "Wojciecha Cybulskiego",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.031705,
+                  51.116529
+                ],
+                "bearing_before": 293.0,
+                "bearing_after": 113.0,
+                "instruction": "Make a left U-turn to stay on Wojciecha Cybulskiego.",
+                "type": "continue",
+                "modifier": "uturn"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 119.0,
+                  "announcement": "In 400 feet, Turn right onto Most Uniwersytecki.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 400 feet, Turn right onto \u003csay-as interpret-as\u003d\"address\"\u003eMost Uniwersytecki\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 50.0,
+                  "announcement": "Turn right onto Most Uniwersytecki.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto \u003csay-as interpret-as\u003d\"address\"\u003eMost Uniwersytecki\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 129.0,
+                  "primary": {
+                    "text": "Most Uniwersytecki",
+                    "components": [
+                      {
+                        "text": "Most Uniwersytecki",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "turn",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 670.295,
+              "intersections": [
+                {
+                  "duration": 36.23,
+                  "turn_weight": 628.5,
+                  "turn_duration": 27.455,
+                  "weight": 638.591,
+                  "location": [
+                    17.031705,
+                    51.116529
+                  ],
+                  "bearings": [
+                    113,
+                    113
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 8,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "duration": 15.982,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 18.871,
+                  "location": [
+                    17.03222,
+                    51.11639
+                  ],
+                  "bearings": [
+                    24,
+                    113,
+                    293
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 1,
+                  "geometry_index": 9,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "duration": 3.186,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.036,
+                  "weight": 4.122,
+                  "location": [
+                    17.033147,
+                    51.11614
+                  ],
+                  "bearings": [
+                    104,
+                    199,
+                    293
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 11,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "duration": 2.295,
+                  "turn_weight": 2,
+                  "turn_duration": 0.045,
+                  "weight": 4.588,
+                  "location": [
+                    17.033249,
+                    51.116124
+                  ],
+                  "bearings": [
+                    91,
+                    176,
+                    284,
                     356
                   ],
                   "entry": [
                     true,
-                    false
-                  ],
-                  "in": 1,
-                  "turn_weight": 0.75,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "geometry_index": 35,
-                  "location": [
-                    17.03676,
-                    51.119547
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Henryka Probusa"
-                      }
-                    ],
-                    "type": "turn",
-                    "modifier": "left",
-                    "text": "Henryka Probusa"
-                  },
-                  "distanceAlongGeometry": 434.017
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "depart",
-                "instruction": "Drive south on Trzebnicka.",
-                "bearing_after": 172,
-                "bearing_before": 0,
-                "location": [
-                  17.035996,
-                  51.123076
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Trzebnicka",
-              "weight_typical": 106.481,
-              "duration_typical": 71.855,
-              "duration": 71.855,
-              "distance": 434.017,
-              "driving_side": "right",
-              "weight": 106.481,
-              "mode": "driving",
-              "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvD"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 500 feet, Turn right onto <say-as interpret-as=\"address\">Bolesława Drobnera</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "In 500 feet, Turn right onto Bolesława Drobnera.",
-                  "distanceAlongGeometry": 141
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Bolesława Drobnera</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn right onto Bolesława Drobnera.",
-                  "distanceAlongGeometry": 83.333
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
                     false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    34,
-                    133,
-                    251
-                  ],
-                  "duration": 6.82,
-                  "turn_weight": 12.5,
-                  "turn_duration": 4.345,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 15.284,
-                  "geometry_index": 42,
-                  "location": [
-                    17.036549,
-                    51.119257
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    133,
-                    313
-                  ],
-                  "duration": 19.8,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 22.775,
-                  "geometry_index": 43,
-                  "location": [
-                    17.036662,
-                    51.11919
-                  ]
-                },
-                {
-                  "entry": [
                     false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    44,
-                    132,
-                    222,
-                    313
-                  ],
-                  "duration": 2.944,
-                  "turn_weight": 2,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.291,
-                  "geometry_index": 44,
-                  "location": [
-                    17.037589,
-                    51.118656
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 5,
-                  "bearings": [
-                    46,
-                    134,
-                    176,
-                    227,
-                    253,
-                    312
-                  ],
-                  "duration": 1.669,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 3.911,
-                  "geometry_index": 47,
-                  "location": [
-                    17.037728,
-                    51.118577
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
                     false
                   ],
                   "in": 2,
-                  "bearings": [
-                    117,
-                    146,
-                    314
-                  ],
-                  "duration": 2.785,
-                  "turn_weight": 0.75,
-                  "turn_duration": 0.015,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 3.935,
-                  "geometry_index": 48,
-                  "location": [
-                    17.03779,
-                    51.118539
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    153,
-                    326
-                  ],
-                  "duration": 2.769,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
                   "out": 0,
-                  "weight": 3.685,
-                  "geometry_index": 50,
-                  "location": [
-                    17.037866,
-                    51.118467
-                  ]
-                },
-                {
-                  "bearings": [
-                    37,
-                    77,
-                    167,
-                    259,
-                    333
-                  ],
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 4,
-                  "turn_weight": 2,
-                  "turn_duration": 0.018,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
+                  "geometry_index": 13,
                   "is_urban": true,
                   "admin_index": 0,
-                  "out": 2,
-                  "geometry_index": 52,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                },
+                {
+                  "turn_weight": 0.5,
                   "location": [
-                    17.037931,
-                    51.118387
-                  ]
+                    17.033323,
+                    51.116123
+                  ],
+                  "bearings": [
+                    96,
+                    271
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 15,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "street"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 83.165,
+              "distance": 213.0,
+              "duration": 42.78799999999999,
+              "duration_typical": 42.749,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "id{n`B{ksn_@dCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM",
+              "name": "Most Uniwersytecki",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.033422,
+                  51.116117
+                ],
+                "bearing_before": 96.0,
+                "bearing_after": 169.0,
+                "instruction": "Turn right onto Most Uniwersytecki.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 196.333,
+                  "announcement": "In 700 feet, Turn right onto Grodzka.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 700 feet, Turn right onto \u003csay-as interpret-as\u003d\"address\"\u003eGrodzka\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 77.778,
+                  "announcement": "Turn right onto Grodzka.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn right onto \u003csay-as interpret-as\u003d\"address\"\u003eGrodzka\u003c/say-as\u003e.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
                 }
               ],
               "bannerInstructions": [
                 {
+                  "distanceAlongGeometry": 213.0,
                   "primary": {
+                    "text": "Grodzka",
                     "components": [
                       {
-                        "type": "text",
-                        "text": "Bolesława Drobnera"
+                        "text": "Grodzka",
+                        "type": "text"
                       }
                     ],
                     "type": "turn",
-                    "modifier": "right",
-                    "text": "Bolesława Drobnera"
-                  },
-                  "distanceAlongGeometry": 151
+                    "modifier": "right"
+                  }
                 }
               ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn left onto Henryka Probusa.",
-                "modifier": "left",
-                "bearing_after": 133,
-                "bearing_before": 214,
-                "location": [
-                  17.036549,
-                  51.119257
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Henryka Probusa",
-              "weight_typical": 61.02,
-              "duration_typical": 40.404,
-              "duration": 40.404,
-              "distance": 151,
               "driving_side": "right",
-              "weight": 61.02,
-              "mode": "driving",
-              "geometry": "qhao`Bioyn_@dCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaA"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In a quarter mile, Turn right onto <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "In a quarter mile, Turn right onto Wojciecha Cybulskiego.",
-                  "distanceAlongGeometry": 426.333
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>. Then You will arrive at your destination.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn right onto Wojciecha Cybulskiego. Then You will arrive at your destination.",
-                  "distanceAlongGeometry": 105.556
-                }
-              ],
+              "weight": 83.165,
               "intersections": [
                 {
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    82,
-                    191,
-                    255,
-                    347
-                  ],
-                  "duration": 20.405,
-                  "turn_weight": 8,
-                  "turn_duration": 2.005,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 29.16,
-                  "geometry_index": 54,
+                  "duration": 2.14,
+                  "turn_weight": 9,
+                  "turn_duration": 0.831,
+                  "weight": 10.505,
                   "location": [
-                    17.037973,
-                    51.118275
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true
+                    17.033422,
+                    51.116117
                   ],
-                  "in": 0,
-                  "bearings": [
-                    75,
-                    256,
-                    342
-                  ],
-                  "duration": 1.687,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.432,
-                  "geometry_index": 59,
-                  "location": [
-                    17.036702,
-                    51.118056
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    76,
-                    255
-                  ],
-                  "duration": 19.92,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 23.408,
-                  "geometry_index": 60,
-                  "location": [
-                    17.036599,
-                    51.11804
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.035451,
-                    51.117852
-                  ],
-                  "geometry_index": 61,
-                  "admin_index": 0,
-                  "weight": 1.88,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.021,
-                  "turn_weight": 0.5,
-                  "duration": 1.221,
-                  "bearings": [
-                    39,
-                    75,
-                    254
-                  ],
-                  "out": 2,
-                  "in": 1,
-                  "entry": [
-                    false,
-                    false,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.035383,
-                    51.11784
-                  ],
-                  "geometry_index": 63,
-                  "admin_index": 0,
-                  "weight": 5.127,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 0.5,
-                  "duration": 4.031,
-                  "bearings": [
-                    74,
-                    256,
-                    294
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.03512,
-                    51.117798
-                  ],
-                  "geometry_index": 66,
-                  "admin_index": 0,
-                  "weight": 5.896,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.022,
-                  "turn_weight": 2,
-                  "duration": 3.411,
-                  "bearings": [
-                    76,
-                    163,
-                    253,
-                    345
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.034895,
-                    51.117754
-                  ],
-                  "geometry_index": 68,
-                  "admin_index": 0,
-                  "weight": 5.364,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.03,
-                  "turn_weight": 2,
-                  "duration": 2.955,
-                  "bearings": [
-                    23,
-                    73,
-                    204,
-                    247
-                  ],
-                  "out": 3,
-                  "in": 1,
-                  "entry": [
-                    true,
-                    false,
-                    false,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.034722,
-                    51.117707
-                  ],
-                  "geometry_index": 69,
-                  "admin_index": 0,
-                  "weight": 13.86,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.052,
-                  "turn_weight": 0.75,
-                  "duration": 11.452,
-                  "bearings": [
-                    67,
-                    234,
-                    304
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.034316,
-                    51.117486
-                  ],
-                  "geometry_index": 74,
-                  "admin_index": 0,
-                  "weight": 2.57,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.03,
-                  "turn_weight": 0.5,
-                  "duration": 1.83,
-                  "bearings": [
-                    44,
-                    217,
-                    263,
-                    313
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.03426,
-                    51.117439
-                  ],
-                  "geometry_index": 76,
-                  "admin_index": 0,
-                  "weight": 20.334,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.024,
-                  "turn_weight": 2,
-                  "duration": 15.967,
-                  "bearings": [
-                    37,
-                    122,
-                    212,
-                    300
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.033783,
-                    51.116966
-                  ],
-                  "geometry_index": 80,
-                  "admin_index": 0,
-                  "weight": 2.887,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 0.779,
-                  "bearings": [
-                    32,
-                    121,
-                    212,
-                    303
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.033763,
-                    51.116946
-                  ],
-                  "geometry_index": 81,
-                  "admin_index": 0,
-                  "weight": 2.296,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 0.265,
-                  "bearings": [
-                    32,
-                    122,
-                    212,
-                    301
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    32,
-                    211
-                  ],
-                  "duration": 1.029,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 1.683,
-                  "geometry_index": 82,
-                  "location": [
-                    17.033755,
-                    51.116938
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.033723,
-                    51.116905
-                  ],
-                  "geometry_index": 83,
-                  "admin_index": 0,
-                  "weight": 3.49,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.009,
-                  "turn_weight": 0.5,
-                  "duration": 2.609,
-                  "bearings": [
-                    31,
-                    215,
-                    304,
-                    353
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    35,
-                    214
-                  ],
-                  "duration": 1.4,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.11,
-                  "geometry_index": 84,
-                  "location": [
-                    17.033617,
-                    51.11681
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    34,
-                    101,
-                    187,
-                    304
-                  ],
-                  "duration": 4.192,
-                  "turn_weight": 2,
-                  "turn_duration": 0.142,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 6.658,
-                  "geometry_index": 85,
-                  "location": [
-                    17.033558,
-                    51.116755
-                  ]
-                },
-                {
-                  "bearings": [
-                    5,
-                    46,
-                    196
-                  ],
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.014,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "geometry_index": 87,
-                  "location": [
-                    17.033516,
-                    51.116519
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Wojciecha Cybulskiego"
-                      }
-                    ],
-                    "type": "turn",
-                    "modifier": "right",
-                    "text": "Wojciecha Cybulskiego"
-                  },
-                  "distanceAlongGeometry": 443
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn right onto Bolesława Drobnera.",
-                "modifier": "right",
-                "bearing_after": 255,
-                "bearing_before": 167,
-                "location": [
-                  17.037973,
-                  51.118275
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Bolesława Drobnera",
-              "weight_typical": 136.979,
-              "duration_typical": 99.535,
-              "duration": 99.535,
-              "distance": 443,
-              "driving_side": "right",
-              "weight": 136.979,
-              "mode": "driving",
-              "geometry": "ek_o`Bih|n_@j@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GM"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">You have arrived at your destination.</prosody></amazon:effect></speak>",
-                  "announcement": "You have arrived at your destination.",
-                  "distanceAlongGeometry": 7
-                }
-              ],
-              "intersections": [
-                {
                   "bearings": [
                     1,
                     125,
@@ -2349,121 +2942,888 @@
                     276
                   ],
                   "entry": [
+                    true,
                     false,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 2,
+                  "geometry_index": 16,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.146,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.019,
+                  "weight": 2.946,
+                  "location": [
+                    17.033443,
+                    51.11605
+                  ],
+                  "bearings": [
+                    168,
+                    218,
+                    349
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 17,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 11.077,
+                  "turn_weight": 5.5,
+                  "weight": 18.238,
+                  "location": [
+                    17.033481,
+                    51.115936
+                  ],
+                  "bearings": [
+                    168,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 19,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 4.32,
+                  "turn_weight": 5.5,
+                  "weight": 10.468,
+                  "location": [
+                    17.033724,
+                    51.115236
+                  ],
+                  "bearings": [
+                    168,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 20,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.68,
+                  "turn_weight": 0.5,
+                  "weight": 2.432,
+                  "location": [
+                    17.033777,
+                    51.115081
+                  ],
+                  "bearings": [
+                    168,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 21,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.222,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 3.048,
+                  "location": [
+                    17.033798,
+                    51.115018
+                  ],
+                  "bearings": [
+                    168,
+                    259,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 22,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 0.277,
+                  "turn_weight": 5.5,
+                  "weight": 5.818,
+                  "location": [
+                    17.033823,
+                    51.114946
+                  ],
+                  "bearings": [
+                    173,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 23,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 13.371,
+                  "turn_weight": 0.5,
+                  "weight": 15.877,
+                  "location": [
+                    17.033824,
+                    51.114941
+                  ],
+                  "bearings": [
+                    168,
+                    353
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 24,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.059,
+                  "turn_weight": 5.5,
+                  "weight": 6.718,
+                  "location": [
+                    17.033985,
+                    51.114481
+                  ],
+                  "bearings": [
+                    163,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 26,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 2,
+                  "turn_duration": 0.009,
+                  "location": [
+                    17.034006,
+                    51.114437
+                  ],
+                  "bearings": [
+                    70,
+                    167,
+                    253,
+                    343
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 29,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                }
+              ]
+            },
+            {
+              "weight_typical": 92.148,
+              "distance": 290.545,
+              "duration": 63.67100000000001,
+              "duration_typical": 66.728,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "uown`Byttn_@\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArI",
+              "name": "Grodzka",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.034077,
+                  51.114251
+                ],
+                "bearing_before": 167.0,
+                "bearing_after": 250.0,
+                "instruction": "Turn right onto Grodzka.",
+                "type": "turn",
+                "modifier": "right"
+              },
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 273.879,
+                  "announcement": "In 1,000 feet, Your destination will be on the right.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn 1,000 feet, Your destination will be on the right.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 69.444,
+                  "announcement": "Your destination is on the right.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYour destination is on the right.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 290.545,
+                  "primary": {
+                    "text": "Your destination will be on the right",
+                    "components": [
+                      {
+                        "text": "Your destination will be on the right",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "right"
+                  }
+                },
+                {
+                  "distanceAlongGeometry": 69.444,
+                  "primary": {
+                    "text": "Your destination is on the right",
+                    "components": [
+                      {
+                        "text": "Your destination is on the right",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "right"
+                  }
+                }
+              ],
+              "driving_side": "right",
+              "weight": 92.148,
+              "intersections": [
+                {
+                  "duration": 4.906,
+                  "turn_weight": 8,
+                  "turn_duration": 3.636,
+                  "weight": 9.461,
+                  "location": [
+                    17.034077,
+                    51.114251
+                  ],
+                  "bearings": [
+                    68,
+                    170,
+                    250,
+                    347
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 2,
+                  "geometry_index": 33,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 2.777,
+                  "turn_weight": 2,
+                  "turn_duration": 0.024,
+                  "weight": 5.166,
+                  "location": [
+                    17.033999,
+                    51.114233
+                  ],
+                  "bearings": [
+                    70,
+                    132,
+                    246,
+                    329
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 35,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 18.024,
+                  "turn_weight": 2,
+                  "turn_duration": 0.024,
+                  "weight": 22.7,
+                  "location": [
+                    17.033826,
+                    51.114184
+                  ],
+                  "bearings": [
+                    66,
+                    151,
+                    242,
+                    327
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 38,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 3.176,
+                  "turn_weight": 0.5,
+                  "weight": 4.153,
+                  "location": [
+                    17.032758,
+                    51.113826
+                  ],
+                  "bearings": [
+                    60,
+                    241
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 41,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 0.776,
+                  "turn_duration": 0.009,
+                  "turn_weight": 0.5,
+                  "duration": 0.249,
+                  "location": [
+                    17.03257,
+                    51.113761
+                  ],
+                  "bearings": [
+                    61,
+                    159,
+                    245
+                  ],
+                  "entry": [
                     false,
                     true,
                     true
                   ],
                   "in": 0,
-                  "turn_weight": 8,
-                  "turn_duration": 2.649,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 43,
                   "is_urban": true,
                   "admin_index": 0,
-                  "out": 3,
-                  "geometry_index": 91,
-                  "location": [
-                    17.033422,
-                    51.116117
-                  ]
-                }
-              ],
-              "bannerInstructions": [
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
                 {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "You have arrived at your destination"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "straight",
-                    "text": "You have arrived at your destination"
-                  },
-                  "distanceAlongGeometry": 7
+                  "duration": 1.2,
+                  "turn_weight": 0.5,
+                  "weight": 1.88,
+                  "location": [
+                    17.032553,
+                    51.113756
+                  ],
+                  "bearings": [
+                    65,
+                    245
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 44,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 16.16,
+                  "turn_weight": 0.5,
+                  "turn_duration": 2,
+                  "weight": 16.784,
+                  "location": [
+                    17.032489,
+                    51.113737
+                  ],
+                  "bearings": [
+                    65,
+                    243
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 45,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 6.692,
+                  "turn_duration": 0.022,
+                  "turn_weight": 2,
+                  "duration": 4.102,
+                  "location": [
+                    17.031735,
+                    51.113492
+                  ],
+                  "bearings": [
+                    62,
+                    153,
+                    240,
+                    334
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 51,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.707,
+                  "turn_duration": 0.007,
+                  "turn_weight": 5.5,
+                  "duration": 0.187,
+                  "location": [
+                    17.031523,
+                    51.113416
+                  ],
+                  "bearings": [
+                    60,
+                    155,
+                    242
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 53,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "location": [
+                    17.031517,
+                    51.113414
+                  ],
+                  "bearings": [
+                    62,
+                    242,
+                    259
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 54,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
                 }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn right onto Wojciecha Cybulskiego.",
-                "modifier": "right",
-                "bearing_after": 276,
-                "bearing_before": 181,
-                "location": [
-                  17.033422,
-                  51.116117
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Wojciecha Cybulskiego",
-              "weight_typical": 11.22,
-              "duration_typical": 5.449,
-              "duration": 5.449,
-              "distance": 7,
-              "driving_side": "right",
-              "weight": 11.22,
-              "mode": "driving",
-              "geometry": "id{n`B{ksn_@KdE"
+              ]
             },
             {
+              "weight_typical": 0,
+              "distance": 0.0,
+              "duration": 0.0,
+              "duration_typical": 0.0,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "}eun`Bommn_@??",
+              "name": "Grodzka",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.030376,
+                  51.113071
+                ],
+                "bearing_before": 249.0,
+                "bearing_after": 0.0,
+                "instruction": "Your destination is on the right.",
+                "type": "arrive",
+                "modifier": "right"
+              },
               "voiceInstructions": [],
+              "bannerInstructions": [],
+              "driving_side": "right",
+              "weight": 0.0,
               "intersections": [
                 {
+                  "location": [
+                    17.030376,
+                    51.113071
+                  ],
                   "bearings": [
-                    96
+                    69
                   ],
                   "entry": [
                     true
                   ],
                   "in": 0,
-                  "admin_index": 0,
-                  "geometry_index": 92,
-                  "location": [
-                    17.033323,
-                    51.116123
-                  ]
+                  "geometry_index": 60,
+                  "admin_index": 0
                 }
-              ],
-              "bannerInstructions": [],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "arrive",
-                "instruction": "You have arrived at your destination.",
-                "bearing_after": 0,
-                "bearing_before": 276,
-                "location": [
-                  17.033323,
-                  51.116123
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Wojciecha Cybulskiego",
-              "weight_typical": 0,
-              "duration_typical": 0,
-              "duration": 0,
-              "distance": 0,
-              "driving_side": "right",
-              "weight": 0,
-              "mode": "driving",
-              "geometry": "ud{n`Buesn_@??"
-            }
-          ],
-          "distance": 1035.017,
-          "summary": "Trzebnicka, Bolesława Drobnera"
-        },
-        {
-          "via_waypoints": [],
-          "admins": [
-            {
-              "iso_3166_1_alpha3": "POL",
-              "iso_3166_1": "PL"
+              ]
             }
           ],
           "annotation": {
+            "distance": [
+              0.0,
+              3.2,
+              2.0,
+              1.8,
+              5.6,
+              3.3,
+              67.2,
+              39.2,
+              39.2,
+              67.2,
+              5.6,
+              1.8,
+              2.0,
+              3.2,
+              7.0,
+              7.6,
+              10.9,
+              2.0,
+              79.8,
+              17.6,
+              7.2,
+              8.2,
+              0.6,
+              8.4,
+              44.0,
+              0.8,
+              0.7,
+              3.6,
+              2.1,
+              9.0,
+              8.6,
+              1.6,
+              5.0,
+              0.8,
+              9.2,
+              1.8,
+              2.3,
+              2.4,
+              63.4,
+              18.8,
+              11.6,
+              3.4,
+              1.3,
+              4.9,
+              21.9,
+              3.2,
+              11.6,
+              0.5,
+              17.7,
+              4.4,
+              5.1,
+              12.0,
+              0.5,
+              2.1,
+              30.9,
+              8.4,
+              20.4,
+              14.1,
+              12.3,
+              12.6
+            ],
+            "duration": [
+              0.0,
+              1.261,
+              0.812,
+              0.729,
+              2.227,
+              0.74,
+              15.124,
+              10.073,
+              8.814,
+              15.124,
+              2.506,
+              0.82,
+              0.913,
+              1.418,
+              3.128,
+              1.244,
+              1.787,
+              0.335,
+              11.043,
+              4.235,
+              1.72,
+              2.272,
+              0.158,
+              2.332,
+              12.187,
+              0.175,
+              0.144,
+              0.764,
+              0.445,
+              1.914,
+              1.812,
+              0.346,
+              1.119,
+              0.189,
+              2.06,
+              0.402,
+              0.523,
+              0.547,
+              14.258,
+              4.237,
+              2.613,
+              0.762,
+              0.314,
+              1.187,
+              5.267,
+              0.768,
+              2.782,
+              0.112,
+              4.245,
+              1.066,
+              1.222,
+              2.872,
+              0.086,
+              0.373,
+              5.556,
+              1.518,
+              3.68,
+              2.545,
+              2.222,
+              2.265
+            ],
+            "speed": [
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              0.0,
+              2.2,
+              2.2,
+              2.2,
+              2.2,
+              2.2,
+              6.1,
+              6.1,
+              6.1,
+              7.2,
+              4.2,
+              4.2,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.7,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              0.0
+            ],
             "maxspeed": [
               {
                 "speed": 30,
@@ -2767,1345 +4127,1785 @@
               43,
               43,
               null
-            ],
-            "speed": [
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              0.0,
-              2.2,
-              2.2,
-              2.2,
-              2.2,
-              2.2,
-              6.1,
-              6.1,
-              6.1,
-              7.2,
-              4.2,
-              4.2,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.7,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              0
-            ],
-            "distance": [
-              0,
-              3.2,
-              2,
-              1.8,
-              5.6,
-              3.3,
-              67.2,
-              39.2,
-              39.2,
-              67.2,
-              5.6,
-              1.8,
-              2,
-              3.2,
-              7,
-              7.6,
-              10.9,
-              2,
-              79.8,
-              17.6,
-              7.2,
-              8.2,
-              0.6,
-              8.4,
-              44,
-              0.8,
-              0.7,
-              3.6,
-              2.1,
-              9,
-              8.6,
-              1.6,
-              5,
-              0.8,
-              9.2,
-              1.8,
-              2.3,
-              2.4,
-              63.4,
-              18.8,
-              11.6,
-              3.4,
-              1.3,
-              4.9,
-              21.9,
-              3.2,
-              11.6,
-              0.5,
-              17.7,
-              4.4,
-              5.1,
-              12,
-              0.5,
-              2.1,
-              30.9,
-              8.4,
-              20.4,
-              14.1,
-              12.3,
-              12.6
-            ],
-            "duration": [
-              0,
-              1.261,
-              0.812,
-              0.729,
-              2.227,
-              0.74,
-              15.124,
-              10.073,
-              8.814,
-              15.124,
-              2.506,
-              0.82,
-              0.913,
-              1.418,
-              3.128,
-              1.244,
-              1.787,
-              0.335,
-              11.043,
-              4.235,
-              1.72,
-              2.272,
-              0.158,
-              2.332,
-              12.187,
-              0.175,
-              0.144,
-              0.764,
-              0.445,
-              1.914,
-              1.812,
-              0.346,
-              1.119,
-              0.189,
-              2.06,
-              0.402,
-              0.523,
-              0.547,
-              14.258,
-              4.237,
-              2.613,
-              0.762,
-              0.314,
-              1.187,
-              5.267,
-              0.768,
-              2.782,
-              0.112,
-              4.245,
-              1.066,
-              1.222,
-              2.872,
-              0.086,
-              0.373,
-              5.556,
-              1.518,
-              3.68,
-              2.545,
-              2.222,
-              2.265
             ]
-          },
-          "weight_typical": 884.532,
-          "duration_typical": 201.157,
-          "weight": 884.532,
-          "duration": 201.157,
+          }
+        },
+        {
+          "weight_typical": 311.327,
+          "weight": 300.763,
+          "via_waypoints": [],
+          "distance": 1049.454,
+          "duration": 235.2469999999999,
+          "duration_typical": 236.14,
+          "summary": "Nowy Świat",
+          "admins": [
+            {
+              "iso_3166_1": "PL",
+              "iso_3166_1_alpha3": "POL"
+            }
+          ],
           "steps": [
             {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive south on <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>. Then, in 400 feet, Make a left U-turn to stay on <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Drive south on Wojciecha Cybulskiego. Then, in 400 feet, Make a left U-turn to stay on Wojciecha Cybulskiego.",
-                  "distanceAlongGeometry": 122
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Make a left U-turn to stay on <say-as interpret-as=\"address\">Wojciecha Cybulskiego</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Make a left U-turn to stay on Wojciecha Cybulskiego.",
-                  "distanceAlongGeometry": 66.667
-                }
-              ],
-              "intersections": [
-                {
-                  "bearings": [
-                    180
-                  ],
-                  "entry": [
-                    true
-                  ],
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "geometry_index": 0,
-                  "location": [
-                    17.033323,
-                    51.116123
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    0,
-                    271
-                  ],
-                  "duration": 2,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 2.8,
-                  "geometry_index": 1,
-                  "location": [
-                    17.033323,
-                    51.116123
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    91,
-                    176,
-                    284,
-                    356
-                  ],
-                  "duration": 2.815,
-                  "turn_weight": 2,
-                  "turn_duration": 0.015,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 5.22,
-                  "geometry_index": 3,
-                  "location": [
-                    17.033249,
-                    51.116124
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    104,
-                    199,
-                    293
-                  ],
-                  "duration": 15.988,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.013,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 18.871,
-                  "geometry_index": 5,
-                  "location": [
-                    17.033147,
-                    51.11614
-                  ]
-                },
-                {
-                  "bearings": [
-                    24,
-                    113,
-                    293
-                  ],
-                  "entry": [
-                    true,
-                    false,
-                    true
-                  ],
-                  "in": 1,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "geometry_index": 7,
-                  "location": [
-                    17.03222,
-                    51.11639
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Wojciecha Cybulskiego"
-                      }
-                    ],
-                    "driving_side": "right",
-                    "type": "turn",
-                    "modifier": "uturn",
-                    "text": "Wojciecha Cybulskiego"
-                  },
-                  "distanceAlongGeometry": 122
-                }
-              ],
+              "weight_typical": 311.327,
+              "distance": 1049.454,
+              "duration": 235.2469999999999,
+              "duration_typical": 236.14,
               "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "depart",
-                "instruction": "Drive south on Wojciecha Cybulskiego.",
-                "bearing_after": 180,
-                "bearing_before": 0,
-                "location": [
-                  17.033323,
-                  51.116123
-                ]
-              },
               "speedLimitSign": "vienna",
-              "name": "Wojciecha Cybulskiego",
-              "weight_typical": 38.924,
-              "duration_typical": 30.839,
-              "duration": 30.839,
-              "distance": 122,
-              "driving_side": "right",
-              "weight": 38.924,
+              "geometry": "}eun`Bommn_@TjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD",
+              "name": "Nowy Świat",
               "mode": "driving",
-              "geometry": "ud{n`Buesn_@??CxA@x@Ar@]vCWtA{Mfv@uGd_@"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 400 feet, Turn right onto <say-as interpret-as=\"address\">Most Uniwersytecki</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "In 400 feet, Turn right onto Most Uniwersytecki.",
-                  "distanceAlongGeometry": 119
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Most Uniwersytecki</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn right onto Most Uniwersytecki.",
-                  "distanceAlongGeometry": 50
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    113,
-                    113
-                  ],
-                  "duration": 36.23,
-                  "turn_weight": 628.5,
-                  "turn_duration": 27.455,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 638.591,
-                  "geometry_index": 8,
-                  "location": [
-                    17.031705,
-                    51.116529
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    24,
-                    113,
-                    293
-                  ],
-                  "duration": 15.982,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 18.871,
-                  "geometry_index": 9,
-                  "location": [
-                    17.03222,
-                    51.11639
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    104,
-                    199,
-                    293
-                  ],
-                  "duration": 3.186,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.036,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 4.122,
-                  "geometry_index": 11,
-                  "location": [
-                    17.033147,
-                    51.11614
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false,
-                    false,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    91,
-                    176,
-                    284,
-                    356
-                  ],
-                  "duration": 2.295,
-                  "turn_weight": 2,
-                  "turn_duration": 0.045,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 4.588,
-                  "geometry_index": 13,
-                  "location": [
-                    17.033249,
-                    51.116124
-                  ]
-                },
-                {
-                  "bearings": [
-                    96,
-                    271
-                  ],
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "street"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "geometry_index": 15,
-                  "location": [
-                    17.033323,
-                    51.116123
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Most Uniwersytecki"
-                      }
-                    ],
-                    "type": "turn",
-                    "modifier": "right",
-                    "text": "Most Uniwersytecki"
-                  },
-                  "distanceAlongGeometry": 129
-                }
-              ],
-              "speedLimitUnit": "km/h",
               "maneuver": {
-                "type": "continue",
-                "instruction": "Make a left U-turn to stay on Wojciecha Cybulskiego.",
-                "modifier": "uturn",
-                "bearing_after": 113,
-                "bearing_before": 293,
-                "location": [
-                  17.031705,
-                  51.116529
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Wojciecha Cybulskiego",
-              "weight_typical": 670.295,
-              "duration_typical": 60.842,
-              "duration": 60.842,
-              "distance": 129,
-              "driving_side": "right",
-              "weight": 670.295,
-              "mode": "driving",
-              "geometry": "a~{n`Bq`pn_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeE"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 700 feet, Turn right onto <say-as interpret-as=\"address\">Grodzka</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "In 700 feet, Turn right onto Grodzka.",
-                  "distanceAlongGeometry": 196.333
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Turn right onto <say-as interpret-as=\"address\">Grodzka</say-as>.</prosody></amazon:effect></speak>",
-                  "announcement": "Turn right onto Grodzka.",
-                  "distanceAlongGeometry": 77.778
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
-                    true,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    1,
-                    125,
-                    169,
-                    276
-                  ],
-                  "duration": 2.14,
-                  "turn_weight": 9,
-                  "turn_duration": 0.831,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 10.505,
-                  "geometry_index": 16,
-                  "location": [
-                    17.033422,
-                    51.116117
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    168,
-                    218,
-                    349
-                  ],
-                  "duration": 2.146,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 2.946,
-                  "geometry_index": 17,
-                  "location": [
-                    17.033443,
-                    51.11605
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    348
-                  ],
-                  "duration": 11.077,
-                  "turn_weight": 5.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 18.238,
-                  "geometry_index": 19,
-                  "location": [
-                    17.033481,
-                    51.115936
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    348
-                  ],
-                  "duration": 4.32,
-                  "turn_weight": 5.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 10.468,
-                  "geometry_index": 20,
-                  "location": [
-                    17.033724,
-                    51.115236
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    348
-                  ],
-                  "duration": 1.68,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 2.432,
-                  "geometry_index": 21,
-                  "location": [
-                    17.033777,
-                    51.115081
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    168,
-                    259,
-                    348
-                  ],
-                  "duration": 2.222,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.048,
-                  "geometry_index": 22,
-                  "location": [
-                    17.033798,
-                    51.115018
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    173,
-                    348
-                  ],
-                  "duration": 0.277,
-                  "turn_weight": 5.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 5.818,
-                  "geometry_index": 23,
-                  "location": [
-                    17.033823,
-                    51.114946
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    353
-                  ],
-                  "duration": 13.371,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 15.877,
-                  "geometry_index": 24,
-                  "location": [
-                    17.033824,
-                    51.114941
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    163,
-                    348
-                  ],
-                  "duration": 1.059,
-                  "turn_weight": 5.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 6.718,
-                  "geometry_index": 26,
-                  "location": [
-                    17.033985,
-                    51.114481
-                  ]
-                },
-                {
-                  "bearings": [
-                    70,
-                    167,
-                    253,
-                    343
-                  ],
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "turn_weight": 2,
-                  "turn_duration": 0.009,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "geometry_index": 29,
-                  "location": [
-                    17.034006,
-                    51.114437
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Grodzka"
-                      }
-                    ],
-                    "type": "turn",
-                    "modifier": "right",
-                    "text": "Grodzka"
-                  },
-                  "distanceAlongGeometry": 213
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn right onto Most Uniwersytecki.",
-                "modifier": "right",
-                "bearing_after": 169,
-                "bearing_before": 96,
-                "location": [
-                  17.033422,
-                  51.116117
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Most Uniwersytecki",
-              "weight_typical": 83.165,
-              "duration_typical": 42.749,
-              "duration": 42.749,
-              "distance": 213,
-              "driving_side": "right",
-              "weight": 83.165,
-              "mode": "driving",
-              "geometry": "id{n`B{ksn_@dCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM"
-            },
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In 1,000 feet, Your destination will be on the right.</prosody></amazon:effect></speak>",
-                  "announcement": "In 1,000 feet, Your destination will be on the right.",
-                  "distanceAlongGeometry": 273.879
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Your destination is on the right.</prosody></amazon:effect></speak>",
-                  "announcement": "Your destination is on the right.",
-                  "distanceAlongGeometry": 69.444
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    68,
-                    170,
-                    250,
-                    347
-                  ],
-                  "duration": 4.906,
-                  "turn_weight": 8,
-                  "turn_duration": 3.636,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 9.461,
-                  "geometry_index": 33,
-                  "location": [
-                    17.034077,
-                    51.114251
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    70,
-                    132,
-                    246,
-                    329
-                  ],
-                  "duration": 2.777,
-                  "turn_weight": 2,
-                  "turn_duration": 0.024,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 5.166,
-                  "geometry_index": 35,
-                  "location": [
-                    17.033999,
-                    51.114233
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    66,
-                    151,
-                    242,
-                    327
-                  ],
-                  "duration": 18.024,
-                  "turn_weight": 2,
-                  "turn_duration": 0.024,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 22.7,
-                  "geometry_index": 38,
-                  "location": [
-                    17.033826,
-                    51.114184
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    60,
-                    241
-                  ],
-                  "duration": 3.176,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 4.153,
-                  "geometry_index": 41,
-                  "location": [
-                    17.032758,
-                    51.113826
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "left"
-                      ],
-                      "valid": false,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.03257,
-                    51.113761
-                  ],
-                  "geometry_index": 43,
-                  "admin_index": 0,
-                  "weight": 0.776,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.009,
-                  "turn_weight": 0.5,
-                  "duration": 0.249,
-                  "bearings": [
-                    61,
-                    159,
-                    245
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    65,
-                    245
-                  ],
-                  "duration": 1.2,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 1.88,
-                  "geometry_index": 44,
-                  "location": [
-                    17.032553,
-                    51.113756
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    65,
-                    243
-                  ],
-                  "duration": 16.16,
-                  "turn_weight": 0.5,
-                  "turn_duration": 2,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 16.784,
-                  "geometry_index": 45,
-                  "location": [
-                    17.032489,
-                    51.113737
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.031735,
-                    51.113492
-                  ],
-                  "geometry_index": 51,
-                  "admin_index": 0,
-                  "weight": 6.692,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.022,
-                  "turn_weight": 2,
-                  "duration": 4.102,
-                  "bearings": [
-                    62,
-                    153,
-                    240,
-                    334
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.031523,
-                    51.113416
-                  ],
-                  "geometry_index": 53,
-                  "admin_index": 0,
-                  "weight": 5.707,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 5.5,
-                  "duration": 0.187,
-                  "bearings": [
-                    60,
-                    155,
-                    242
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true
-                  ]
-                },
-                {
-                  "bearings": [
-                    62,
-                    242,
-                    259
-                  ],
-                  "entry": [
-                    false,
-                    true,
-                    false
-                  ],
-                  "in": 0,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "geometry_index": 54,
-                  "location": [
-                    17.031517,
-                    51.113414
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Your destination will be on the right"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "right",
-                    "text": "Your destination will be on the right"
-                  },
-                  "distanceAlongGeometry": 290.545
-                },
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "Your destination is on the right"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "right",
-                    "text": "Your destination is on the right"
-                  },
-                  "distanceAlongGeometry": 69.444
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "turn",
-                "instruction": "Turn right onto Grodzka.",
-                "modifier": "right",
-                "bearing_after": 250,
-                "bearing_before": 167,
-                "location": [
-                  17.034077,
-                  51.114251
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Grodzka",
-              "weight_typical": 92.148,
-              "duration_typical": 66.728,
-              "duration": 66.728,
-              "distance": 290.545,
-              "driving_side": "right",
-              "weight": 92.148,
-              "mode": "driving",
-              "geometry": "uown`Byttn_@\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArI"
-            },
-            {
-              "voiceInstructions": [],
-              "intersections": [
-                {
-                  "bearings": [
-                    69
-                  ],
-                  "entry": [
-                    true
-                  ],
-                  "in": 0,
-                  "admin_index": 0,
-                  "geometry_index": 60,
-                  "location": [
-                    17.030376,
-                    51.113071
-                  ]
-                }
-              ],
-              "bannerInstructions": [],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "arrive",
-                "instruction": "Your destination is on the right.",
-                "modifier": "right",
-                "bearing_after": 0,
-                "bearing_before": 249,
                 "location": [
                   17.030376,
                   51.113071
-                ]
+                ],
+                "bearing_before": 0.0,
+                "bearing_after": 252.0,
+                "instruction": "Drive west on Nowy Świat.",
+                "type": "depart"
               },
-              "speedLimitSign": "vienna",
-              "name": "Grodzka",
-              "weight_typical": 0,
-              "duration_typical": 0,
-              "duration": 0,
-              "distance": 0,
+              "voiceInstructions": [
+                {
+                  "distanceAlongGeometry": 1049.454,
+                  "announcement": "Drive west on Nowy Świat for a half mile.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive west on \u003csay-as interpret-as\u003d\"address\"\u003eNowy Świat\u003c/say-as\u003e for a half mile.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 402.336,
+                  "announcement": "In a quarter mile, You will arrive at your destination.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, You will arrive at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                },
+                {
+                  "distanceAlongGeometry": 69.444,
+                  "announcement": "You have arrived at your destination.",
+                  "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYou have arrived at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+                }
+              ],
+              "bannerInstructions": [
+                {
+                  "distanceAlongGeometry": 1049.454,
+                  "primary": {
+                    "text": "You will arrive at your destination",
+                    "components": [
+                      {
+                        "text": "You will arrive at your destination",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight"
+                  }
+                },
+                {
+                  "distanceAlongGeometry": 69.444,
+                  "primary": {
+                    "text": "You have arrived at your destination",
+                    "components": [
+                      {
+                        "text": "You have arrived at your destination",
+                        "type": "text"
+                      }
+                    ],
+                    "type": "arrive",
+                    "modifier": "straight"
+                  }
+                }
+              ],
               "driving_side": "right",
-              "weight": 0,
-              "mode": "driving",
-              "geometry": "}eun`Bommn_@??"
-            }
-          ],
-          "distance": 754.545,
-          "summary": "Wojciecha Cybulskiego, Grodzka"
-        },
-        {
-          "via_waypoints": [],
-          "admins": [
+              "weight": 300.763,
+              "intersections": [
+                {
+                  "duration": 1.882,
+                  "weight": 2.164,
+                  "location": [
+                    17.030376,
+                    51.113071
+                  ],
+                  "bearings": [
+                    252
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "out": 0,
+                  "geometry_index": 0,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 10.987,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 13.127,
+                  "location": [
+                    17.030229,
+                    51.113042
+                  ],
+                  "bearings": [
+                    72,
+                    254,
+                    341
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 2,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 1.999,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.019,
+                  "weight": 2.777,
+                  "location": [
+                    17.02938,
+                    51.112899
+                  ],
+                  "bearings": [
+                    51,
+                    77,
+                    256
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 1,
+                  "out": 2,
+                  "geometry_index": 6,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 7.874,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.019,
+                  "weight": 9.533,
+                  "location": [
+                    17.029225,
+                    51.112874
+                  ],
+                  "bearings": [
+                    76,
+                    221,
+                    255
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 8,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 21.934,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 25.716,
+                  "location": [
+                    17.028887,
+                    51.112818
+                  ],
+                  "bearings": [
+                    75,
+                    237,
+                    255
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "geometry_index": 12,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 10.473,
+                  "turn_weight": 0.5,
+                  "weight": 12.544,
+                  "location": [
+                    17.027979,
+                    51.112643
+                  ],
+                  "bearings": [
+                    68,
+                    239
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "geometry_index": 16,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 34.246,
+                  "turn_duration": 0.041,
+                  "turn_weight": 0.75,
+                  "duration": 29.169,
+                  "location": [
+                    17.027597,
+                    51.112484
+                  ],
+                  "bearings": [
+                    54,
+                    222,
+                    310
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 19,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 6.516,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 3.935,
+                  "location": [
+                    17.027004,
+                    51.111793
+                  ],
+                  "bearings": [
+                    19,
+                    96,
+                    198,
+                    275
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 26,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 3.505,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 1.316,
+                  "location": [
+                    17.02695,
+                    51.111689
+                  ],
+                  "bearings": [
+                    18,
+                    86,
+                    198,
+                    260
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 28,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 3.505,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 1.316,
+                  "location": [
+                    17.026933,
+                    51.111657
+                  ],
+                  "bearings": [
+                    18,
+                    63,
+                    198,
+                    255
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 29,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 13.332,
+                  "turn_duration": 0.021,
+                  "turn_weight": 7,
+                  "duration": 5.527,
+                  "location": [
+                    17.026913,
+                    51.111619
+                  ],
+                  "bearings": [
+                    18,
+                    122,
+                    195,
+                    277,
+                    314
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 30,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 11.254,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 8.054,
+                  "location": [
+                    17.026816,
+                    51.111393
+                  ],
+                  "bearings": [
+                    15,
+                    104,
+                    195,
+                    283
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 33,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "duration": 6.565,
+                  "turn_weight": 0.5,
+                  "weight": 8.049,
+                  "location": [
+                    17.02668,
+                    51.111064
+                  ],
+                  "bearings": [
+                    15,
+                    194
+                  ],
+                  "entry": [
+                    false,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight",
+                        "right"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 35,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 2.205,
+                  "turn_duration": 0.009,
+                  "turn_weight": 0.5,
+                  "duration": 1.491,
+                  "location": [
+                    17.026569,
+                    51.110798
+                  ],
+                  "bearings": [
+                    15,
+                    198,
+                    283
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 37,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 6.588,
+                  "turn_duration": 0.021,
+                  "turn_weight": 0.5,
+                  "duration": 5.315,
+                  "location": [
+                    17.02654,
+                    51.110741
+                  ],
+                  "bearings": [
+                    18,
+                    195,
+                    284
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true
+                  ],
+                  "in": 0,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 38,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.653,
+                  "turn_duration": 0.007,
+                  "turn_weight": 2,
+                  "duration": 3.184,
+                  "location": [
+                    17.026447,
+                    51.110523
+                  ],
+                  "bearings": [
+                    15,
+                    104,
+                    195,
+                    289
+                  ],
+                  "entry": [
+                    false,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 2,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 41,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 6.14,
+                  "turn_duration": 0.071,
+                  "turn_weight": 2,
+                  "duration": 3.671,
+                  "location": [
+                    17.026392,
+                    51.110395
+                  ],
+                  "bearings": [
+                    15,
+                    86,
+                    107,
+                    177,
+                    277
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    true,
+                    false
+                  ],
+                  "in": 0,
+                  "out": 3,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 44,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 14.102,
+                  "turn_duration": 0.028,
+                  "turn_weight": 2,
+                  "duration": 10.551,
+                  "location": [
+                    17.026401,
+                    51.110277
+                  ],
+                  "bearings": [
+                    101,
+                    172,
+                    282,
+                    357
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 47,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "tertiary"
+                  }
+                },
+                {
+                  "weight": 5.354,
+                  "turn_duration": 0.019,
+                  "turn_weight": 0.5,
+                  "duration": 4.24,
+                  "location": [
+                    17.026479,
+                    51.10994
+                  ],
+                  "bearings": [
+                    171,
+                    338,
+                    351
+                  ],
+                  "entry": [
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 50,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 3.972,
+                  "turn_weight": 0.5,
+                  "weight": 5.068,
+                  "location": [
+                    17.026559,
+                    51.109637
+                  ],
+                  "bearings": [
+                    168,
+                    351
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 52,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 15.628,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.028,
+                  "weight": 18.44,
+                  "location": [
+                    17.026652,
+                    51.109355
+                  ],
+                  "bearings": [
+                    162,
+                    177,
+                    348
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 55,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 2.664,
+                  "turn_weight": 2,
+                  "turn_duration": 0.024,
+                  "weight": 5.036,
+                  "location": [
+                    17.026986,
+                    51.108814
+                  ],
+                  "bearings": [
+                    66,
+                    150,
+                    242,
+                    335
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 60,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 7.466,
+                  "turn_weight": 2,
+                  "turn_duration": 0.026,
+                  "weight": 10.556,
+                  "location": [
+                    17.027068,
+                    51.108726
+                  ],
+                  "bearings": [
+                    58,
+                    144,
+                    237,
+                    330
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 63,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 4.215,
+                  "turn_weight": 2,
+                  "turn_duration": 0.061,
+                  "weight": 6.777,
+                  "location": [
+                    17.027326,
+                    51.108502
+                  ],
+                  "bearings": [
+                    66,
+                    128,
+                    232,
+                    324
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 68,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 4.459,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.028,
+                  "weight": 5.595,
+                  "location": [
+                    17.027677,
+                    51.10834
+                  ],
+                  "bearings": [
+                    119,
+                    220,
+                    305
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 72,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 0.438,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.022,
+                  "weight": 0.978,
+                  "location": [
+                    17.028079,
+                    51.108207
+                  ],
+                  "bearings": [
+                    114,
+                    206,
+                    297
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 76,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 2.492,
+                  "turn_weight": 0.5,
+                  "weight": 3.366,
+                  "location": [
+                    17.028119,
+                    51.108196
+                  ],
+                  "bearings": [
+                    110,
+                    294
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 77,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 1.267,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.021,
+                  "weight": 1.933,
+                  "location": [
+                    17.028364,
+                    51.10814
+                  ],
+                  "bearings": [
+                    109,
+                    206,
+                    290
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 79,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 6.516,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.008,
+                  "weight": 7.984,
+                  "location": [
+                    17.028483,
+                    51.108114
+                  ],
+                  "bearings": [
+                    111,
+                    199,
+                    289
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 80,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 1.819,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.019,
+                  "weight": 2.57,
+                  "location": [
+                    17.029114,
+                    51.107963
+                  ],
+                  "bearings": [
+                    110,
+                    200,
+                    291
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 83,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 2.222,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.007,
+                  "weight": 3.048,
+                  "location": [
+                    17.029285,
+                    51.107924
+                  ],
+                  "bearings": [
+                    110,
+                    199,
+                    290
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 85,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 3.468,
+                  "turn_weight": 2,
+                  "turn_duration": 0.007,
+                  "weight": 5.981,
+                  "location": [
+                    17.029496,
+                    51.107876
+                  ],
+                  "bearings": [
+                    18,
+                    110,
+                    197,
+                    290
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "geometry_index": 87,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 20.312,
+                  "turn_weight": 0.5,
+                  "turn_duration": 0.021,
+                  "weight": 23.835,
+                  "location": [
+                    17.029839,
+                    51.107799
+                  ],
+                  "bearings": [
+                    109,
+                    203,
+                    290
+                  ],
+                  "entry": [
+                    true,
+                    true,
+                    false
+                  ],
+                  "in": 2,
+                  "out": 0,
+                  "geometry_index": 90,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 4.091,
+                  "turn_weight": 0.5,
+                  "weight": 5.205,
+                  "location": [
+                    17.031499,
+                    51.10742
+                  ],
+                  "bearings": [
+                    115,
+                    293
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 97,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "duration": 2.455,
+                  "turn_weight": 0.5,
+                  "weight": 3.323,
+                  "location": [
+                    17.031825,
+                    51.107323
+                  ],
+                  "bearings": [
+                    117,
+                    295
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "geometry_index": 98,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "weight": 1.253,
+                  "turn_duration": 2,
+                  "turn_weight": 0.5,
+                  "duration": 2.655,
+                  "location": [
+                    17.032023,
+                    51.107261
+                  ],
+                  "bearings": [
+                    112,
+                    297
+                  ],
+                  "entry": [
+                    true,
+                    false
+                  ],
+                  "in": 1,
+                  "out": 0,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "uturn",
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 99,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                },
+                {
+                  "turn_weight": 2,
+                  "turn_duration": 0.022,
+                  "location": [
+                    17.032075,
+                    51.107248
+                  ],
+                  "bearings": [
+                    18,
+                    109,
+                    197,
+                    292
+                  ],
+                  "entry": [
+                    false,
+                    true,
+                    false,
+                    false
+                  ],
+                  "in": 3,
+                  "out": 1,
+                  "lanes": [
+                    {
+                      "valid": false,
+                      "active": false,
+                      "indications": [
+                        "uturn",
+                        "left"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": false,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    },
+                    {
+                      "valid": true,
+                      "active": true,
+                      "valid_indication": "straight",
+                      "indications": [
+                        "straight"
+                      ]
+                    }
+                  ],
+                  "geometry_index": 101,
+                  "is_urban": true,
+                  "admin_index": 0,
+                  "mapbox_streets_v8": {
+                    "class": "secondary"
+                  }
+                }
+              ]
+            },
             {
-              "iso_3166_1_alpha3": "POL",
-              "iso_3166_1": "PL"
+              "weight_typical": 0,
+              "distance": 0.0,
+              "duration": 0.0,
+              "duration_typical": 0.0,
+              "speedLimitUnit": "km/h",
+              "speedLimitSign": "vienna",
+              "geometry": "oxin`Bo~pn_@??",
+              "name": "Nowy Świat",
+              "mode": "driving",
+              "maneuver": {
+                "location": [
+                  17.032184,
+                  51.107224
+                ],
+                "bearing_before": 109.0,
+                "bearing_after": 0.0,
+                "instruction": "You have arrived at your destination.",
+                "type": "arrive"
+              },
+              "voiceInstructions": [],
+              "bannerInstructions": [],
+              "driving_side": "right",
+              "weight": 0.0,
+              "intersections": [
+                {
+                  "location": [
+                    17.032184,
+                    51.107224
+                  ],
+                  "bearings": [
+                    289
+                  ],
+                  "entry": [
+                    true
+                  ],
+                  "in": 0,
+                  "geometry_index": 103,
+                  "admin_index": 0
+                }
+              ]
             }
           ],
           "annotation": {
+            "distance": [
+              4.2,
+              6.8,
+              4.1,
+              5.2,
+              32.2,
+              19.9,
+              8.8,
+              2.4,
+              8.2,
+              0.4,
+              11.5,
+              4.3,
+              15.5,
+              34.0,
+              9.1,
+              8.0,
+              17.4,
+              8.9,
+              5.9,
+              4.2,
+              11.9,
+              17.7,
+              19.6,
+              29.2,
+              3.2,
+              2.8,
+              3.4,
+              8.8,
+              3.8,
+              4.5,
+              11.2,
+              11.7,
+              3.2,
+              2.3,
+              35.5,
+              26.1,
+              4.5,
+              6.7,
+              2.7,
+              19.4,
+              3.1,
+              3.0,
+              6.0,
+              5.7,
+              7.0,
+              3.1,
+              3.0,
+              4.4,
+              3.0,
+              30.5,
+              2.1,
+              32.0,
+              8.6,
+              15.9,
+              7.5,
+              24.0,
+              7.0,
+              24.5,
+              7.6,
+              1.5,
+              1.8,
+              5.8,
+              3.7,
+              1.6,
+              2.1,
+              12.9,
+              13.3,
+              0.8,
+              13.9,
+              3.6,
+              9.8,
+              3.2,
+              4.9,
+              11.3,
+              11.0,
+              4.6,
+              3.1,
+              15.7,
+              2.6,
+              8.8,
+              4.1,
+              37.7,
+              5.4,
+              9.2,
+              3.5,
+              8.3,
+              7.4,
+              4.7,
+              13.2,
+              7.6,
+              12.5,
+              3.9,
+              20.0,
+              19.7,
+              25.0,
+              35.0,
+              7.4,
+              25.2,
+              15.5,
+              2.3,
+              1.6,
+              1.6,
+              6.5
+            ],
+            "duration": [
+              0.755,
+              1.224,
+              0.745,
+              0.93,
+              5.804,
+              3.583,
+              1.581,
+              0.432,
+              2.676,
+              0.146,
+              3.758,
+              1.42,
+              5.058,
+              11.141,
+              2.975,
+              2.608,
+              5.681,
+              2.901,
+              1.93,
+              1.375,
+              3.893,
+              5.799,
+              6.415,
+              9.548,
+              1.034,
+              0.923,
+              1.118,
+              2.867,
+              1.229,
+              1.458,
+              2.514,
+              2.623,
+              0.726,
+              0.516,
+              7.997,
+              5.871,
+              1.017,
+              1.499,
+              0.597,
+              4.358,
+              0.698,
+              0.683,
+              1.348,
+              1.291,
+              1.943,
+              0.864,
+              0.836,
+              1.21,
+              0.838,
+              8.451,
+              0.643,
+              9.614,
+              2.588,
+              4.778,
+              2.252,
+              5.769,
+              1.685,
+              5.889,
+              1.817,
+              0.37,
+              0.433,
+              1.402,
+              0.889,
+              0.388,
+              0.502,
+              3.097,
+              3.201,
+              0.199,
+              1.724,
+              0.452,
+              1.212,
+              0.397,
+              0.603,
+              1.405,
+              1.366,
+              0.569,
+              0.379,
+              1.944,
+              0.318,
+              1.093,
+              0.51,
+              4.682,
+              0.667,
+              1.148,
+              0.431,
+              1.027,
+              0.921,
+              0.58,
+              1.64,
+              0.94,
+              2.052,
+              0.634,
+              3.273,
+              3.219,
+              4.093,
+              5.732,
+              1.214,
+              4.126,
+              2.531,
+              0.373,
+              0.268,
+              0.257,
+              1.064
+            ],
+            "speed": [
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              5.6,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              3.1,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              4.4,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              3.6,
+              3.3,
+              3.3,
+              3.3,
+              3.3,
+              3.3,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              4.2,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              8.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1,
+              6.1
+            ],
             "maxspeed": [
               {
                 "speed": 50,
@@ -4624,1815 +6424,28 @@
               3,
               3,
               3
-            ],
-            "speed": [
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              5.6,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              3.1,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              4.4,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              3.6,
-              3.3,
-              3.3,
-              3.3,
-              3.3,
-              3.3,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              4.2,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              8.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1,
-              6.1
-            ],
-            "distance": [
-              4.2,
-              6.8,
-              4.1,
-              5.2,
-              32.2,
-              19.9,
-              8.8,
-              2.4,
-              8.2,
-              0.4,
-              11.5,
-              4.3,
-              15.5,
-              34,
-              9.1,
-              8,
-              17.4,
-              8.9,
-              5.9,
-              4.2,
-              11.9,
-              17.7,
-              19.6,
-              29.2,
-              3.2,
-              2.8,
-              3.4,
-              8.8,
-              3.8,
-              4.5,
-              11.2,
-              11.7,
-              3.2,
-              2.3,
-              35.5,
-              26.1,
-              4.5,
-              6.7,
-              2.7,
-              19.4,
-              3.1,
-              3,
-              6,
-              5.7,
-              7,
-              3.1,
-              3,
-              4.4,
-              3,
-              30.5,
-              2.1,
-              32,
-              8.6,
-              15.9,
-              7.5,
-              24,
-              7,
-              24.5,
-              7.6,
-              1.5,
-              1.8,
-              5.8,
-              3.7,
-              1.6,
-              2.1,
-              12.9,
-              13.3,
-              0.8,
-              13.9,
-              3.6,
-              9.8,
-              3.2,
-              4.9,
-              11.3,
-              11,
-              4.6,
-              3.1,
-              15.7,
-              2.6,
-              8.8,
-              4.1,
-              37.7,
-              5.4,
-              9.2,
-              3.5,
-              8.3,
-              7.4,
-              4.7,
-              13.2,
-              7.6,
-              12.5,
-              3.9,
-              20,
-              19.7,
-              25,
-              35,
-              7.4,
-              25.2,
-              15.5,
-              2.3,
-              1.6,
-              1.6,
-              6.5
-            ],
-            "duration": [
-              0.755,
-              1.224,
-              0.745,
-              0.93,
-              5.804,
-              3.583,
-              1.581,
-              0.432,
-              2.676,
-              0.146,
-              3.758,
-              1.42,
-              5.058,
-              11.141,
-              2.975,
-              2.608,
-              5.681,
-              2.901,
-              1.93,
-              1.375,
-              3.893,
-              5.799,
-              6.415,
-              9.548,
-              1.034,
-              0.923,
-              1.118,
-              2.867,
-              1.229,
-              1.458,
-              2.514,
-              2.623,
-              0.726,
-              0.516,
-              7.997,
-              5.871,
-              1.017,
-              1.499,
-              0.597,
-              4.358,
-              0.698,
-              0.683,
-              1.348,
-              1.291,
-              1.943,
-              0.864,
-              0.836,
-              1.21,
-              0.838,
-              8.451,
-              0.643,
-              9.614,
-              2.588,
-              4.778,
-              2.252,
-              5.769,
-              1.685,
-              5.889,
-              1.817,
-              0.37,
-              0.433,
-              1.402,
-              0.889,
-              0.388,
-              0.502,
-              3.097,
-              3.201,
-              0.199,
-              1.724,
-              0.452,
-              1.212,
-              0.397,
-              0.603,
-              1.405,
-              1.366,
-              0.569,
-              0.379,
-              1.944,
-              0.318,
-              1.093,
-              0.51,
-              4.682,
-              0.667,
-              1.148,
-              0.431,
-              1.027,
-              0.921,
-              0.58,
-              1.64,
-              0.94,
-              2.052,
-              0.634,
-              3.273,
-              3.219,
-              4.093,
-              5.732,
-              1.214,
-              4.126,
-              2.531,
-              0.373,
-              0.268,
-              0.257,
-              1.064
             ]
-          },
-          "weight_typical": 311.327,
-          "duration_typical": 236.14,
-          "weight": 300.763,
-          "duration": 226.953,
-          "steps": [
-            {
-              "voiceInstructions": [
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">Drive west on <say-as interpret-as=\"address\">Nowy Świat</say-as> for a half mile.</prosody></amazon:effect></speak>",
-                  "announcement": "Drive west on Nowy Świat for a half mile.",
-                  "distanceAlongGeometry": 1049.454
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">In a quarter mile, You will arrive at your destination.</prosody></amazon:effect></speak>",
-                  "announcement": "In a quarter mile, You will arrive at your destination.",
-                  "distanceAlongGeometry": 402.336
-                },
-                {
-                  "ssmlAnnouncement": "<speak><amazon:effect name=\"drc\"><prosody rate=\"1.08\">You have arrived at your destination.</prosody></amazon:effect></speak>",
-                  "announcement": "You have arrived at your destination.",
-                  "distanceAlongGeometry": 69.444
-                }
-              ],
-              "intersections": [
-                {
-                  "entry": [
-                    true
-                  ],
-                  "bearings": [
-                    252
-                  ],
-                  "duration": 1.882,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 2.164,
-                  "geometry_index": 0,
-                  "location": [
-                    17.030376,
-                    51.113071
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    72,
-                    254,
-                    341
-                  ],
-                  "duration": 10.987,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 13.127,
-                  "geometry_index": 2,
-                  "location": [
-                    17.030229,
-                    51.113042
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    51,
-                    77,
-                    256
-                  ],
-                  "duration": 1.999,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 2.777,
-                  "geometry_index": 6,
-                  "location": [
-                    17.02938,
-                    51.112899
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    76,
-                    221,
-                    255
-                  ],
-                  "duration": 7.874,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 9.533,
-                  "geometry_index": 8,
-                  "location": [
-                    17.029225,
-                    51.112874
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    75,
-                    237,
-                    255
-                  ],
-                  "duration": 21.934,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 2,
-                  "weight": 25.716,
-                  "geometry_index": 12,
-                  "location": [
-                    17.028887,
-                    51.112818
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    68,
-                    239
-                  ],
-                  "duration": 10.473,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 12.544,
-                  "geometry_index": 16,
-                  "location": [
-                    17.027979,
-                    51.112643
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.027597,
-                    51.112484
-                  ],
-                  "geometry_index": 19,
-                  "admin_index": 0,
-                  "weight": 34.246,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.041,
-                  "turn_weight": 0.75,
-                  "duration": 29.169,
-                  "bearings": [
-                    54,
-                    222,
-                    310
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.027004,
-                    51.111793
-                  ],
-                  "geometry_index": 26,
-                  "admin_index": 0,
-                  "weight": 6.516,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 3.935,
-                  "bearings": [
-                    19,
-                    96,
-                    198,
-                    275
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.02695,
-                    51.111689
-                  ],
-                  "geometry_index": 28,
-                  "admin_index": 0,
-                  "weight": 3.505,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 1.316,
-                  "bearings": [
-                    18,
-                    86,
-                    198,
-                    260
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026933,
-                    51.111657
-                  ],
-                  "geometry_index": 29,
-                  "admin_index": 0,
-                  "weight": 3.505,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 1.316,
-                  "bearings": [
-                    18,
-                    63,
-                    198,
-                    255
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026913,
-                    51.111619
-                  ],
-                  "geometry_index": 30,
-                  "admin_index": 0,
-                  "weight": 13.332,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.021,
-                  "turn_weight": 7,
-                  "duration": 5.527,
-                  "bearings": [
-                    18,
-                    122,
-                    195,
-                    277,
-                    314
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026816,
-                    51.111393
-                  ],
-                  "geometry_index": 33,
-                  "admin_index": 0,
-                  "weight": 11.254,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 8.054,
-                  "bearings": [
-                    15,
-                    104,
-                    195,
-                    283
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight",
-                        "right"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "entry": [
-                    false,
-                    true
-                  ],
-                  "in": 0,
-                  "bearings": [
-                    15,
-                    194
-                  ],
-                  "duration": 6.565,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 8.049,
-                  "geometry_index": 35,
-                  "location": [
-                    17.02668,
-                    51.111064
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026569,
-                    51.110798
-                  ],
-                  "geometry_index": 37,
-                  "admin_index": 0,
-                  "weight": 2.205,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.009,
-                  "turn_weight": 0.5,
-                  "duration": 1.491,
-                  "bearings": [
-                    15,
-                    198,
-                    283
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.02654,
-                    51.110741
-                  ],
-                  "geometry_index": 38,
-                  "admin_index": 0,
-                  "weight": 6.588,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.021,
-                  "turn_weight": 0.5,
-                  "duration": 5.315,
-                  "bearings": [
-                    18,
-                    195,
-                    284
-                  ],
-                  "out": 1,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    true
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026447,
-                    51.110523
-                  ],
-                  "geometry_index": 41,
-                  "admin_index": 0,
-                  "weight": 5.653,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.007,
-                  "turn_weight": 2,
-                  "duration": 3.184,
-                  "bearings": [
-                    15,
-                    104,
-                    195,
-                    289
-                  ],
-                  "out": 2,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026392,
-                    51.110395
-                  ],
-                  "geometry_index": 44,
-                  "admin_index": 0,
-                  "weight": 6.14,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.071,
-                  "turn_weight": 2,
-                  "duration": 3.671,
-                  "bearings": [
-                    15,
-                    86,
-                    107,
-                    177,
-                    277
-                  ],
-                  "out": 3,
-                  "in": 0,
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026401,
-                    51.110277
-                  ],
-                  "geometry_index": 47,
-                  "admin_index": 0,
-                  "weight": 14.102,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "tertiary"
-                  },
-                  "turn_duration": 0.028,
-                  "turn_weight": 2,
-                  "duration": 10.551,
-                  "bearings": [
-                    101,
-                    172,
-                    282,
-                    357
-                  ],
-                  "out": 1,
-                  "in": 3,
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.026479,
-                    51.10994
-                  ],
-                  "geometry_index": 50,
-                  "admin_index": 0,
-                  "weight": 5.354,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "turn_duration": 0.019,
-                  "turn_weight": 0.5,
-                  "duration": 4.24,
-                  "bearings": [
-                    171,
-                    338,
-                    351
-                  ],
-                  "out": 0,
-                  "in": 2,
-                  "entry": [
-                    true,
-                    false,
-                    false
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    168,
-                    351
-                  ],
-                  "duration": 3.972,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 5.068,
-                  "geometry_index": 52,
-                  "location": [
-                    17.026559,
-                    51.109637
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    162,
-                    177,
-                    348
-                  ],
-                  "duration": 15.628,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.028,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 18.44,
-                  "geometry_index": 55,
-                  "location": [
-                    17.026652,
-                    51.109355
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    66,
-                    150,
-                    242,
-                    335
-                  ],
-                  "duration": 2.664,
-                  "turn_weight": 2,
-                  "turn_duration": 0.024,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.036,
-                  "geometry_index": 60,
-                  "location": [
-                    17.026986,
-                    51.108814
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    58,
-                    144,
-                    237,
-                    330
-                  ],
-                  "duration": 7.466,
-                  "turn_weight": 2,
-                  "turn_duration": 0.026,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 10.556,
-                  "geometry_index": 63,
-                  "location": [
-                    17.027068,
-                    51.108726
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    66,
-                    128,
-                    232,
-                    324
-                  ],
-                  "duration": 4.215,
-                  "turn_weight": 2,
-                  "turn_duration": 0.061,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 6.777,
-                  "geometry_index": 68,
-                  "location": [
-                    17.027326,
-                    51.108502
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    119,
-                    220,
-                    305
-                  ],
-                  "duration": 4.459,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.028,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 5.595,
-                  "geometry_index": 72,
-                  "location": [
-                    17.027677,
-                    51.10834
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    114,
-                    206,
-                    297
-                  ],
-                  "duration": 0.438,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.022,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 0.978,
-                  "geometry_index": 76,
-                  "location": [
-                    17.028079,
-                    51.108207
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    110,
-                    294
-                  ],
-                  "duration": 2.492,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.366,
-                  "geometry_index": 77,
-                  "location": [
-                    17.028119,
-                    51.108196
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    109,
-                    206,
-                    290
-                  ],
-                  "duration": 1.267,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.021,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 1.933,
-                  "geometry_index": 79,
-                  "location": [
-                    17.028364,
-                    51.10814
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    111,
-                    199,
-                    289
-                  ],
-                  "duration": 6.516,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.008,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 7.984,
-                  "geometry_index": 80,
-                  "location": [
-                    17.028483,
-                    51.108114
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    110,
-                    200,
-                    291
-                  ],
-                  "duration": 1.819,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.019,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 2.57,
-                  "geometry_index": 83,
-                  "location": [
-                    17.029114,
-                    51.107963
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    110,
-                    199,
-                    290
-                  ],
-                  "duration": 2.222,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.048,
-                  "geometry_index": 85,
-                  "location": [
-                    17.029285,
-                    51.107924
-                  ]
-                },
-                {
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "bearings": [
-                    18,
-                    110,
-                    197,
-                    290
-                  ],
-                  "duration": 3.468,
-                  "turn_weight": 2,
-                  "turn_duration": 0.007,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "weight": 5.981,
-                  "geometry_index": 87,
-                  "location": [
-                    17.029496,
-                    51.107876
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    true,
-                    false
-                  ],
-                  "in": 2,
-                  "bearings": [
-                    109,
-                    203,
-                    290
-                  ],
-                  "duration": 20.312,
-                  "turn_weight": 0.5,
-                  "turn_duration": 0.021,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 23.835,
-                  "geometry_index": 90,
-                  "location": [
-                    17.029839,
-                    51.107799
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    115,
-                    293
-                  ],
-                  "duration": 4.091,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 5.205,
-                  "geometry_index": 97,
-                  "location": [
-                    17.031499,
-                    51.10742
-                  ]
-                },
-                {
-                  "entry": [
-                    true,
-                    false
-                  ],
-                  "in": 1,
-                  "bearings": [
-                    117,
-                    295
-                  ],
-                  "duration": 2.455,
-                  "turn_weight": 0.5,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 0,
-                  "weight": 3.323,
-                  "geometry_index": 98,
-                  "location": [
-                    17.031825,
-                    51.107323
-                  ]
-                },
-                {
-                  "lanes": [
-                    {
-                      "indications": [
-                        "uturn",
-                        "left"
-                      ],
-                      "valid": false,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "location": [
-                    17.032023,
-                    51.107261
-                  ],
-                  "geometry_index": 99,
-                  "admin_index": 0,
-                  "weight": 1.253,
-                  "is_urban": true,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "turn_duration": 2,
-                  "turn_weight": 0.5,
-                  "duration": 2.655,
-                  "bearings": [
-                    112,
-                    297
-                  ],
-                  "out": 0,
-                  "in": 1,
-                  "entry": [
-                    true,
-                    false
-                  ]
-                },
-                {
-                  "bearings": [
-                    18,
-                    109,
-                    197,
-                    292
-                  ],
-                  "entry": [
-                    false,
-                    true,
-                    false,
-                    false
-                  ],
-                  "in": 3,
-                  "turn_weight": 2,
-                  "lanes": [
-                    {
-                      "indications": [
-                        "uturn",
-                        "left"
-                      ],
-                      "valid": false,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": false
-                    },
-                    {
-                      "indications": [
-                        "straight"
-                      ],
-                      "valid_indication": "straight",
-                      "valid": true,
-                      "active": true
-                    }
-                  ],
-                  "turn_duration": 0.022,
-                  "mapbox_streets_v8": {
-                    "class": "secondary"
-                  },
-                  "is_urban": true,
-                  "admin_index": 0,
-                  "out": 1,
-                  "geometry_index": 101,
-                  "location": [
-                    17.032075,
-                    51.107248
-                  ]
-                }
-              ],
-              "bannerInstructions": [
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "You will arrive at your destination"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "straight",
-                    "text": "You will arrive at your destination"
-                  },
-                  "distanceAlongGeometry": 1049.454
-                },
-                {
-                  "primary": {
-                    "components": [
-                      {
-                        "type": "text",
-                        "text": "You have arrived at your destination"
-                      }
-                    ],
-                    "type": "arrive",
-                    "modifier": "straight",
-                    "text": "You have arrived at your destination"
-                  },
-                  "distanceAlongGeometry": 69.444
-                }
-              ],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "depart",
-                "instruction": "Drive west on Nowy Świat.",
-                "bearing_after": 252,
-                "bearing_before": 0,
-                "location": [
-                  17.030376,
-                  51.113071
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Nowy Świat",
-              "weight_typical": 311.327,
-              "duration_typical": 236.14,
-              "duration": 226.953,
-              "distance": 1049.454,
-              "driving_side": "right",
-              "weight": 300.763,
-              "mode": "driving",
-              "geometry": "}eun`Bommn_@TjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD"
-            },
-            {
-              "voiceInstructions": [],
-              "intersections": [
-                {
-                  "bearings": [
-                    289
-                  ],
-                  "entry": [
-                    true
-                  ],
-                  "in": 0,
-                  "admin_index": 0,
-                  "geometry_index": 103,
-                  "location": [
-                    17.032184,
-                    51.107224
-                  ]
-                }
-              ],
-              "bannerInstructions": [],
-              "speedLimitUnit": "km/h",
-              "maneuver": {
-                "type": "arrive",
-                "instruction": "You have arrived at your destination.",
-                "bearing_after": 0,
-                "bearing_before": 109,
-                "location": [
-                  17.032184,
-                  51.107224
-                ]
-              },
-              "speedLimitSign": "vienna",
-              "name": "Nowy Świat",
-              "weight_typical": 0,
-              "duration_typical": 0,
-              "duration": 0,
-              "distance": 0,
-              "driving_side": "right",
-              "weight": 0,
-              "mode": "driving",
-              "geometry": "oxin`Bo~pn_@??"
-            }
-          ],
-          "distance": 1049.454,
-          "summary": "Nowy Świat"
+          }
         }
       ],
-      "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvDdCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaAj@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GMKdE??CxA@x@Ar@]vCWtA{Mfv@uGd_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeEdCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArITjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD",
-      "voiceLocale": "en-US"
+      "routeOptions": {
+        "baseUrl": "https://api.mapbox.com",
+        "user": "mapbox",
+        "profile": "driving-traffic",
+        "coordinates": "17.0359582,51.1230732;17.0333423,51.1160887;17.0303647,51.1130915;17.0321327,51.1072076",
+        "continue_straight": true,
+        "roundabout_exits": true,
+        "geometries": "polyline6",
+        "overview": "full",
+        "steps": true,
+        "annotations": "congestion_numeric,maxspeed,closure,speed,duration,distance",
+        "voice_instructions": true,
+        "banner_instructions": true,
+        "enable_refresh": true
+      },
+      "voiceLocale": "en-US",
+      "requestUuid": "pmzkNPXknULJwETblENCKWMNIHAUDtN8LGwlbbeyydAACiKP_nLYog\u003d\u003d"
     }
   ],
-  "waypoints": [
-    {
-      "distance": 2.663,
-      "name": "Trzebnicka",
-      "location": [
-        17.035996,
-        51.123076
-      ]
-    },
-    {
-      "distance": 4.049,
-      "name": "Wojciecha Cybulskiego",
-      "location": [
-        17.033323,
-        51.116123
-      ]
-    },
-    {
-      "distance": 2.355,
-      "name": "Nowy Świat",
-      "location": [
-        17.030376,
-        51.113071
-      ]
-    },
-    {
-      "distance": 4.023,
-      "name": "Kazimierza Wielkiego",
-      "location": [
-        17.032184,
-        51.107224
-      ]
-    }
-  ],
-  "code": "Ok",
-  "uuid": "pmzkNPXknULJwETblENCKWMNIHAUDtN8LGwlbbeyydAACiKP_nLYog=="
+  "uuid": "pmzkNPXknULJwETblENCKWMNIHAUDtN8LGwlbbeyydAACiKP_nLYog\u003d\u003d"
 }

--- a/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
+++ b/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
@@ -47,26 +47,28 @@ fun createNavigationRoutes(
     options: RouteOptions = response.routes().first().routeOptions()!!,
     routerOrigin: RouterOrigin = RouterOrigin.Offboard,
 ): List<NavigationRoute> {
-    val parser = object : SDKRouteParser {
-        override fun parseDirectionsResponse(
-            response: String,
-            request: String,
-            routerOrigin: RouterOrigin
-        ): Expected<String, List<RouteInterface>> {
-            val result = createRouteInterfacesFromDirectionRequestResponse(
-                requestUri = request,
-                response = response,
-                routerOrigin = routerOrigin
-            )
-            return ExpectedFactory.createValue(result)
-        }
-    }
+    val parser = TestSDKRouteParser()
     return com.mapbox.navigation.base.internal.route.createNavigationRoutes(
         response,
         options,
         parser,
         routerOrigin
     )
+}
+
+class TestSDKRouteParser : SDKRouteParser {
+    override fun parseDirectionsResponse(
+        response: String,
+        request: String,
+        routerOrigin: RouterOrigin
+    ): Expected<String, List<RouteInterface>> {
+        val result = createRouteInterfacesFromDirectionRequestResponse(
+            requestUri = request,
+            response = response,
+            routerOrigin = routerOrigin
+        )
+        return ExpectedFactory.createValue(result)
+    }
 }
 
 fun createRouteInterfacesFromDirectionRequestResponse(

--- a/libtesting-thirdparty/src/main/java/com/mapbox/navigation/testing/factories/DirectionsResponseFactories.kt
+++ b/libtesting-thirdparty/src/main/java/com/mapbox/navigation/testing/factories/DirectionsResponseFactories.kt
@@ -51,27 +51,40 @@ fun createRouteLeg(
     annotation: LegAnnotation? = createRouteLegAnnotation(),
     incidents: List<Incident>? = null,
     closures: List<Closure>? = null,
-    legStep: List<LegStep> = listOf(createRouteStep()),
+    steps: List<LegStep> = listOf(createRouteStep()),
+    duration: Double? = null
 ): RouteLeg {
     return RouteLeg.builder()
         .annotation(annotation)
         .incidents(incidents)
         .closures(closures)
-        .steps(legStep)
+        .duration(duration)
+        .steps(steps)
         .build()
 }
 
-fun createRouteStep(): LegStep {
+fun createRouteStep(
+    distance: Double = 123.0,
+    duration: Double = 333.4,
+    mode: String = "driving",
+    maneuver: StepManeuver = createManeuver(),
+    weight: Double = 111.0,
+    bannerInstructions: List<BannerInstructions> = listOf(createBannerInstructions())
+): LegStep {
     return LegStep
         .builder()
-        .distance(123.0)
-        .duration(334.0)
-        .mode("mode")
-        .maneuver(StepManeuver.builder().rawLocation(doubleArrayOf(123.3434, 37.2233)).build())
-        .weight(111.0)
-        .bannerInstructions(listOf(createBannerInstructions()))
+        .distance(distance)
+        .duration(duration)
+        .mode(mode)
+        .maneuver(maneuver)
+        .weight(weight)
+        .bannerInstructions(bannerInstructions)
         .build()
 }
+
+fun createManeuver(
+    rawLocation: DoubleArray = doubleArrayOf(123.3434, 37.2233)
+): StepManeuver = StepManeuver.builder().rawLocation(rawLocation).build()
 
 fun createBannerInstructions(
     primary: BannerText = createBannerText(),


### PR DESCRIPTION
Navigation SDK didn't update any of duration fields from directions route. This PR introduces recalculation of durations based on annotations.

### Problems with recalculation

During the deep discussion, we found out that Directions API doesn't include duration of manoeuvres in duration annotations. It means, that if you refresh a route immediately and recalculate duration based on annotations, you get a value which is little bit less than original one. @LukasPaczos did some research of [how recalculated route duration deviates from the original one](https://github.com/mapbox/navigation-sdks/issues/1835#issuecomment-1184365001).

We also found out that NN uses duration annotation to calculate remaining time, so the error is already present in our SDK.

Directions API team plan to fix duration annotations so that they include manoeuvre's time. I propose to fix client side ahead. It let us release v2.8 with a fix, which will start work great as soon as Directions API fix back end implementation.

### Notes for reviewer

I calculated durations manually for a simple route and used them as expected values in `NavigationRouteExTest`. But routes used in `RouterWrapperTest` are so big, that I just replaced them by the actual value to make the tests green. It would be nice to update test routes by a real ones when Directions API fix annotations and start producing routes where durations and annotations are consistent. Feel free to advice me if you know a better approach. 

### Super short introduction to annotations
I learned how to use annotations in this PR. This knowledge is essential to review the PR, please read the following section if you aren't familiar with annotations. Check if my understanding is correct if you are familiar with annotations. 🙂 

Route and route step has a geometry. It's a set of points encoded in polyline or polyline6. When you follow a route - you're moving between points from its geometry. Parts of the route between the points are called segments. Annotations represent data for route segments. Data available by index 0 in an annotations array is for the route segment between point 0 and 1. Checkout example for the route `18.576643884351938,54.410360746511714;18.576223679158517,54.41205221865337` 
![mapping-of-annotation-to-route-geometry drawio](https://user-images.githubusercontent.com/6190346/189121611-642f54af-540e-48f5-be7f-2c138148708a.svg)

### TODO

- [x] manual testing
- [x] test a few legs route
- [x] does route geomerty decoding require separate thread?
