### PR TITLE
[Android Auto] QA-Test-App Crash Fix

### DIFF
--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -43,9 +43,12 @@ dependencies {
     // build.gradle.
     def carNavVersion = "2.8.0-beta.3"
     def carSearchVersion = "1.0.0-beta.35"
-    api("com.mapbox.navigation:android:${carNavVersion}")
     api("com.mapbox.search:mapbox-search-android:${carSearchVersion}")
-    implementation("com.mapbox.navigation:ui-app:${carNavVersion}")
+
+    debugApi project(":libnavigation-android")
+    releaseApi("com.mapbox.navigation:android:${carNavVersion}")
+    debugImplementation project(":libnavui-app")
+    releaseImplementation("com.mapbox.navigation:ui-app:${carNavVersion}")
 
     implementation(dependenciesList.androidXAppCompat)
     implementation(dependenciesList.coroutinesCore)


### PR DESCRIPTION
### Description

- Updated `libnavui-androidauto` dependencies to use `project()` references for **DEBUG** build variant.
   (**RELEASE** variant still references published maven artifacts)

### Investigation

**Crash log**

```java
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.mapbox.navigation.qa_test_app, PID: 10933
    java.lang.IncompatibleClassChangeError: The method 'com.mapbox.navigation.core.lifecycle.MapboxNavigationApp com.mapbox.navigation.core.lifecycle.MapboxNavigationApp.registerObserver(com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver)' was expected to be of type virtual but instead was found to be of type static (declaration of 'com.mapbox.androidauto.MapboxCarApp' appears in /data/app/~~MP2o_VBXCrIWIlpmG3qpXg==/com.mapbox.navigation.qa_test_app-PJLztWbeCrdeMBmWcZFqbw==/base.apk!classes5.dex)
        at com.mapbox.androidauto.MapboxCarApp.setup(MapboxCarApp.kt:52)
        at com.mapbox.navigation.qa_test_app.QaTestApplication.onCreate(QaTestApplication.kt:11)
        at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1223)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6762)
        at android.app.ActivityThread.access$1500(ActivityThread.java:256)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2091)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7870)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```
**Findings**

_QA-Test-App_ directly references the `:libnavigation-android` module, which references the `:libnavigation-core`. The last module defines the `MapboxNavigationObserver` interface. The `:libnavui-androidauto` module references `com.mapbox.navigation:android:X.X.X` maven artifact which also defines `MapboxNavigationObserver` interface. 
Unfortunately, from the ART point of view, those two interfaces are not the same hence the ` java.lang.IncompatibleClassChangeError`.

**Solution**

Update the `:libnavui-androidauto` module configuration to directly reference the `:libnavigation-android` module when compiling **DEBUG** build variant and only reference maven artifacts when compiling **RELEASE** build variant.
 