### PR TITLE
Expose `PointAnnotationOptions` instead of using `MapMarkerFactory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Optimized calls to modify route arrow layer visibility. [#6308](https://github.com/mapbox/mapbox-navigation-android/pull/6308)
 - Provide better java support for `MapboxNavigationApp`. [#6292](https://github.com/mapbox/mapbox-navigation-android/pull/6292)
+- Expose `PointAnnotationOptions` in Drop-In UI to allow users to define the destination marker icon and it's positioning. [#6314](https://github.com/mapbox/mapbox-navigation-android/pull/6314)
 
 ## Mapbox Navigation SDK 2.8.0-beta.3 - 09 September, 2022
 ### Changelog

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -180,7 +180,7 @@ package com.mapbox.navigation.dropin {
     ctor public ViewStyleCustomization();
     method public Integer? getAudioGuidanceButtonStyle();
     method public Integer? getCameraModeButtonStyle();
-    method public Integer? getDestinationMarker();
+    method public com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions? getDestinationMarkerAnnotationOptions();
     method public Integer? getEndNavigationButtonStyle();
     method public Integer? getInfoPanelBackground();
     method public Integer? getInfoPanelMarginEnd();
@@ -197,7 +197,7 @@ package com.mapbox.navigation.dropin {
     method public Integer? getTripProgressStyle();
     method public void setAudioGuidanceButtonStyle(Integer?);
     method public void setCameraModeButtonStyle(Integer?);
-    method public void setDestinationMarker(Integer?);
+    method public void setDestinationMarkerAnnotationOptions(com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions?);
     method public void setEndNavigationButtonStyle(Integer?);
     method public void setInfoPanelBackground(Integer?);
     method public void setInfoPanelMarginEnd(Integer?);
@@ -214,7 +214,7 @@ package com.mapbox.navigation.dropin {
     method public void setTripProgressStyle(Integer?);
     property public final Integer? audioGuidanceButtonStyle;
     property public final Integer? cameraModeButtonStyle;
-    property public final Integer? destinationMarker;
+    property public final com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions? destinationMarkerAnnotationOptions;
     property public final Integer? endNavigationButtonStyle;
     property public final Integer? infoPanelBackground;
     property public final Integer? infoPanelMarginEnd;
@@ -235,13 +235,13 @@ package com.mapbox.navigation.dropin {
   public static final class ViewStyleCustomization.Companion {
     method @StyleRes public int defaultAudioGuidanceButtonStyle();
     method @StyleRes public int defaultCameraModeButtonStyle();
-    method @DrawableRes public int defaultDestinationMarker();
     method @StyleRes public int defaultEndNavigationButtonStyle();
     method @DrawableRes public int defaultInfoPanelBackground();
     method @Px public int defaultInfoPanelMarginEnd();
     method @Px public int defaultInfoPanelMarginStart();
     method @Px public int defaultInfoPanelPeekHeight(android.content.Context context);
     method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions defaultManeuverViewOptions();
+    method public com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions defaultMarkerAnnotationOptions(android.content.Context context);
     method @StyleRes public int defaultRecenterButtonStyle();
     method @DrawableRes public int defaultRoadNameBackground();
     method @StyleRes public int defaultRoadNameTextAppearance();

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewStyles.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewStyles.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.dropin
 
 import android.content.Context
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,14 +37,14 @@ internal class NavigationViewStyles(context: Context) {
         MutableStateFlow(ViewStyleCustomization.defaultSpeedLimitStyle())
     private var _speedLimitTextAppearance: MutableStateFlow<Int> =
         MutableStateFlow(ViewStyleCustomization.defaultSpeedLimitTextAppearance())
-    private var _destinationMarker: MutableStateFlow<Int> =
-        MutableStateFlow(ViewStyleCustomization.defaultDestinationMarker())
     private var _roadNameBackground: MutableStateFlow<Int> =
         MutableStateFlow(ViewStyleCustomization.defaultRoadNameBackground())
     private var _roadNameTextAppearance: MutableStateFlow<Int> =
         MutableStateFlow(ViewStyleCustomization.defaultRoadNameTextAppearance())
     private var _maneuverViewOptions: MutableStateFlow<ManeuverViewOptions> =
         MutableStateFlow(ViewStyleCustomization.defaultManeuverViewOptions())
+    private var _destinationMarkerAnnotationOptions: MutableStateFlow<PointAnnotationOptions> =
+        MutableStateFlow(ViewStyleCustomization.defaultMarkerAnnotationOptions(context))
 
     val infoPanelPeekHeight: StateFlow<Int> = _infoPanelPeekHeight.asStateFlow()
     val infoPanelMarginStart: StateFlow<Int> = _infoPanelMarginStart.asStateFlow()
@@ -58,7 +59,8 @@ internal class NavigationViewStyles(context: Context) {
     val startNavigationButtonStyle: StateFlow<Int> = _startNavigationButtonStyle.asStateFlow()
     val speedLimitStyle: StateFlow<Int> = _speedLimitStyle.asStateFlow()
     val speedLimitTextAppearance: StateFlow<Int> = _speedLimitTextAppearance.asStateFlow()
-    val destinationMarker: StateFlow<Int> = _destinationMarker.asStateFlow()
+    val destinationMarkerAnnotationOptions: StateFlow<PointAnnotationOptions> =
+        _destinationMarkerAnnotationOptions.asStateFlow()
     val roadNameBackground: StateFlow<Int> = _roadNameBackground.asStateFlow()
     val roadNameTextAppearance: StateFlow<Int> = _roadNameTextAppearance.asStateFlow()
     val maneuverViewOptions: StateFlow<ManeuverViewOptions> = _maneuverViewOptions.asStateFlow()
@@ -78,7 +80,9 @@ internal class NavigationViewStyles(context: Context) {
         customization.speedLimitStyle?.also { _speedLimitStyle.tryEmit(it) }
         customization.maneuverViewOptions?.also { _maneuverViewOptions.tryEmit(it) }
         customization.speedLimitTextAppearance?.also { _speedLimitTextAppearance.tryEmit(it) }
-        customization.destinationMarker?.also { _destinationMarker.tryEmit(it) }
+        customization.destinationMarkerAnnotationOptions?.also {
+            _destinationMarkerAnnotationOptions.tryEmit(it)
+        }
         customization.roadNameBackground?.also { _roadNameBackground.tryEmit(it) }
         customization.roadNameTextAppearance?.also { _roadNameTextAppearance.tryEmit(it) }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
@@ -4,7 +4,11 @@ import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.annotation.Px
 import androidx.annotation.StyleRes
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import com.google.android.material.resources.TextAppearance
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.ui.base.view.MapboxExtendableButton
 import com.mapbox.navigation.ui.maneuver.model.ManeuverExitOptions
@@ -55,11 +59,10 @@ class ViewStyleCustomization {
     var infoPanelBackground: Int? = null
 
     /**
-     * Provide custom destination marker icon.
-     * Use [defaultDestinationMarker] to reset to default.
+     * Provide [PointAnnotationOptions] for destination marker.
+     * Use [defaultMarkerAnnotationOptions] to reset to default.
      */
-    @DrawableRes
-    var destinationMarker: Int? = null
+    var destinationMarkerAnnotationOptions: PointAnnotationOptions? = null
 
     /**
      * Provide custom [MapboxRoadNameView] background.
@@ -171,10 +174,18 @@ class ViewStyleCustomization {
         fun defaultInfoPanelBackground(): Int = R.drawable.mapbox_bg_info_panel
 
         /**
-         * Default destination marker icon.
+         * Default [PointAnnotationOptions] for showing destination marker.
          */
-        @DrawableRes
-        fun defaultDestinationMarker(): Int = R.drawable.mapbox_ic_destination_marker
+        fun defaultMarkerAnnotationOptions(context: Context): PointAnnotationOptions =
+            PointAnnotationOptions().apply {
+                withIconImage(
+                    ContextCompat.getDrawable(
+                        context,
+                        R.drawable.mapbox_ic_destination_marker
+                    )!!.toBitmap()
+                )
+                withIconAnchor(IconAnchor.BOTTOM)
+            }
 
         /**
          * Default [MapboxRoadNameView] background.

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
@@ -65,9 +65,9 @@ internal class MapBinder(
             },
             CameraComponent(store, mapView),
             reloadOnChange(
-                context.styles.destinationMarker
-            ) { marker ->
-                MapMarkersComponent(store, mapView, marker)
+                context.styles.destinationMarkerAnnotationOptions
+            ) { markerAnnotationOptions ->
+                MapMarkersComponent(store, mapView, markerAnnotationOptions)
             },
             reloadOnChange(navigationState) {
                 longPressMapComponent(it)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/MapMarkersComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/MapMarkersComponent.kt
@@ -1,8 +1,8 @@
 package com.mapbox.navigation.dropin.component.marker
 
-import androidx.annotation.DrawableRes
 import com.mapbox.maps.MapView
 import com.mapbox.maps.plugin.annotation.annotations
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
@@ -16,12 +16,9 @@ import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 internal open class MapMarkersComponent(
     private val store: Store,
     protected val mapView: MapView,
-    @DrawableRes val iconImage: Int,
+    private val markerAnnotationOptions: PointAnnotationOptions,
 ) : UIComponent() {
 
-    private val mapMarkerFactory by lazy {
-        MapMarkerFactory.create(mapView.context)
-    }
     private var annotationManager = mapView.annotations.createPointAnnotationManager()
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
@@ -31,8 +28,11 @@ internal open class MapMarkersComponent(
             .observe { point ->
                 annotationManager.deleteAll()
                 if (point != null) {
-                    val annotation = mapMarkerFactory.createPin(point, iconImage)
-                    annotationManager.create(annotation)
+                    annotationManager.create(
+                        markerAnnotationOptions.apply {
+                            withPoint(point)
+                        }
+                    )
                 }
             }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApi.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApi.kt
@@ -148,7 +148,7 @@ internal class MapboxNavigationViewApi(
     }
 
     private fun NavigationRoute.getDestination(): Point? {
-        return directionsResponse.waypoints()?.lastOrNull()?.location()
+        return routeOptions.coordinatesList().lastOrNull()
     }
 }
 

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApiTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/internal/MapboxNavigationViewApiTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.dropin.internal
 
-import com.mapbox.api.directions.v5.models.DirectionsWaypoint
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
@@ -126,9 +125,9 @@ class MapboxNavigationViewApiTest {
         val point = Point.fromLngLat(11.0, 22.0)
         val routes = listOf(
             navigationRoute(
-                waypoint(Point.fromLngLat(1.0, 2.0)),
-                waypoint(Point.fromLngLat(2.0, 3.0)),
-                waypoint(point),
+                Point.fromLngLat(1.0, 2.0),
+                Point.fromLngLat(2.0, 3.0),
+                point,
             )
         )
 
@@ -211,9 +210,9 @@ class MapboxNavigationViewApiTest {
         val point = Point.fromLngLat(11.0, 22.0)
         val routes = listOf(
             navigationRoute(
-                waypoint(Point.fromLngLat(1.0, 2.0)),
-                waypoint(Point.fromLngLat(2.0, 3.0)),
-                waypoint(point),
+                Point.fromLngLat(1.0, 2.0),
+                Point.fromLngLat(2.0, 3.0),
+                point,
             )
         )
 
@@ -286,9 +285,9 @@ class MapboxNavigationViewApiTest {
         val point = Point.fromLngLat(11.0, 22.0)
         val routes = listOf(
             navigationRoute(
-                waypoint(Point.fromLngLat(1.0, 2.0)),
-                waypoint(Point.fromLngLat(2.0, 3.0)),
-                waypoint(point),
+                Point.fromLngLat(1.0, 2.0),
+                Point.fromLngLat(2.0, 3.0),
+                point,
             )
         )
 
@@ -334,17 +333,11 @@ class MapboxNavigationViewApiTest {
         verify { testStore.dispatch(TripSessionStarterAction.EnableTripSession) }
     }
 
-    private fun navigationRoute(vararg waypoints: DirectionsWaypoint): NavigationRoute {
+    private fun navigationRoute(vararg waypoints: Point): NavigationRoute {
         return mockk {
-            every { directionsResponse } returns mockk {
-                every { waypoints() } returns waypoints.toList()
+            every { routeOptions } returns mockk(relaxed = true) {
+                every { coordinatesList() } returns waypoints.toList()
             }
-        }
-    }
-
-    private fun waypoint(point: Point): DirectionsWaypoint {
-        return mockk {
-            every { location() } returns point
         }
     }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -14,12 +14,16 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.appcompat.widget.SwitchCompat
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.MutableLiveData
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.geojson.Point
 import com.mapbox.maps.MapView
 import com.mapbox.maps.Style
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
@@ -37,13 +41,13 @@ import com.mapbox.navigation.dropin.NavigationViewListener
 import com.mapbox.navigation.dropin.ViewOptionsCustomization.Companion.defaultRouteLineOptions
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultAudioGuidanceButtonStyle
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultCameraModeButtonStyle
-import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultDestinationMarker
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultEndNavigationButtonStyle
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelBackground
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelMarginEnd
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelMarginStart
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelPeekHeight
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultManeuverViewOptions
+import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultMarkerAnnotationOptions
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRecenterButtonStyle
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRoadNameBackground
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRoadNameTextAppearance
@@ -334,7 +338,15 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
                 tripProgressStyle = R.style.MyCustomTripProgressStyle
                 speedLimitStyle = R.style.MyCustomSpeedLimitStyle
                 speedLimitTextAppearance = R.style.MyCustomSpeedLimitTextAppearance
-                destinationMarker = R.drawable.mapbox_ic_marker
+                destinationMarkerAnnotationOptions = PointAnnotationOptions().apply {
+                    withIconImage(
+                        ContextCompat.getDrawable(
+                            this@MapboxNavigationViewCustomizedActivity,
+                            R.drawable.mapbox_ic_marker
+                        )!!.toBitmap()
+                    )
+                    withIconAnchor(IconAnchor.BOTTOM)
+                }
                 roadNameBackground = R.drawable.mapbox_bg_road_name
                 roadNameTextAppearance = R.style.MyCustomRoadNameViewTextAppearance
                 audioGuidanceButtonStyle = R.style.MyCustomAudioGuidanceButton
@@ -351,7 +363,9 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
                 speedLimitStyle = defaultSpeedLimitStyle()
                 speedLimitTextAppearance = defaultSpeedLimitTextAppearance()
                 maneuverViewOptions = defaultManeuverViewOptions()
-                destinationMarker = defaultDestinationMarker()
+                destinationMarkerAnnotationOptions = defaultMarkerAnnotationOptions(
+                    this@MapboxNavigationViewCustomizedActivity
+                )
                 roadNameBackground = defaultRoadNameBackground()
                 roadNameTextAppearance = defaultRoadNameTextAppearance()
                 audioGuidanceButtonStyle = defaultAudioGuidanceButtonStyle()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes #6297 

Exposes `PointAnnotationOptions` instead of `MapMarkerFactory` that would allow users to specify other properties on `PointAnnotationOptions` like `iconImage`, `iconAnchor`, `iconOffset` etc.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
