### PR TITLE
[Drop-In UI] extract thunk actions from NavigationViewApi

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/backpress/OnKeyListenerComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/backpress/OnKeyListenerComponent.kt
@@ -7,6 +7,8 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.NavigationView
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
+import com.mapbox.navigation.ui.app.internal.endNavigation
+import com.mapbox.navigation.ui.app.internal.extension.dispatch
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
@@ -66,10 +68,7 @@ internal class OnKeyListenerComponent(
                 true
             }
             NavigationState.Arrival -> {
-                store.dispatch(RoutesAction.SetRoutes(emptyList()))
-                store.dispatch(RoutePreviewAction.Ready(emptyList()))
-                store.dispatch(DestinationAction.SetDestination(null))
-                store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
+                store.dispatch(endNavigation())
                 true
             }
         }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/RoutePreviewButtonComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/RoutePreviewButtonComponent.kt
@@ -6,7 +6,7 @@ import com.mapbox.navigation.dropin.internal.extensions.onClick
 import com.mapbox.navigation.dropin.internal.extensions.tryUpdateStyle
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.extension.dispatch
-import com.mapbox.navigation.ui.app.internal.showRoutePreview
+import com.mapbox.navigation.ui.app.internal.fetchRouteAndShowRoutePreview
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import com.mapbox.navigation.ui.base.view.MapboxExtendableButton
 import kotlinx.coroutines.flow.StateFlow
@@ -26,7 +26,7 @@ internal class RoutePreviewButtonComponent(
         }
 
         button.onClick(coroutineScope) {
-            store.dispatch(showRoutePreview())
+            store.dispatch(fetchRouteAndShowRoutePreview())
         }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/StartNavigationButtonComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/StartNavigationButtonComponent.kt
@@ -6,7 +6,7 @@ import com.mapbox.navigation.dropin.internal.extensions.onClick
 import com.mapbox.navigation.dropin.internal.extensions.tryUpdateStyle
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.extension.dispatch
-import com.mapbox.navigation.ui.app.internal.startActiveNavigation
+import com.mapbox.navigation.ui.app.internal.fetchRouteAndStartActiveNavigation
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import com.mapbox.navigation.ui.base.view.MapboxExtendableButton
 import kotlinx.coroutines.flow.StateFlow
@@ -26,7 +26,7 @@ internal class StartNavigationButtonComponent(
         }
 
         button.onClick(coroutineScope) {
-            store.dispatch(startActiveNavigation())
+            store.dispatch(fetchRouteAndStartActiveNavigation())
         }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/FreeDriveLongPressMapComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/marker/FreeDriveLongPressMapComponent.kt
@@ -8,10 +8,8 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.dropin.util.HapticFeedback
 import com.mapbox.navigation.ui.app.internal.Store
-import com.mapbox.navigation.ui.app.internal.destination.Destination
-import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
+import com.mapbox.navigation.ui.app.internal.extension.dispatch
+import com.mapbox.navigation.ui.app.internal.showDestinationPreview
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 
 @ExperimentalPreviewMapboxNavigationAPI
@@ -38,8 +36,7 @@ internal class FreeDriveLongPressMapComponent(
 
     private val longClickListener = OnMapLongClickListener { point ->
         if (context.options.enableMapLongClickIntercept.value) {
-            store.dispatch(DestinationAction.SetDestination(Destination(point)))
-            store.dispatch(NavigationStateAction.Update(NavigationState.DestinationPreview))
+            store.dispatch(showDestinationPreview(point))
             hapticFeedback?.tick()
         }
         false

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -11,7 +11,7 @@ class CustomizedViewModel : ViewModel() {
     val useCustomInfoPanelStyles = MutableLiveData(false)
     val showCustomInfoPanelContent = MutableLiveData(false)
     val showBottomSheetInFreeDrive = MutableLiveData(false)
-    val enableOnMapLongClick = MutableLiveData(true)
+    val enableDestinationPreview = MutableLiveData(true)
     val isInfoPanelHideable = MutableLiveData(false)
     val infoPanelStateOverride = MutableLiveData("--")
     val fullScreen = MutableLiveData(false)

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -102,12 +102,12 @@
                 android:textAllCaps="true" />
 
             <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/toggleOnMapLongClick"
+                android:id="@+id/toggleEnableDestinationPreview"
                 android:layout_weight="1"
                 android:paddingVertical="10dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Enable Long Click"
+                android:text="Enable Destination Preview"
                 android:textAllCaps="true" />
 
             <TextView


### PR DESCRIPTION
Also added an example that shows how customers can remove DestinationPreview state from their apps. It involves overriding back click, map long click and usage of `NavigationViewApi`. 

https://user-images.githubusercontent.com/2395284/190181276-0194c103-3006-4249-afb9-bd6a13e20b36.mp4

