### PR TITLE
[Android Auto] Remove MapboxNavigation from CarSpeedLimitRenderer

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Remove experimental from `MapboxCarNavigationManager` and showcase java. [#6292](https://github.com/mapbox/mapbox-navigation-android/pull/6292)
 - Removed `MapboxNavigation` from `CarNavigationInfoObserver` constructor, and rename to `CarNavigationInfoProvider`. Removed dependencies from `CarActiveGuidanceCarContext` that require `MapboxNavigation`. [#6224](https://github.com/mapbox/mapbox-navigation-android/pull/6224)
+- Removed `MapboxNavigation` from `CarSpeedLimitRenderer` constructor. [#6325](https://github.com/mapbox/mapbox-navigation-android/pull/6325)
 
 ## androidauto-v0.10.0 - Sep 9, 2022
 ### Changelog

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitServices.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitServices.kt
@@ -1,0 +1,11 @@
+package com.mapbox.androidauto.car.navigation.speedlimit
+
+import com.mapbox.navigation.base.speed.model.SpeedLimitSign
+
+/**
+ * This class helps with unit testing.
+ */
+internal class CarSpeedLimitServices {
+    fun speedLimitWidget(signFormat: SpeedLimitSign): SpeedLimitWidget =
+        SpeedLimitWidget(signFormat)
+}

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitRendererTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitRendererTest.kt
@@ -1,0 +1,56 @@
+package com.mapbox.androidauto.car.navigation.speedlimit
+
+import com.mapbox.androidauto.car.MainCarContext
+import com.mapbox.androidauto.testing.CarAppTestRule
+import com.mapbox.maps.MapboxExperimental
+import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface
+import com.mapbox.navigation.core.MapboxNavigation
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(MapboxExperimental::class)
+class CarSpeedLimitRendererTest {
+
+    @get:Rule
+    val carAppTestRule = CarAppTestRule()
+
+    private val speedLimitWidget: SpeedLimitWidget = mockk()
+    private val services: CarSpeedLimitServices = mockk {
+        every { speedLimitWidget(any()) } returns speedLimitWidget
+    }
+    private val options = MutableStateFlow(SpeedLimitOptions.Builder().build())
+    private val ctx: MainCarContext = mockk {
+        every { speedLimitOptions } returns options
+    }
+    private val sut = CarSpeedLimitRenderer(services, ctx)
+
+    @Test
+    fun `verify speed limit widget is created`() {
+        val mapboxNavigation: MapboxNavigation = mockk(relaxed = true)
+        val mapboxCarMapSurface: MapboxCarMapSurface = mockk(relaxed = true)
+
+        carAppTestRule.onAttached(mapboxNavigation)
+        sut.onAttached(mapboxCarMapSurface)
+
+        assertNotNull(sut.speedLimitWidget)
+        verify { services.speedLimitWidget(any()) }
+    }
+
+    @Test
+    fun `verify speed limit widget is null map is detached`() {
+        val mapboxNavigation: MapboxNavigation = mockk(relaxed = true)
+        val mapboxCarMapSurface: MapboxCarMapSurface = mockk(relaxed = true)
+
+        carAppTestRule.onAttached(mapboxNavigation)
+        sut.onAttached(mapboxCarMapSurface)
+        sut.onDetached(mapboxCarMapSurface)
+
+        assertNull(sut.speedLimitWidget)
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Addressing https://github.com/mapbox/mapbox-navigation-android/issues/6141

Removing the direct reference to `MapboxNavigation` in the `CarSpeedLimitRenderer`. 

I also did a little refactoring to set up this class for unit tests. I've only added a couple unit tests for now. 

