### PR TITLE
Add changelog for androidauto-0.11.0

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -5,11 +5,24 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+
+## androidauto-v0.11.0 - Sep 16, 2022
+### Changelog
+[Changes between 0.10.0 and 0.11.0](https://github.com/mapbox/mapbox-navigation-android/compare/androidauto-v0.10.0...androidauto-v0.11.0)
+
+#### Features
+- Added `CarArrivalTrigger` and `CarActiveGuidanceMarkers` for logical components that help build the `ActiveGuidanceScreen`. [#6326](https://github.com/mapbox/mapbox-navigation-android/pull/6326)
+#### Bug fixes and improvements
 - Remove experimental from `MapboxCarNavigationManager` and showcase java. [#6292](https://github.com/mapbox/mapbox-navigation-android/pull/6292)
 - Removed `MapboxNavigation` from `CarNavigationInfoObserver` constructor, and rename to `CarNavigationInfoProvider`. Removed dependencies from `CarActiveGuidanceCarContext` that require `MapboxNavigation`. [#6224](https://github.com/mapbox/mapbox-navigation-android/pull/6224)
 - Removed `MapboxNavigation` from `CarSpeedLimitRenderer` constructor. [#6325](https://github.com/mapbox/mapbox-navigation-android/pull/6325)
 - Deleted `CarActiveGuidanceCarContext` because it is no longer needed after `MapboxNavigation` is removed. [#6326](https://github.com/mapbox/mapbox-navigation-android/pull/6326)
-- Added `CarArrivalTrigger` and `CarActiveGuidanceMarkers` for logical components that help build the `ActiveGuidanceScreen`. [#6326](https://github.com/mapbox/mapbox-navigation-android/pull/6326)
+
+### Mapbox dependencies
+This release defines minimum versions for the Mapbox dependencies.
+- Mapbox Maps Android Auto Extension `v0.2.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/extension-androidauto-v0.2.0))
+- Mapbox Navigation `v2.8.0-beta.3` ([release notes](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.8.0-beta.3))
+- Mapbox Search `v1.0.0-beta.35` ([release notes](https://github.com/mapbox/mapbox-search-android/releases/tag/v1.0.0-beta.35))
 
 ## androidauto-v0.10.0 - Sep 9, 2022
 ### Changelog


### PR DESCRIPTION
This is the final release to depend on nav-sdk 2.8 release train. Starting to work on 2.9

## androidauto-v0.11.0 - Sep 16, 2022
### Changelog
[Changes between 0.10.0 and 0.11.0](https://github.com/mapbox/mapbox-navigation-android/compare/androidauto-v0.10.0...androidauto-v0.11.0)

#### Features
- Added `CarArrivalTrigger` and `CarActiveGuidanceMarkers` for logical components that help build the `ActiveGuidanceScreen`. [#6326](https://github.com/mapbox/mapbox-navigation-android/pull/6326)
#### Bug fixes and improvements
- Remove experimental from `MapboxCarNavigationManager` and showcase java. [#6292](https://github.com/mapbox/mapbox-navigation-android/pull/6292)
- Removed `MapboxNavigation` from `CarNavigationInfoObserver` constructor, and rename to `CarNavigationInfoProvider`. Removed dependencies from `CarActiveGuidanceCarContext` that require `MapboxNavigation`. [#6224](https://github.com/mapbox/mapbox-navigation-android/pull/6224)
- Removed `MapboxNavigation` from `CarSpeedLimitRenderer` constructor. [#6325](https://github.com/mapbox/mapbox-navigation-android/pull/6325)
- Deleted `CarActiveGuidanceCarContext` because it is no longer needed after `MapboxNavigation` is removed. [#6326](https://github.com/mapbox/mapbox-navigation-android/pull/6326)

### Mapbox dependencies
This release defines minimum versions for the Mapbox dependencies.
- Mapbox Maps Android Auto Extension `v0.2.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/extension-androidauto-v0.2.0))
- Mapbox Navigation `v2.8.0-beta.3` ([release notes](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.8.0-beta.3))
- Mapbox Search `v1.0.0-beta.35` ([release notes](https://github.com/mapbox/mapbox-search-android/releases/tag/v1.0.0-beta.35))
