### PR TITLE
Adding try/catch and logging around getting unit string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Optimized calls to modify route arrow layer visibility. [#6308](https://github.com/mapbox/mapbox-navigation-android/pull/6308)
 - Provide better java support for `MapboxNavigationApp`. [#6292](https://github.com/mapbox/mapbox-navigation-android/pull/6292)
+- Added a try/catch and logging around calls to get string resources related to distance formatting suffixes. [#6309](https://github.com/mapbox/mapbox-navigation-android/pull/6309)
 
 ## Mapbox Navigation SDK 2.8.0-beta.3 - 09 September, 2022
 ### Changelog


### PR DESCRIPTION
### Description
The following error was reported related to crashes that were logged for a customer:

```
Happens when accessing com.mapbox.navigation.core.R
android.content.res.Resources$NotFoundException: String resource ID #0x7d08002e
```
The developer is doing some lazy initialization of the maps and nav. SDK that may be affecting this but there isn't enough information to be sure.  The `com.mapbox.navigation.core.R` is only used in `MapboxDistanceUtil`.  The work in this PR is intended to get more information by logging any resource not found errors while at the same time protecting against a crash by wrapping the code in a try/catch.

### Screenshots or Gifs

