### PR TITLE
Add jvm-default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,12 @@ allprojects {
     }
     gradlePluginPortal()
   }
+
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+      freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all"
+    }
+  }
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ allprojects {
 
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
-      freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all"
+      freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=compatibility"
     }
   }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-default/

Running some tests on this. When introducing new interfaces where the implementation is empty there are compatibility issues in public apis. 

But adding this flag allows you to define these apis and then downstream solutions need to include the compiler flag if they want the backwards compatibility in java. Here is an example https://github.com/mapbox/mapbox-maps-android/pull/1670  

There are no changes to our current api, because we have been blocked from adding interfaces with default implementations for this reason. We have been using abstract or open classes.