### PR TITLE
Exposed alternatives id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Provide better java support for `MapboxNavigationApp`. [#6292](https://github.com/mapbox/mapbox-navigation-android/pull/6292)
 - Expose `PointAnnotationOptions` in Drop-In UI to allow users to define the destination marker icon and it's positioning. [#6314](https://github.com/mapbox/mapbox-navigation-android/pull/6314)
 - Marked `MapboxNavigationApp` methods with `@Throws` annotation. [#6324](https://github.com/mapbox/mapbox-navigation-android/pull/6324)
+- Exposed `AlternativeRouteMetadata#alternativeId` which lets user distinguish a new alternative from updated alternatives. [#6329](https://github.com/mapbox/mapbox-navigation-android/pull/6329)
 
 ## Mapbox Navigation SDK 2.8.0-beta.3 - 09 September, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/AlternativeRouteMetadata.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/AlternativeRouteMetadata.kt
@@ -15,6 +15,7 @@ import com.mapbox.navigation.core.directions.session.RoutesObserver
  * from the perspective of the primary route
  * @param infoFromFork information about the alternative route from the fork with the primary route, until the destination
  * @param infoFromStartOfPrimary summed up information about the alternative route by joining
+ * @param alternativeId is an id of alternative route. New alternative routes which matches tracking alternatives have the same alternativeId.
  * the primary route's data until the deviation point with the alternative route's data from the deviation point
  */
 class AlternativeRouteMetadata internal constructor(
@@ -23,6 +24,7 @@ class AlternativeRouteMetadata internal constructor(
     val forkIntersectionOfPrimaryRoute: AlternativeRouteIntersection,
     val infoFromFork: AlternativeRouteInfo,
     val infoFromStartOfPrimary: AlternativeRouteInfo,
+    val alternativeId: Int,
 ) {
     /**
      * Indicates whether some other object is "equal to" this one.
@@ -39,6 +41,7 @@ class AlternativeRouteMetadata internal constructor(
         if (forkIntersectionOfPrimaryRoute != other.forkIntersectionOfPrimaryRoute) return false
         if (infoFromFork != other.infoFromFork) return false
         if (infoFromStartOfPrimary != other.infoFromStartOfPrimary) return false
+        if (alternativeId != other.alternativeId) return false
 
         return true
     }
@@ -52,6 +55,7 @@ class AlternativeRouteMetadata internal constructor(
         result = 31 * result + forkIntersectionOfPrimaryRoute.hashCode()
         result = 31 * result + infoFromFork.hashCode()
         result = 31 * result + infoFromStartOfPrimary.hashCode()
+        result = 31 * result + alternativeId.hashCode()
         return result
     }
 
@@ -64,7 +68,8 @@ class AlternativeRouteMetadata internal constructor(
             "forkIntersectionOfAlternativeRoute=$forkIntersectionOfAlternativeRoute, " +
             "forkIntersectionOfPrimaryRoute=$forkIntersectionOfPrimaryRoute, " +
             "infoFromFork=$infoFromFork, " +
-            "infoFromStartOfPrimary=$infoFromStartOfPrimary" +
+            "infoFromStartOfPrimary=$infoFromStartOfPrimary, " +
+            "alternativeId=$alternativeId" +
             ")"
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -279,6 +279,7 @@ private fun RouteAlternative.mapToMetadata(
         forkIntersectionOfPrimaryRoute = mainRouteFork.mapToPlatform(),
         infoFromFork = infoFromFork.mapToPlatform(),
         infoFromStartOfPrimary = infoFromStart.mapToPlatform(),
+        alternativeId = id
     )
 }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
@@ -599,7 +599,7 @@ class RouteAlternativesControllerTest {
             routeAlternativesController.register(firstObserver)
             nativeObserver.captured.onRouteAlternativesChanged(
                 listOf(
-                    createNativeAlternativeMock()
+                    createNativeAlternativeMock(alternativeId = 4)
                 ),
                 emptyList()
             )
@@ -617,6 +617,7 @@ class RouteAlternativesControllerTest {
             assertEquals(platformForkMain, metadata.forkIntersectionOfPrimaryRoute)
             assertEquals(platformInfoStart, metadata.infoFromStartOfPrimary)
             assertEquals(platformInfoFork, metadata.infoFromFork)
+            assertEquals(4, metadata.alternativeId)
 
             unmockkStatic(RouteOptions::fromUrl)
         }
@@ -792,7 +793,9 @@ class RouteAlternativesControllerTest {
         legIndex = 6, // legIndex
     )
 
-    private fun createNativeAlternativeMock(): RouteAlternative {
+    private fun createNativeAlternativeMock(
+        alternativeId: Int = 0,
+    ): RouteAlternative {
         return mockk {
             every { route.routeId } returns UUID.randomUUID().toString()
             every { route.responseJson } returns FileUtils.loadJsonFixture(
@@ -809,6 +812,7 @@ class RouteAlternativesControllerTest {
             every { mainRouteFork } returns nativeForkMain
             every { infoFromFork } returns nativeInfoFork
             every { infoFromStart } returns nativeInfoStart
+            every { id } returns alternativeId
         }
     }
 }


### PR DESCRIPTION
### Description

When user follows primary route, the Navigation SDK updates alternatives. Some updated alternatives suggest following new routes, while the other are just shorter versions of previously tracked alternatives.

`alternativeId` can help distinguish new and updated old alternatives. If NN creates a new alternative which matches existing one, the new alternative will have the same `alternativeId` as the old one, despite the fact that they have different `NavigationRoutes#id`