### PR TITLE
Make SharedApp backwards compatible and removable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 #### Bug fixes and improvements
 - Optimized calls to modify route arrow layer visibility. [#6308](https://github.com/mapbox/mapbox-navigation-android/pull/6308)
+- Make `SharedApp` backwards compatible and removable. [#6303](https://github.com/mapbox/mapbox-navigation-android/pull/6303)
 
 ## Mapbox Navigation SDK 2.8.0-beta.3 - 09 September, 2022
 ### Changelog

--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Removed `MapboxCarApp.setup`, replace with `MapboxNavigationApp.registerObserver(MapboxCarApp)` so it can be disabled. [#6275](https://github.com/mapbox/mapbox-navigation-android/pull/6275)
 
 ## androidauto-v0.10.0 - Sep 9, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -2,7 +2,6 @@ package com.mapbox.navigation.dropin
 
 import android.Manifest
 import android.app.Activity
-import android.app.Application
 import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -20,6 +19,7 @@ import com.mapbox.maps.MapView
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.internal.extensions.attachCreated
+import com.mapbox.navigation.core.internal.extensions.attachStarted
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.dropin.component.analytics.AnalyticsComponent
@@ -109,7 +109,7 @@ class NavigationView @JvmOverloads constructor(
         keepScreenOn = true
         captureSystemBarsInsets()
 
-        SharedApp.setup(context.applicationContext as Application)
+        MapboxNavigationApp.registerObserver(SharedApp)
         if (!MapboxNavigationApp.isSetup()) {
             MapboxNavigationApp.setup(
                 NavigationOptions.Builder(context)

--- a/qa-test-app/build.gradle
+++ b/qa-test-app/build.gradle
@@ -98,6 +98,9 @@ dependencies {
     implementation project(':libnavui-androidauto')
     implementation dependenciesList.mapboxSearchSdk
 
+    // TODO Remove after 2.8.0-rc.1
+    implementation project(':libnavui-app')
+
     // test
     androidTestImplementation project(':libtesting-ui')
     androidTestImplementation dependenciesList.testRunner

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
@@ -1,13 +1,5 @@
 package com.mapbox.navigation.qa_test_app
 
 import android.app.Application
-import com.mapbox.androidauto.MapboxCarApp
 
-class QaTestApplication : Application() {
-
-    override fun onCreate() {
-        super.onCreate()
-
-        MapboxCarApp.setup(this)
-    }
-}
+class QaTestApplication : Application()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.mapbox.android.core.permissions.PermissionsManager
+import com.mapbox.androidauto.MapboxCarApp
 import com.mapbox.androidauto.MapboxCarNavigationManager
 import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.androidauto.car.MainScreenManager
@@ -27,9 +28,11 @@ import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMap
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.internal.extensions.attachCreated
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.ui.app.internal.SharedApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -47,6 +50,11 @@ class MainCarSession : Session() {
 
     init {
         logAndroidAuto("MainCarSession constructor")
+
+        // TODO remove after 2.8.0-rc.1
+        MapboxNavigationApp.registerObserver(SharedApp)
+        attachCreated(MapboxCarApp)
+
         val logoSurfaceRenderer = CarLogoSurfaceRenderer()
         val compassSurfaceRenderer = CarCompassSurfaceRenderer()
         MapboxNavigationApp.attach(lifecycleOwner = this)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/6253

There is an incompatibility with `SharedApp` where it can only be setup once and it is the only opportunity to specify custom services https://github.com/mapbox/mapbox-navigation-android/pull/6213/files#r964971123

Every time the `SharedApp.setup` function changes it will break compatibility with anything that uses it. Converting the `SharedApp` to a `MapboxNavigationObserver` to resolve it and removing customizability so it can stay backwards compatible.

On the topic of, creating custom services like `MapboxAudioGuidance`. We should be discussing public api options for how to do so, that way the `SharedApp` will not break compatibility with AA. Am also considering that custom services can be swapped with `MapboxNavigationApp.unregisterObserver` and `MapboxNavigationApp.registerObserver`, which are going to be forever backwards compatible and they are public. 

There is no public interface for declaring custom services so it should be removed from this `SharedApp.setup` function.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
