### PR TITLE
Fix qa test app crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,8 +57,11 @@ allprojects {
     // we allow access to snapshots repo if ALLOW_SNAPSHOT_REPOSITORY is set, what means we are running on CI
     // with Navigation Native forced to be some snapshot version
     // if you need to use snapshots while development, just set `addSnapshotsRepo` to true manually
-    def addSnapshotsRepo = project.hasProperty('ALLOW_SNAPSHOT_REPOSITORY') ? project.property('ALLOW_SNAPSHOT_REPOSITORY') : (System.getenv("ALLOW_SNAPSHOT_REPOSITORY")?.toBoolean() ?: false)
-    if (addSnapshotsRepo) {
+    //def addSnapshotsRepo = project.hasProperty('ALLOW_SNAPSHOT_REPOSITORY') ? project.property('ALLOW_SNAPSHOT_REPOSITORY') : (System.getenv("ALLOW_SNAPSHOT_REPOSITORY")?.toBoolean() ?: false)
+    // TODO https://mapbox.atlassian.net/browse/NAVSDK-544
+    //   snapshots are enabled for libnavui-androidauto
+    //   delete after 2.8.0-rc.1 is available
+    if (true) {
       println("Snapshot repository reference added.")
       maven {
         url 'https://api.mapbox.com/downloads/v2/snapshots/maven'

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -41,7 +41,10 @@ dependencies {
     // This defines the minimum version of Maps, Navigation, and Search which are included in
     // this SDK. To upgrade the SDK versions, you can specify a newer version in your downstream
     // build.gradle.
-    def carNavVersion = "2.8.0-beta.3"
+    // TODO https://mapbox.atlassian.net/browse/NAVSDK-544
+    //   incompatible change requires a 2.8.0 release
+    //   change to the 2.8.0-rc.1 when available
+    def carNavVersion = "2.9.0-SNAPSHOT"
     def carSearchVersion = "1.0.0-beta.35"
     api("com.mapbox.navigation:android:${carNavVersion}")
     api("com.mapbox.search:mapbox-search-android:${carSearchVersion}")


### PR DESCRIPTION
Opening as draft here because I just noticed this one https://github.com/mapbox/mapbox-navigation-android/pull/6316. Adding the release and debug dependencies may not fix CI/CD issues so will just leave this in case we want it.

### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

https://mapbox.atlassian.net/browse/NAVSDK-544

Because `libnavui-androidauto` can use independent versions of the `nav-sdk`, changes to the `nav-sdk` can cause binary incompatibilities when the function signatures change.

This was a non-backwards compatible change to the `MapboxNavigationApp` https://github.com/mapbox/mapbox-navigation-android/pull/6292. I added the `@JvmStatic` annotation for better java interop.

I'm actually on the fence a little, to remove the `@JvmStatic` function because when we add it now we'll have it forever (unless kotlin addresses it in some way https://issuetracker.google.com/issues/158393309)

This pull request is following the direction that we want to keep `@JvmStatic`. Android Auto can use the snapshot releases until `2.8.0-rc.1` is released. 

Related issues
- https://github.com/mapbox/mapbox-navigation-android/pull/6303
- https://github.com/mapbox/mapbox-navigation-android/pull/6213/files#r964971123
- https://github.com/mapbox/mapbox-navigation-android/pull/6316