### PR TITLE
fix maneuver view layout in landscape with drop-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Expose `PointAnnotationOptions` in Drop-In UI to allow users to define the destination marker icon and it's positioning. [#6314](https://github.com/mapbox/mapbox-navigation-android/pull/6314)
 - Marked `MapboxNavigationApp` methods with `@Throws` annotation. [#6324](https://github.com/mapbox/mapbox-navigation-android/pull/6324)
 - Exposed `AlternativeRouteMetadata#alternativeId` which lets user distinguish a new alternative from updated alternatives. [#6329](https://github.com/mapbox/mapbox-navigation-android/pull/6329)
+- Fixed an issue with `NavigationView` that caused maneuver view to be cut off. [#6328](https://github.com/mapbox/mapbox-navigation-android/pull/6328)
 
 ## Mapbox Navigation SDK 2.8.0-beta.3 - 09 September, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
@@ -56,7 +56,6 @@
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     tools:layout_height="120dp"
-                    app:layout_constraintWidth_max="375dp"
                     tools:background="@color/mapbox_main_maneuver_background_color" />
 
                 <FrameLayout


### PR DESCRIPTION
### Description
The issue can be reproduced by bumping `constraint_layout` dependency to the latest version. Max width of `guidanceLayout` has to be 383dp, because `mapbox_maneuver_layout` has width 375dp in landscape and it is surrounded by 4dp paddings. At the same time we don't need to specify max width at all, because `MapboxManeuverView`'s width is already limited. 

### Screenshots or Gifs
Before:
![before](https://user-images.githubusercontent.com/2395284/190132096-75ba6a41-ee62-43e0-a77f-43d353f13738.png)
After:
![after](https://user-images.githubusercontent.com/2395284/190132120-7a7e5a42-c73a-4eb0-b4f4-f29b7bc0c11b.png)
