### PR TITLE
Unblock android auto releases 2

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Added options to customize behavior of the Speed limit widget. [#6275](https://github.com/mapbox/mapbox-navigation-android/pull/6275)
 
 #### Bug fixes and improvements
+- Bump minimum version nav-sdk requirement to 2.8.0-beta.3. [#6305](https://github.com/mapbox/mapbox-navigation-android/pull/6305)
 
 ## androidauto-v0.9.0 - Sep 1, 2022
 ### Changelog

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -41,12 +41,11 @@ dependencies {
     // This defines the minimum version of Maps, Navigation, and Search which are included in
     // this SDK. To upgrade the SDK versions, you can specify a newer version in your downstream
     // build.gradle.
-    def carNavVersion = "2.8.0-beta.2"
+    def carNavVersion = "2.8.0-beta.3"
     def carSearchVersion = "1.0.0-beta.35"
     api("com.mapbox.navigation:android:${carNavVersion}")
     api("com.mapbox.search:mapbox-search-android:${carSearchVersion}")
-    //implementation("com.mapbox.navigation:ui-app:${carNavVersion}")
-    implementation project(":libnavui-app")
+    implementation("com.mapbox.navigation:ui-app:${carNavVersion}")
 
     implementation(dependenciesList.androidXAppCompat)
     implementation(dependenciesList.coroutinesCore)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Was searching for a way to maintain better backwards compatibility here https://github.com/mapbox/mapbox-navigation-android/pull/6304

But that approach has issues, the audio guidance controller has a strong dependency inside `SharedApp`. Continuing to think about this as we make it so components can be removed. But for now we'll need to bump the version according to original plan