### PR TITLE
Make MapboxNavigationApp.setup create new instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,6 +598,7 @@ jobs:
 
   static-analysis:
     executor: ndk-r22-latest-executor
+    resource_class: medium+
     steps:
       - when:
           condition:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Introduced `MapboxManeuverView#maneuverViewState` to allow users to observe changes to `MapboxManeuverViewState` when the view expands and collapses. [#6286](https://github.com/mapbox/mapbox-navigation-android/pull/6286)
 - Introduced `NavigationViewApi#onManeuverCollapsed` and `NavigationViewApi#onManeuverExpanded` callback which is triggered upon changes to `MapboxManeuverViewState`. [#6286](https://github.com/mapbox/mapbox-navigation-android/pull/6286)
 - Implemented logic that would display `BannerComponents` of `type` `GuidanceView` and `subType` `BannerComponents#SAPA`, `BannerComponents#CITYREAL`, `BannerComponents#AFTERTOLL`, `BannerComponents#SIGNBOARD`, `BannerComponents#TOLLBRANCH`, `BannerComponents#EXPRESSWAY_ENTRANCE`, `BannerComponents#EXPRESSWAY_EXIT` using `JunctionViewApi`. [#6285](https://github.com/mapbox/mapbox-navigation-android/pull/6285)
+- Calling `MapboxNavigationApp.setup` will create a new `MapboxNavigation` instance with new `NavigationOptions` even if the app has been setup. [#6285](https://github.com/mapbox/mapbox-navigation-android/pull/6285)
 #### Bug fixes and improvements
 - Fixed an issue with `NavigationView` that caused overview camera to have wrong pitch. [#6278](https://github.com/mapbox/mapbox-navigation-android/pull/6278)
 - Fixed an issue with `NavigationView` that caused camera issues after reroute or switching to an alternative route. [#6283](https://github.com/mapbox/mapbox-navigation-android/pull/6283)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.core.lifecycle
 import android.app.Application
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.utils.internal.logI
 import kotlin.reflect.KClass
 
 /**
@@ -24,16 +23,7 @@ internal class MapboxNavigationAppDelegate {
         }
 
         if (isSetup) {
-            logI(
-                """
-                    MapboxNavigationApp.setup was ignored because it has already been setup.
-                    If you want to use new NavigationOptions, you must first call
-                    MapboxNavigationApp.disable() and then call MapboxNavigationApp.setup(..).
-                    Calling setup multiple times, is harmless otherwise.
-                """.trimIndent(),
-                LOG_CATEGORY
-            )
-            return this
+            disable()
         }
 
         mapboxNavigationOwner.setup(navigationOptionsProvider)
@@ -80,8 +70,4 @@ internal class MapboxNavigationAppDelegate {
 
     fun <T : MapboxNavigationObserver> getObservers(kClass: KClass<T>): List<T> =
         mapboxNavigationOwner.getObservers(kClass)
-
-    private companion object {
-        private const val LOG_CATEGORY = "MapboxNavigationAppDelegate"
-    }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MainActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MainActivity.kt
@@ -9,7 +9,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.databinding.ActivityMainBinding
 import com.mapbox.navigation.qa_test_app.domain.TestActivityDescription
@@ -54,9 +53,6 @@ class MainActivity : AppCompatActivity() {
         (binding.activitiesList.adapter as GenericListAdapter<TestActivityDescription, *>).swap(
             TestActivitySuite.testActivities
         )
-
-        // Each example is responsible for setting up their NavigationOptions.
-        MapboxNavigationApp.disable()
     }
 
     override fun onRequestPermissionsResult(


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

We have been discussing an issue where the examples need to call `disable` to have their new `NavigationOptions` accepted by the `MapboxNavigationApp`

- https://github.com/mapbox/mapbox-navigation-android-examples/pull/129#discussion_r945596178
- https://github.com/mapbox/mapbox-navigation-android/pull/6233#discussion_r957610510

The solution was to add a disable into the "orchestrating" activity. Which is the MainActivity that helps you select different examples.

The problem with that is that it breaks Android Auto while you're selecting an example. The whole point of this is to make the examples work well with Android Auto.

Why this new solution is being considered desirable, is because there is a `MapboxNavigationApp.isSetup` function available. If you really do not want to trigger a recreation, that option is available. The new setup function puts more trust into the caller that they know setup will trigger a new instance of `MapboxNavigation`.