### PR TITLE
Unblock android auto releases

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Added options to customize behavior of the Speed limit widget. [#6275](https://github.com/mapbox/mapbox-navigation-android/pull/6275)
 
 #### Bug fixes and improvements
+- Allow Android Auto release to be paired with old version of nav-sdk. [#6304](https://github.com/mapbox/mapbox-navigation-android/pull/6304)
 
 ## androidauto-v0.9.0 - Sep 1, 2022
 ### Changelog

--- a/libnavui-androidauto/api/current.txt
+++ b/libnavui-androidauto/api/current.txt
@@ -20,7 +20,7 @@ package com.mapbox.androidauto {
     method public com.mapbox.navigation.ui.voice.internal.MapboxAudioGuidance carAppAudioGuidanceService();
     method public com.mapbox.androidauto.navigation.location.CarAppLocation carAppLocationService();
     method public kotlinx.coroutines.flow.StateFlow<com.mapbox.androidauto.CarAppState> getCarAppState();
-    method public void setup(android.app.Application application);
+    method public void setup();
     method public void updateCarAppState(com.mapbox.androidauto.CarAppState carAppState);
     property public final kotlinx.coroutines.flow.StateFlow<com.mapbox.androidauto.CarAppState> carAppState;
     field public static final com.mapbox.androidauto.MapboxCarApp INSTANCE;

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -45,8 +45,7 @@ dependencies {
     def carSearchVersion = "1.0.0-beta.35"
     api("com.mapbox.navigation:android:${carNavVersion}")
     api("com.mapbox.search:mapbox-search-android:${carSearchVersion}")
-    //implementation("com.mapbox.navigation:ui-app:${carNavVersion}")
-    implementation project(":libnavui-app")
+    implementation("com.mapbox.navigation:ui-app:${carNavVersion}")
 
     implementation(dependenciesList.androidXAppCompat)
     implementation(dependenciesList.coroutinesCore)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
@@ -1,13 +1,5 @@
 package com.mapbox.navigation.qa_test_app
 
 import android.app.Application
-import com.mapbox.androidauto.MapboxCarApp
 
-class QaTestApplication : Application() {
-
-    override fun onCreate() {
-        super.onCreate()
-
-        MapboxCarApp.setup(this)
-    }
-}
+class QaTestApplication : Application()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/car/MainCarSession.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.mapbox.android.core.permissions.PermissionsManager
+import com.mapbox.androidauto.MapboxCarApp
 import com.mapbox.androidauto.MapboxCarNavigationManager
 import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.androidauto.car.MainScreenManager
@@ -47,6 +48,7 @@ class MainCarSession : Session() {
 
     init {
         logAndroidAuto("MainCarSession constructor")
+        MapboxCarApp.setup()
         val logoSurfaceRenderer = CarLogoSurfaceRenderer()
         val compassSurfaceRenderer = CarCompassSurfaceRenderer()
         MapboxNavigationApp.attach(lifecycleOwner = this)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Related to this issue https://github.com/mapbox/mapbox-navigation-android/pull/6303

There is a temporary backwards compatibility issue with `SharedApp` that we need to resolve. But we need to wait for the next nav-sdk release train. 

In the meantime, android auto is not actually using `SharedApp` so it is unnecessary to build a strong dependency on the release.
