### PR TITLE
[Drop-In UI] remove arrow layers when arrow component is detached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Marked `PredictiveCacheController`, `MapboxBuildingView`, `ViewportDataSourceUpdateObserver`, `NavigationScaleGestureHandler`, `NavigationCameraStateChangedObserver`, `NavigationCameraStateTransition`, `NavigationCameraTransition`, `TransitionEndListener`, `MapboxRecenterButton`, `MapboxRouteOverviewButton`, `MapboxJunctionView`, `MapboxSignboardView`, `MapboxRoadNameLabelView`, `MapboxRoadNameView`, `MapboxRouteArrowView`, `MapboxRouteLineView`, `MapboxCameraModeButton` methods and `View.capture` extension with `@UiThread` annotation. [#6235](https://github.com/mapbox/mapbox-navigation-android/pull/6235)
 - Marked `Binder`, `MapboxExtendableButton` methods and `MapboxNavigation#installComponents` methods with `@UiThread` annotation. [#6268](https://github.com/mapbox/mapbox-navigation-android/pull/6268)
+- Fixed an issue with `NavigationView` that caused `ViewOptionsCustomization.routeArrowOptions` to be ignored, if arrows have already been drawn on the map. [#6333](https://github.com/mapbox/mapbox-navigation-android/pull/6333)
 
 ## Mapbox Navigation SDK 2.9.0-alpha.2 - 16 September, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponent.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponent.kt
@@ -6,6 +6,7 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.internal.extensions.flowRouteProgress
 import com.mapbox.navigation.core.internal.extensions.flowRoutesUpdated
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import com.mapbox.navigation.ui.maps.route.arrow.RouteArrowUtils
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
@@ -45,6 +46,7 @@ class RouteArrowComponent(
         super.onDetached(mapboxNavigation)
         mapboxMap.getStyle()?.also { style ->
             routeArrowView.render(style, routeArrowApi.clearArrows())
+            RouteArrowUtils.removeLayers(style)
         }
     }
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
@@ -4,7 +4,6 @@ import androidx.core.graphics.drawable.DrawableCompat
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.maps.LayerPosition
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.Style
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.mapbox.maps.extension.style.layers.addPersistentLayer
@@ -55,7 +54,6 @@ internal object RouteArrowUtils {
         return arrowCurrentSliced.coordinates().reversed().plus(arrowUpcomingSliced.coordinates())
     }
 
-    @OptIn(MapboxExperimental::class)
     fun initializeLayers(style: Style, options: RouteArrowOptions) {
         if (layersAreInitialized(style)) {
             return
@@ -261,5 +259,16 @@ internal object RouteArrowUtils {
             style.styleLayerExists(RouteLayerConstants.ARROW_HEAD_CASING_LAYER_ID) &&
             style.styleLayerExists(RouteLayerConstants.ARROW_SHAFT_LINE_LAYER_ID) &&
             style.styleLayerExists(RouteLayerConstants.ARROW_HEAD_LAYER_ID)
+    }
+
+    internal fun removeLayers(style: Style) {
+        style.removeStyleImage(RouteLayerConstants.ARROW_HEAD_ICON_CASING)
+        style.removeStyleImage(RouteLayerConstants.ARROW_HEAD_ICON)
+        style.removeStyleLayer(RouteLayerConstants.ARROW_SHAFT_CASING_LINE_LAYER_ID)
+        style.removeStyleLayer(RouteLayerConstants.ARROW_HEAD_CASING_LAYER_ID)
+        style.removeStyleLayer(RouteLayerConstants.ARROW_SHAFT_LINE_LAYER_ID)
+        style.removeStyleLayer(RouteLayerConstants.ARROW_HEAD_LAYER_ID)
+        style.removeStyleSource(RouteLayerConstants.ARROW_SHAFT_SOURCE_ID)
+        style.removeStyleSource(RouteLayerConstants.ARROW_HEAD_SOURCE_ID)
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponentTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponentTest.kt
@@ -10,6 +10,7 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.maps.route.arrow.RouteArrowUtils
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
 import com.mapbox.navigation.ui.maps.route.arrow.model.ClearArrowsValue
@@ -20,8 +21,10 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -34,7 +37,7 @@ import org.junit.Test
 class RouteArrowComponentTest {
 
     @get:Rule
-    var coroutineRule = MainCoroutineRule()
+    val coroutineRule = MainCoroutineRule()
 
     private val context = mockk<Context>()
     private val routeArrowOptions by lazy { RouteArrowOptions.Builder(context).build() }
@@ -42,14 +45,17 @@ class RouteArrowComponentTest {
     @Before
     fun setUp() {
         mockkStatic(AppCompatResources::class)
+        mockkObject(RouteArrowUtils)
         every { AppCompatResources.getDrawable(any(), any()) } returns mockk(relaxed = true) {
             every { intrinsicHeight } returns 24
             every { intrinsicWidth } returns 24
         }
+        every { RouteArrowUtils.removeLayers(any()) } just Runs
     }
 
     @After
     fun tearDown() {
+        unmockkObject(RouteArrowUtils)
         unmockkStatic(AppCompatResources::class)
     }
 
@@ -131,6 +137,7 @@ class RouteArrowComponentTest {
         sut.onDetached(mockMapboxNavigation)
 
         verify { mockView.render(mockStyle, clearValue) }
+        verify { RouteArrowUtils.removeLayers(mockStyle) }
     }
 
     private fun mockMapWithStyleLoaded(style: Style): MapboxMap = mockk {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
@@ -7,7 +7,6 @@ import androidx.appcompat.content.res.AppCompatResources
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.geojson.Point
 import com.mapbox.maps.Image
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.Style
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
@@ -26,13 +25,13 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import io.mockk.verifySequence
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-@OptIn(MapboxExperimental::class)
 class RouteArrowUtilsTest {
 
     private val ctx: Context = mockk()
@@ -389,5 +388,32 @@ class RouteArrowUtilsTest {
 
         verify(exactly = 0) { style.addImage(ARROW_HEAD_ICON_CASING, any<Bitmap>()) }
         verify(exactly = 0) { style.addImage(ARROW_HEAD_ICON_CASING, any<Image>()) }
+    }
+
+    @Test
+    fun `styles sources are removed after style layers and images`() {
+        val style = mockk<Style> {
+            every { removeStyleSource(ARROW_SHAFT_SOURCE_ID) } returns mockk()
+            every { removeStyleSource(ARROW_HEAD_SOURCE_ID) } returns mockk()
+            every { removeStyleLayer(ARROW_SHAFT_CASING_LINE_LAYER_ID) } returns mockk()
+            every { removeStyleLayer(ARROW_HEAD_CASING_LAYER_ID) } returns mockk()
+            every { removeStyleLayer(ARROW_SHAFT_LINE_LAYER_ID) } returns mockk()
+            every { removeStyleLayer(ARROW_HEAD_LAYER_ID) } returns mockk()
+            every { removeStyleImage(ARROW_HEAD_ICON_CASING) } returns mockk()
+            every { removeStyleImage(ARROW_HEAD_ICON) } returns mockk()
+        }
+
+        RouteArrowUtils.removeLayers(style)
+
+        verifySequence {
+            style.removeStyleImage(ARROW_HEAD_ICON_CASING)
+            style.removeStyleImage(ARROW_HEAD_ICON)
+            style.removeStyleLayer(ARROW_SHAFT_CASING_LINE_LAYER_ID)
+            style.removeStyleLayer(ARROW_HEAD_CASING_LAYER_ID)
+            style.removeStyleLayer(ARROW_SHAFT_LINE_LAYER_ID)
+            style.removeStyleLayer(ARROW_HEAD_LAYER_ID)
+            style.removeStyleSource(ARROW_SHAFT_SOURCE_ID)
+            style.removeStyleSource(ARROW_HEAD_SOURCE_ID)
+        }
     }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -53,6 +53,7 @@ import com.mapbox.navigation.dropin.ActionButtonDescription.Position.START
 import com.mapbox.navigation.dropin.MapViewObserver
 import com.mapbox.navigation.dropin.MapboxExtendableButtonParams
 import com.mapbox.navigation.dropin.NavigationViewListener
+import com.mapbox.navigation.dropin.ViewOptionsCustomization.Companion.defaultRouteArrowOptions
 import com.mapbox.navigation.dropin.ViewOptionsCustomization.Companion.defaultRouteLineOptions
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultAudioGuidanceButtonParams
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultCameraModeButtonParams
@@ -229,9 +230,6 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
 
         binding.navigationView.addListener(freeDriveInfoPanelInstaller)
         binding.navigationView.addListener(navViewListener)
-        binding.navigationView.customizeViewOptions {
-            routeArrowOptions = customRouteArrowOptions()
-        }
 
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.getDefaultNightMode())
 
@@ -497,6 +495,7 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             }
             binding.navigationView.customizeViewOptions {
                 routeLineOptions = customRouteLineOptions()
+                routeArrowOptions = customRouteArrowOptions()
                 mapStyleUriDay = Style.LIGHT
                 mapStyleUriNight = Style.DARK
             }
@@ -508,6 +507,7 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             }
             binding.navigationView.customizeViewOptions {
                 routeLineOptions = defaultRouteLineOptions(applicationContext)
+                routeArrowOptions = defaultRouteArrowOptions(applicationContext)
                 mapStyleUriDay = NavigationStyles.NAVIGATION_DAY_STYLE
                 mapStyleUriNight = NavigationStyles.NAVIGATION_NIGHT_STYLE
             }


### PR DESCRIPTION
### Description
Fixes #6065. 
Fixes NAVAND-319.

We could also add a function to `MapboxRouteArrowView` that removes the layers, what do you think?

### Screenshots or Gifs

https://user-images.githubusercontent.com/2395284/190407071-432ce5d3-64aa-4c28-b95a-1cafba01cf72.mp4

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
