### PR TITLE
Fix step distance and trip progress views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed an issue with `NavigationView` that caused overview camera to have wrong pitch. [#6278](https://github.com/mapbox/mapbox-navigation-android/pull/6278)
 - Fixed an issue with `NavigationView` that caused camera issues after reroute or switching to an alternative route. [#6283](https://github.com/mapbox/mapbox-navigation-android/pull/6283)
 - Fixed an issue with `NavigationView` that caused camera to unexpectedly change state in some situations. [#6291](https://github.com/mapbox/mapbox-navigation-android/pull/6291)
+- Fixed an issue where step distance in `MapboxManeuverView` could have been cut off. [#6296](https://github.com/mapbox/mapbox-navigation-android/pull/6296)
+- Fixed an issue where trip progress in `MapboxTripProgressView` could have been cut off if large font size is used. [#6296](https://github.com/mapbox/mapbox-navigation-android/pull/6296)
 
 ## Mapbox Navigation SDK 2.8.0-beta.2 - 01 September, 2022
 ### Changelog

--- a/libnavui-maneuver/src/main/res/layout/mapbox_main_maneuver_layout.xml
+++ b/libnavui-maneuver/src/main/res/layout/mapbox_main_maneuver_layout.xml
@@ -55,12 +55,13 @@
 
     <com.mapbox.navigation.ui.maneuver.view.MapboxStepDistance
         android:id="@+id/stepDistance"
-        android:layout_width="96dp"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="4dp"
         android:gravity="center"
         android:paddingTop="4dp"
         android:paddingBottom="4dp"
+        android:paddingEnd="2dp"
         android:textAppearance="@style/MapboxStyleStepDistance"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/mainManeuverGuideline"

--- a/libnavui-tripprogress/src/main/res/layout/mapbox_trip_progress_layout.xml
+++ b/libnavui-tripprogress/src/main/res/layout/mapbox_trip_progress_layout.xml
@@ -17,7 +17,9 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="4dp"
             app:layout_constraintStart_toStartOf="@id/timeRemainingText"
-            app:layout_constraintTop_toBottomOf="@id/timeRemainingText" >
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/timeRemainingText">
+
             <ImageView
                 android:id="@+id/distanceRemainingIcon"
                 android:layout_width="18dp"
@@ -31,7 +33,7 @@
             <com.mapbox.navigation.ui.tripprogress.view.DistanceRemainingView
                 android:id="@+id/distanceRemainingText"
                 android:layout_width="wrap_content"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:includeFontPadding="false"
                 tools:text="5 mi"/>
         </androidx.appcompat.widget.LinearLayoutCompat>
@@ -57,7 +59,7 @@
             <com.mapbox.navigation.ui.tripprogress.view.EstimatedArrivalTimeView
                 android:id="@+id/estimatedTimeToArriveText"
                 android:layout_width="wrap_content"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:includeFontPadding="false"
                 tools:text="4:28 pm"/>
         </androidx.appcompat.widget.LinearLayoutCompat>
@@ -69,6 +71,7 @@
             android:includeFontPadding="false"
             tools:text="2h 15m"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/distanceRemainingLayout"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="@id/estimatedArrivalTimeLayout"
             />


### PR DESCRIPTION
With `russian` lang + `imperial` units `step distance` view might be cut off:

| cut off | 1 | 2 | 3 | 1 large | 2 large | 3 large |
| - | - | - | - | - | - | - |
| ![123123](https://user-images.githubusercontent.com/14282440/189317691-6214b102-3aca-423c-b8d2-63afdd9c8b96.jpeg) | ![photo_2022-09-09 12 25 41](https://user-images.githubusercontent.com/14282440/189318209-8734fc9e-efd4-4e77-8b7f-c2c1b96102ad.jpeg) | ![photo_2022-09-09 12 25 42](https://user-images.githubusercontent.com/14282440/189318213-fa9b6740-cc57-43de-aa85-8e0d2be15e2e.jpeg) | ![photo_2022-09-09 12 25 46](https://user-images.githubusercontent.com/14282440/189318215-0dcc3dfd-05b9-4426-ab30-831c15fe2523.jpeg) | ![photo_2022-09-09 12 25 43](https://user-images.githubusercontent.com/14282440/189318231-0cad6eed-0924-4264-bf19-50da22aff2cf.jpeg) | ![photo_2022-09-09 12 25 44](https://user-images.githubusercontent.com/14282440/189318236-79490a4a-6326-4f4a-8091-6b3528c4262e.jpeg) | ![photo_2022-09-09 12 25 45](https://user-images.githubusercontent.com/14282440/189318241-80f658f1-5771-407a-bbb3-4790f0916501.jpeg) |

as you can see, with `xlarge` font size `TripProgress` data is also cut off ^^.
Fixes:
| default font | xlarge font |
| - | - |
| ![photo_2022-09-09 12 31 17](https://user-images.githubusercontent.com/14282440/189319582-3e7f5dfc-5039-42e7-964d-d4cf914c9602.jpeg) | ![photo_2022-09-09 12 31 18](https://user-images.githubusercontent.com/14282440/189319587-231cbcf9-3cce-41cd-b973-e8d8b89af81e.jpeg) |

