### PR TITLE
always search for relevant notification

### DIFF
--- a/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/trip/service/TripServiceTest.kt
+++ b/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/trip/service/TripServiceTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.core.trip.service
 
-import android.os.Build
 import androidx.test.espresso.Espresso.onIdle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.uiautomator.By
@@ -41,11 +40,7 @@ internal class TripServiceTest :
                 By.res("com.mapbox.navigation.core.test:id/freeDriveText")
 
             openNotification()
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
-                // Android 12 always places foreground notification on top,
-                // no need to scroll and look for it
-                searchForMyForegroundNotification(freeDriveText)
-            }
+            searchForMyForegroundNotification(freeDriveText)
 
             assertFalse(hasObject(etaContent))
             assertTrue(hasObject(freeDriveText))


### PR DESCRIPTION
The comment said that Android 12+ always places the foreground notification on top.
As it turned out, it's not exactly true.
1) I was able to reproduce it locally on API 31: if we have an ActiveGuidance notification from exmaples/qa-test-app/whatever and then run a test, there is a probability (it does not happen every time), that the notification from test will be placed underneath it. Then, especially in landscape mode, there's a chance of it now being visible.
2)  See screenshots from instrumentation tests. The first one is from a successful run, the rest - from a failed run. The second one shows that there was no Nav SDK notification in the beginning, the third one - that it appeared, the fourth one - that it's not on top.
![photo_2022-09-15 20 57 34](https://user-images.githubusercontent.com/32109537/190476423-825363f8-860e-4973-ba95-29406c9a436d.jpeg)
![photo_2022-09-15 20 57 57](https://user-images.githubusercontent.com/32109537/190476491-ef0be2c2-d57d-4b88-8c67-c0268426fb51.jpeg)
![photo_2022-09-15 20 58 00](https://user-images.githubusercontent.com/32109537/190476517-984cfd63-d44c-4b29-97eb-d2c5015a7a6d.jpeg)
![photo_2022-09-15 20 58 03](https://user-images.githubusercontent.com/32109537/190476527-33106b4c-dee6-4fb5-9350-0057404eb1ca.jpeg)
