### PR TITLE
handle route changes and navigation state separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Fixed an issue with `NavigationView` that caused overview camera to have wrong pitch. [#6278](https://github.com/mapbox/mapbox-navigation-android/pull/6278)
 - Fixed an issue with `NavigationView` that caused camera issues after reroute or switching to an alternative route. [#6283](https://github.com/mapbox/mapbox-navigation-android/pull/6283)
+- Fixed an issue with `NavigationView` that caused camera to unexpectedly change state in some situations. [#6291](https://github.com/mapbox/mapbox-navigation-android/pull/6291)
 
 ## Mapbox Navigation SDK 2.8.0-beta.2 - 01 September, 2022
 ### Changelog


### PR DESCRIPTION
### Description

Fixes #6251. 
Previously we combined both flows which caused camera to change state not only when navigation state changes, but also when routes change (reroute or switching to an alternative). By observing the flows separately the issue is fixed. The only exception is free drive state, where we have to wait for routes to become empty and avoid unnecessary camera transitions in an intermediate state. 

### Screenshots or Gifs

https://user-images.githubusercontent.com/2395284/189198184-7e4ef7b9-44a3-4ef2-9834-1551df38ad1c.mp4




<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
