### PR TITLE
Bump AA dependencies

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4525,6 +4525,12 @@ License: [BSD](https://opensource.org/licenses/BSD-2-Clause)
 
 ===========================================================================
 
+Mapbox Navigation uses portions of the Mapbox Base SDK for Android.
+URL: [https://github.com/mapbox/mapbox-search-android](https://github.com/mapbox/mapbox-search-android)
+License: [Mapbox Terms of Service](https://www.mapbox.com/legal/tos)
+
+===========================================================================
+
 Mapbox Navigation uses portions of the Mapbox Common (Artifact that provides Mapbox module and plugin contracts).
 URL: [https://github.com/mapbox/mapbox-base-android](https://github.com/mapbox/mapbox-base-android)
 License: [BSD](https://opensource.org/licenses/BSD-2-Clause)

--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -21,8 +21,8 @@ Mapbox welcomes participation and contributions from everyone.
 ### Mapbox dependencies
 This release defines minimum versions for the Mapbox dependencies.
 - Mapbox Maps Android Auto Extension `v0.2.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/extension-androidauto-v0.2.0))
-- Mapbox Navigation `v2.8.0-beta.3` ([release notes](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.8.0-beta.3))
-- Mapbox Search `v1.0.0-beta.35` ([release notes](https://github.com/mapbox/mapbox-search-android/releases/tag/v1.0.0-beta.35))
+- Mapbox Navigation `v2.8.0-rc.1` ([release notes](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.8.0-beta.3))
+- Mapbox Search `v1.0.0-beta.36` ([release notes](https://github.com/mapbox/mapbox-search-android/releases/tag/v1.0.0-beta.35))
 
 ## androidauto-v0.10.0 - Sep 9, 2022
 ### Changelog

--- a/libnavui-androidauto/api/current.txt
+++ b/libnavui-androidauto/api/current.txt
@@ -146,12 +146,12 @@ package com.mapbox.androidauto.car.feedback.core {
   }
 
   public final class CarFeedbackSearchOptions {
-    ctor public CarFeedbackSearchOptions(java.util.List<com.mapbox.search.record.FavoriteRecord>? favoriteRecords = null, java.util.List<? extends com.mapbox.search.result.SearchSuggestion>? searchSuggestions = null, com.mapbox.navigation.core.geodeeplink.GeoDeeplink? geoDeeplink = null, com.mapbox.api.geocoding.v5.models.GeocodingResponse? geocodingResponse = null);
+    ctor public CarFeedbackSearchOptions(java.util.List<com.mapbox.search.record.FavoriteRecord>? favoriteRecords = null, java.util.List<com.mapbox.search.result.SearchSuggestion>? searchSuggestions = null, com.mapbox.navigation.core.geodeeplink.GeoDeeplink? geoDeeplink = null, com.mapbox.api.geocoding.v5.models.GeocodingResponse? geocodingResponse = null);
     method public java.util.List<com.mapbox.search.record.FavoriteRecord>? component1();
     method public java.util.List<com.mapbox.search.result.SearchSuggestion>? component2();
     method public com.mapbox.navigation.core.geodeeplink.GeoDeeplink? component3();
     method public com.mapbox.api.geocoding.v5.models.GeocodingResponse? component4();
-    method public com.mapbox.androidauto.car.feedback.core.CarFeedbackSearchOptions copy(java.util.List<com.mapbox.search.record.FavoriteRecord>? favoriteRecords, java.util.List<? extends com.mapbox.search.result.SearchSuggestion>? searchSuggestions, com.mapbox.navigation.core.geodeeplink.GeoDeeplink? geoDeeplink, com.mapbox.api.geocoding.v5.models.GeocodingResponse? geocodingResponse);
+    method public com.mapbox.androidauto.car.feedback.core.CarFeedbackSearchOptions copy(java.util.List<com.mapbox.search.record.FavoriteRecord>? favoriteRecords, java.util.List<com.mapbox.search.result.SearchSuggestion>? searchSuggestions, com.mapbox.navigation.core.geodeeplink.GeoDeeplink? geoDeeplink, com.mapbox.api.geocoding.v5.models.GeocodingResponse? geocodingResponse);
     method public java.util.List<com.mapbox.search.record.FavoriteRecord>? getFavoriteRecords();
     method public com.mapbox.navigation.core.geodeeplink.GeoDeeplink? getGeoDeeplink();
     method public com.mapbox.api.geocoding.v5.models.GeocodingResponse? getGeocodingResponse();
@@ -202,7 +202,7 @@ package com.mapbox.androidauto.car.feedback.ui {
   }
 
   @Keep public final class CarFeedbackItem {
-    ctor public CarFeedbackItem(String carFeedbackTitle, String? navigationFeedbackType = null, java.util.List<java.lang.String>? navigationFeedbackSubType = null, @com.mapbox.search.analytics.FeedbackEvent.FeedbackReason String? searchFeedbackReason = null, String? favoritesFeedbackReason = null, com.mapbox.navigation.core.geodeeplink.GeoDeeplink? geoDeeplink = null, com.mapbox.api.geocoding.v5.models.GeocodingResponse? geocodingResponse = null, java.util.List<com.mapbox.search.record.FavoriteRecord>? favoriteRecords = null, java.util.List<? extends com.mapbox.search.result.SearchSuggestion>? searchSuggestions = null);
+    ctor public CarFeedbackItem(String carFeedbackTitle, String? navigationFeedbackType = null, java.util.List<java.lang.String>? navigationFeedbackSubType = null, @com.mapbox.search.analytics.FeedbackEvent.FeedbackReason String? searchFeedbackReason = null, String? favoritesFeedbackReason = null, com.mapbox.navigation.core.geodeeplink.GeoDeeplink? geoDeeplink = null, com.mapbox.api.geocoding.v5.models.GeocodingResponse? geocodingResponse = null, java.util.List<com.mapbox.search.record.FavoriteRecord>? favoriteRecords = null, java.util.List<com.mapbox.search.result.SearchSuggestion>? searchSuggestions = null);
     method public String getCarFeedbackTitle();
     method public java.util.List<com.mapbox.search.record.FavoriteRecord>? getFavoriteRecords();
     method public String? getFavoritesFeedbackReason();

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -41,8 +41,8 @@ dependencies {
     // This defines the minimum version of Maps, Navigation, and Search which are included in
     // this SDK. To upgrade the SDK versions, you can specify a newer version in your downstream
     // build.gradle.
-    def carNavVersion = "2.8.0-beta.3"
-    def carSearchVersion = "1.0.0-beta.35"
+    def carNavVersion = "2.8.0-rc.1"
+    def carSearchVersion = "1.0.0-beta.36"
     api("com.mapbox.search:mapbox-search-android:${carSearchVersion}")
 
     debugApi project(":libnavigation-android")

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/FavoritesApi.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/search/FavoritesApi.kt
@@ -5,8 +5,8 @@ import com.mapbox.androidauto.car.feedback.core.CarFeedbackSearchOptionsProvider
 import com.mapbox.androidauto.car.placeslistonmap.PlacesListOnMapProvider
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
-import com.mapbox.search.AsyncOperationTask
 import com.mapbox.search.CompletionCallback
+import com.mapbox.search.common.AsyncOperationTask
 import com.mapbox.search.record.FavoriteRecord
 import com.mapbox.search.record.FavoritesDataProvider
 import kotlin.coroutines.resume

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/search/FavoritesApiTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/car/search/FavoritesApiTest.kt
@@ -2,8 +2,8 @@ package com.mapbox.androidauto.car.search
 
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.testing.MainCoroutineRule
-import com.mapbox.search.AsyncOperationTask
 import com.mapbox.search.CompletionCallback
+import com.mapbox.search.common.AsyncOperationTask
 import com.mapbox.search.record.FavoriteRecord
 import com.mapbox.search.record.FavoritesDataProvider
 import com.mapbox.search.result.SearchResultType


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Published a little early here https://github.com/mapbox/mapbox-navigation-android/releases/tag/androidauto-v0.11.0. It may not be necessary, but want to publish to the latest stable versions.

This is because I do not intend on making any more changes to a 2.8 build. There are some incompatibilities we're working through that will require us to bump to 2.9
