### PR TITLE
Add more jvmstatic and throws annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Optimized calls to modify route arrow layer visibility. [#6308](https://github.com/mapbox/mapbox-navigation-android/pull/6308)
 - Provide better java support for `MapboxNavigationApp`. [#6292](https://github.com/mapbox/mapbox-navigation-android/pull/6292)
 - Expose `PointAnnotationOptions` in Drop-In UI to allow users to define the destination marker icon and it's positioning. [#6314](https://github.com/mapbox/mapbox-navigation-android/pull/6314)
+- Marked `MapboxNavigationApp` methods with `@Throws` annotation. [#6324](https://github.com/mapbox/mapbox-navigation-android/pull/6324)
 
 ## Mapbox Navigation SDK 2.8.0-beta.3 - 09 September, 2022
 ### Changelog

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -312,13 +312,13 @@ package com.mapbox.navigation.core.lifecycle {
 
   public final class MapboxNavigationApp {
     method @UiThread public static com.mapbox.navigation.core.lifecycle.MapboxNavigationApp attach(androidx.lifecycle.LifecycleOwner lifecycleOwner);
-    method public com.mapbox.navigation.core.lifecycle.MapboxNavigationApp attachAllActivities(android.app.Application application);
+    method public static com.mapbox.navigation.core.lifecycle.MapboxNavigationApp attachAllActivities(android.app.Application application);
     method public static com.mapbox.navigation.core.MapboxNavigation? current();
     method @UiThread public static com.mapbox.navigation.core.lifecycle.MapboxNavigationApp detach(androidx.lifecycle.LifecycleOwner lifecycleOwner);
     method @UiThread public static com.mapbox.navigation.core.lifecycle.MapboxNavigationApp disable();
-    method public androidx.lifecycle.LifecycleOwner getLifecycleOwner();
-    method public static <T extends com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver> T getObserver(kotlin.reflect.KClass<T> kClass);
-    method public static <T extends com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver> T getObserver(Class<T> clazz);
+    method public static androidx.lifecycle.LifecycleOwner getLifecycleOwner();
+    method @kotlin.jvm.Throws(exceptionClasses=IllegalStateException::class) public static <T extends com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver> T getObserver(kotlin.reflect.KClass<T> kClass) throws java.lang.IllegalStateException;
+    method @kotlin.jvm.Throws(exceptionClasses=IllegalStateException::class) public static <T extends com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver> T getObserver(Class<T> clazz) throws java.lang.IllegalStateException;
     method public static <T extends com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver> java.util.List<T> getObservers(kotlin.reflect.KClass<T> kClass);
     method public static <T extends com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver> java.util.List<T> getObservers(Class<T> clazz);
     method @UiThread public static boolean isSetup();
@@ -326,7 +326,7 @@ package com.mapbox.navigation.core.lifecycle {
     method @UiThread public static com.mapbox.navigation.core.lifecycle.MapboxNavigationApp setup(com.mapbox.navigation.base.options.NavigationOptions navigationOptions);
     method @UiThread public static com.mapbox.navigation.core.lifecycle.MapboxNavigationApp setup(com.mapbox.navigation.core.lifecycle.NavigationOptionsProvider navigationOptionsProvider);
     method @UiThread public static com.mapbox.navigation.core.lifecycle.MapboxNavigationApp unregisterObserver(com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver mapboxNavigationObserver);
-    property public final androidx.lifecycle.LifecycleOwner lifecycleOwner;
+    property public static final androidx.lifecycle.LifecycleOwner lifecycleOwner;
     field public static final com.mapbox.navigation.core.lifecycle.MapboxNavigationApp INSTANCE;
   }
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationApp.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationApp.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
+import kotlin.jvm.Throws
 import kotlin.reflect.KClass
 
 /**
@@ -64,6 +65,7 @@ object MapboxNavigationApp {
      * app is in foreground. When both the car and app have been closed, the lifecycle
      * is stopped. The lifecycle is never destroyed.
      */
+    @JvmStatic
     val lifecycleOwner: LifecycleOwner by lazy { mapboxNavigationAppDelegate.lifecycleOwner }
 
     /**
@@ -104,6 +106,7 @@ object MapboxNavigationApp {
      * Detect when any Activity is in the foreground. Use [attach] and [detach] for
      * granular control of which lifecycle is used for creating [MapboxNavigation].
      */
+    @JvmStatic
     fun attachAllActivities(application: Application) = apply {
         mapboxNavigationAppDelegate.attachAllActivities(application)
     }
@@ -173,6 +176,7 @@ object MapboxNavigationApp {
      * @throws IllegalStateException when the class has not been registered.
      */
     @JvmStatic
+    @Throws(IllegalStateException::class)
     fun <T : MapboxNavigationObserver> getObserver(kClass: KClass<T>): T {
         return mapboxNavigationAppDelegate.getObserver(kClass)
     }
@@ -193,6 +197,7 @@ object MapboxNavigationApp {
      * @throws IllegalStateException when the class has not been registered.
      */
     @JvmStatic
+    @Throws(IllegalStateException::class)
     fun <T : MapboxNavigationObserver> getObserver(clazz: Class<T>): T {
         return mapboxNavigationAppDelegate.getObserver(clazz)
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.core.lifecycle
 import android.app.Application
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.navigation.core.MapboxNavigation
+import kotlin.jvm.Throws
 import kotlin.reflect.KClass
 
 /**
@@ -59,9 +60,11 @@ internal class MapboxNavigationAppDelegate {
 
     fun current(): MapboxNavigation? = mapboxNavigationOwner.current()
 
+    @Throws(IllegalStateException::class)
     fun <T : MapboxNavigationObserver> getObserver(clazz: Class<T>): T =
         mapboxNavigationOwner.getObserver(clazz)
 
+    @Throws(IllegalStateException::class)
     fun <T : MapboxNavigationObserver> getObserver(kClass: KClass<T>): T =
         mapboxNavigationOwner.getObserver(kClass)
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationOwner.kt
@@ -6,6 +6,7 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
 import com.mapbox.navigation.utils.internal.logI
 import java.util.concurrent.CopyOnWriteArraySet
+import kotlin.jvm.Throws
 import kotlin.reflect.KClass
 
 internal class MapboxNavigationOwner {
@@ -67,9 +68,11 @@ internal class MapboxNavigationOwner {
 
     fun current(): MapboxNavigation? = mapboxNavigation
 
+    @Throws(IllegalStateException::class)
     fun <T : MapboxNavigationObserver> getObserver(clazz: KClass<T>): T = getObserver(clazz.java)
 
     // Java
+    @Throws(IllegalStateException::class)
     fun <T : MapboxNavigationObserver> getObserver(clazz: Class<T>): T =
         getObservers(clazz).firstOrNull()
             ?: error("Class ${clazz.simpleName} is not been registered to MapboxNavigationApp")

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
@@ -397,6 +397,27 @@ class MapboxNavigationAppDelegateTest {
         mapboxNavigationApp.getObserver(ExampleObserverA::class)
     }
 
+    @Test(expected = java.lang.IllegalStateException::class)
+    fun `verify getObserver java will crash when the observer is not registered`() {
+        val observer = ExampleObserverA()
+        mapboxNavigationApp.registerObserver(observer)
+
+        // Should crash
+        mapboxNavigationApp.getObserver(ExampleObserverB::class.java)
+    }
+
+    @Test(expected = java.lang.IllegalStateException::class)
+    fun `verify getObserver java will crash when the observer is removed`() {
+        val observerFirst = ExampleObserverA()
+        val observerSecond = ExampleObserverB()
+        mapboxNavigationApp.registerObserver(observerFirst)
+        mapboxNavigationApp.registerObserver(observerSecond)
+        mapboxNavigationApp.unregisterObserver(observerFirst)
+
+        // Should crash
+        mapboxNavigationApp.getObserver(ExampleObserverA::class.java)
+    }
+
     @Test
     fun `verify getObservers will return the registered observer`() {
         val observer = ExampleObserverA()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/testing/CarJavaInterfaceChecker.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/testing/CarJavaInterfaceChecker.java
@@ -1,5 +1,7 @@
 package com.mapbox.navigation.qa_test_app.testing;
 
+import android.app.Application;
+
 import androidx.annotation.NonNull;
 import androidx.car.app.CarContext;
 import androidx.lifecycle.LifecycleOwner;
@@ -19,6 +21,7 @@ import kotlinx.coroutines.CoroutineScope;
 class CarJavaInterfaceChecker {
 
   void MapboxNavigationApp(
+          Application application,
           LifecycleOwner lifecycleOwner,
           NavigationOptions navigationOptions,
           MapboxNavigationObserver observer
@@ -33,6 +36,8 @@ class CarJavaInterfaceChecker {
     MapboxNavigationApp.attach(lifecycleOwner);
     MapboxNavigationApp.disable();
     MapboxNavigationApp.detach(lifecycleOwner);
+    MapboxNavigationApp.attachAllActivities(application);
+    MapboxNavigationApp.getLifecycleOwner();
 
     // Get current instance
     MapboxNavigation mapboxNavigation = MapboxNavigationApp.current();


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

There were a couple functions missed https://github.com/mapbox/mapbox-navigation-android/pull/6292

`attachAllActivities` also needs the `@JvmStatic` annotation. This adds the @dzinad suggestion for the throws annotation https://github.com/mapbox/mapbox-navigation-android/pull/6292#discussion_r968566097
