### PR TITLE
[Drop-In UI] added the ability to hide/show scalebar and compass 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Improved stop detector for auto profile. [#6373](https://github.com/mapbox/mapbox-navigation-android/pull/6373)
 - Fixed `RoadNameLabel` position issues by making sure that it updates when expanding and collapsing the info panel. [#6361](https://github.com/mapbox/mapbox-navigation-android/pull/6361)
 - Fixed `InfoPanel` overlapping the `RoadNameLabel` in free drive state with the device being in landscape orientation. [#6361](https://github.com/mapbox/mapbox-navigation-android/pull/6361)
+- Introduced `ViewStyleCustomization#mapScalebarParams` that allows for configuring map scalebar. [#6355](https://github.com/mapbox/mapbox-navigation-android/pull/6355)
 
 ## Mapbox Navigation SDK 2.9.0-alpha.2 - 16 September, 2022
 ### Changelog

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -28,6 +28,20 @@ package com.mapbox.navigation.dropin {
     property public final int style;
   }
 
+  public final class MapboxMapScalebarParams {
+    method public boolean getEnabled();
+    method public boolean isMetricUnits();
+    property public final boolean enabled;
+    property public final boolean isMetricUnits;
+  }
+
+  public static final class MapboxMapScalebarParams.Builder {
+    ctor public MapboxMapScalebarParams.Builder(android.content.Context context);
+    method public com.mapbox.navigation.dropin.MapboxMapScalebarParams build();
+    method public com.mapbox.navigation.dropin.MapboxMapScalebarParams.Builder enabled(boolean enabled);
+    method public com.mapbox.navigation.dropin.MapboxMapScalebarParams.Builder isMetricsUnits(Boolean? isMetricUnits);
+  }
+
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class NavigationView extends android.widget.FrameLayout implements androidx.lifecycle.LifecycleOwner {
     ctor public NavigationView(android.content.Context context, android.util.AttributeSet? attrs = null, String accessToken = attrs.navigationViewAccessToken(context), androidx.lifecycle.ViewModelStoreOwner viewModelStoreOwner = context.toViewModelStoreOwner());
     ctor public NavigationView(android.content.Context context, android.util.AttributeSet? attrs = null, String accessToken = attrs.navigationViewAccessToken(context));
@@ -220,6 +234,7 @@ package com.mapbox.navigation.dropin {
     method public Integer? getInfoPanelPeekHeight();
     method public com.mapbox.maps.plugin.LocationPuck? getLocationPuck();
     method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions? getManeuverViewOptions();
+    method public com.mapbox.navigation.dropin.MapboxMapScalebarParams? getMapScalebarParams();
     method public Integer? getPoiNameTextAppearance();
     method public com.mapbox.navigation.dropin.MapboxExtendableButtonParams? getRecenterButtonParams();
     method public Integer? getRoadNameBackground();
@@ -240,6 +255,7 @@ package com.mapbox.navigation.dropin {
     method public void setInfoPanelPeekHeight(Integer?);
     method public void setLocationPuck(com.mapbox.maps.plugin.LocationPuck?);
     method public void setManeuverViewOptions(com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions?);
+    method public void setMapScalebarParams(com.mapbox.navigation.dropin.MapboxMapScalebarParams?);
     method public void setPoiNameTextAppearance(Integer?);
     method public void setRecenterButtonParams(com.mapbox.navigation.dropin.MapboxExtendableButtonParams?);
     method public void setRoadNameBackground(Integer?);
@@ -260,6 +276,7 @@ package com.mapbox.navigation.dropin {
     property public final Integer? infoPanelPeekHeight;
     property public final com.mapbox.maps.plugin.LocationPuck? locationPuck;
     property public final com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions? maneuverViewOptions;
+    property public final com.mapbox.navigation.dropin.MapboxMapScalebarParams? mapScalebarParams;
     property public final Integer? poiNameTextAppearance;
     property public final com.mapbox.navigation.dropin.MapboxExtendableButtonParams? recenterButtonParams;
     property public final Integer? roadNameBackground;
@@ -284,6 +301,7 @@ package com.mapbox.navigation.dropin {
     method @Px public int defaultInfoPanelPeekHeight(android.content.Context context);
     method public com.mapbox.maps.plugin.LocationPuck defaultLocationPuck(android.content.Context context);
     method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions defaultManeuverViewOptions();
+    method public com.mapbox.navigation.dropin.MapboxMapScalebarParams defaultMapScalebarParams(android.content.Context context);
     method @StyleRes public int defaultPoiNameTextAppearance();
     method public com.mapbox.navigation.dropin.MapboxExtendableButtonParams defaultRecenterButtonParams(android.content.Context context);
     method @DrawableRes public int defaultRoadNameBackground();

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/MapboxMapScalebarParams.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/MapboxMapScalebarParams.kt
@@ -1,0 +1,101 @@
+package com.mapbox.navigation.dropin
+
+import android.content.Context
+import com.mapbox.navigation.base.formatter.UnitType
+import com.mapbox.navigation.base.internal.extensions.LocaleEx.getUnitTypeForLocale
+import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
+
+/**
+ * Params describing the map scalebar config.
+ *
+ * @param enabled true if the scalebar should be shown on the map, false otherwise
+ * @param isMetricUnits true if the scale bar is using metric system,
+ *  false if the scale bar is using imperial units.
+ */
+class MapboxMapScalebarParams private constructor(
+    val enabled: Boolean,
+    val isMetricUnits: Boolean,
+) {
+
+    /**
+     * Indicates whether some other object is "equal to" this one.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MapboxMapScalebarParams
+
+        if (enabled != other.enabled) return false
+        if (isMetricUnits != other.isMetricUnits) return false
+
+        return true
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     */
+    override fun hashCode(): Int {
+        var result = enabled.hashCode()
+        result = 31 * result + isMetricUnits.hashCode()
+        return result
+    }
+
+    /**
+     * Returns a string representation of the object.
+     */
+    override fun toString(): String {
+        return "MapboxMapScalebarParams(" +
+            "enabled=$enabled, " +
+            "isMetricUnits=$isMetricUnits" +
+            ")"
+    }
+
+    /**
+     * Builder for [MapboxMapScalebarParams].
+     */
+    class Builder(context: Context) {
+
+        private val applicationContext = context.applicationContext
+        private var enabled: Boolean = false
+        private var isMetricsUnits: Boolean? = null
+
+        /**
+         * Whether to show the scalebar on the map.
+         * @param enabled true if the scalebar should be shown on the map, false otherwise
+         * @return the same builder object
+         */
+        fun enabled(enabled: Boolean): Builder = apply {
+            this.enabled = enabled
+        }
+
+        /**
+         * Whether the scale bar is using metric unit.
+         * @param isMetricUnits true if the scale bar is using metric system,
+         *  false if the scale bar is using imperial units.
+         *  @return the same builder object
+         */
+        fun isMetricsUnits(isMetricUnits: Boolean?): Builder = apply {
+            this.isMetricsUnits = isMetricUnits
+        }
+
+        /**
+         * Create a [MapboxMapScalebarParams] object.
+         * @return [MapboxMapScalebarParams]
+         */
+        fun build(): MapboxMapScalebarParams {
+            return MapboxMapScalebarParams(
+                enabled,
+                isMetricsUnits ?: getDefaultIsMetricUnits()
+            )
+        }
+
+        private fun getDefaultIsMetricUnits(): Boolean {
+            val unitType = applicationContext.inferDeviceLocale().getUnitTypeForLocale()
+            return when (unitType) {
+                UnitType.IMPERIAL -> false
+                UnitType.METRIC -> true
+            }
+        }
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -32,6 +32,7 @@ import com.mapbox.navigation.dropin.coordinator.ManeuverCoordinator
 import com.mapbox.navigation.dropin.coordinator.MapLayoutCoordinator
 import com.mapbox.navigation.dropin.coordinator.RightFrameCoordinator
 import com.mapbox.navigation.dropin.coordinator.RoadNameLabelCoordinator
+import com.mapbox.navigation.dropin.coordinator.ScalebarPlaceholderCoordinator
 import com.mapbox.navigation.dropin.coordinator.SpeedLimitCoordinator
 import com.mapbox.navigation.dropin.databinding.MapboxNavigationViewLayoutBinding
 import com.mapbox.navigation.dropin.internal.MapboxNavigationViewApi
@@ -129,6 +130,7 @@ class NavigationView @JvmOverloads constructor(
                 this,
                 navigationContext.listenerRegistry
             ),
+            ScalebarPlaceholderCoordinator(navigationContext, binding.scalebarLayout),
             ManeuverCoordinator(navigationContext, binding.guidanceLayout),
             InfoPanelCoordinator(
                 navigationContext,

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewStyles.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewStyles.kt
@@ -52,6 +52,9 @@ internal class NavigationViewStyles(context: Context) {
         MutableStateFlow(ViewStyleCustomization.defaultArrivalTextAppearance())
     private val _locationPuck: MutableStateFlow<LocationPuck> =
         MutableStateFlow(ViewStyleCustomization.defaultLocationPuck(context))
+    private val _mapScalebarParams: MutableStateFlow<MapboxMapScalebarParams> = MutableStateFlow(
+        ViewStyleCustomization.defaultMapScalebarParams(context)
+    )
 
     val infoPanelPeekHeight: StateFlow<Int> = _infoPanelPeekHeight.asStateFlow()
     val infoPanelMarginStart: StateFlow<Int> = _infoPanelMarginStart.asStateFlow()
@@ -80,6 +83,7 @@ internal class NavigationViewStyles(context: Context) {
     val maneuverViewOptions: StateFlow<ManeuverViewOptions> = _maneuverViewOptions.asStateFlow()
     val arrivalTextAppearance: StateFlow<Int> = _arrivalTextAppearance.asStateFlow()
     val locationPuck: StateFlow<LocationPuck> = _locationPuck.asStateFlow()
+    val mapScalebarParams: StateFlow<MapboxMapScalebarParams> = _mapScalebarParams.asStateFlow()
 
     fun applyCustomization(customization: ViewStyleCustomization) {
         customization.infoPanelPeekHeight?.also { _infoPanelPeekHeight.value = it }
@@ -104,5 +108,6 @@ internal class NavigationViewStyles(context: Context) {
         customization.roadNameTextAppearance?.also { _roadNameTextAppearance.value = it }
         customization.arrivalTextAppearance?.also { _arrivalTextAppearance.value = it }
         customization.locationPuck?.also { _locationPuck.value = it }
+        customization.mapScalebarParams?.also { _mapScalebarParams.value = it }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
@@ -168,6 +168,16 @@ class ViewStyleCustomization {
      */
     var locationPuck: LocationPuck? = null
 
+    /**
+     * Map scalebar params.
+     * Use [defaultMapScalebarParams] to reset to default.
+     * NOTE: When `enabled`, the `scalebar` will always be added to the top start corner
+     * of the screen. Position of the `scalebar` using `NavigationView` cannot be changed at any
+     * given time. However, if you change the position using `MapView`, the behavior is undefined
+     * and you will be responsible to ensure the correct positioning based on other view overlays.
+     */
+    var mapScalebarParams: MapboxMapScalebarParams? = null
+
     companion object {
         /**
          * Default info panel peek height in pixels.
@@ -374,6 +384,12 @@ class ViewStyleCustomization {
                 R.drawable.mapbox_navigation_puck_icon,
             )
         )
+
+        /**
+         * Default map scalebar parameters.
+         */
+        fun defaultMapScalebarParams(context: Context): MapboxMapScalebarParams =
+            MapboxMapScalebarParams.Builder(context).build()
 
         private fun Context.defaultSpacing() =
             resources.getDimensionPixelSize(R.dimen.mapbox_actionList_spacing)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/map/MapBinder.kt
@@ -5,7 +5,6 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.MapView
 import com.mapbox.maps.plugin.compass.compass
 import com.mapbox.maps.plugin.locationcomponent.location
-import com.mapbox.maps.plugin.scalebar.scalebar
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.core.MapboxNavigation
@@ -15,6 +14,7 @@ import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.dropin.component.camera.CameraComponent
 import com.mapbox.navigation.dropin.component.camera.CameraLayoutObserver
 import com.mapbox.navigation.dropin.component.logo.LogoAttributionComponent
+import com.mapbox.navigation.dropin.component.map.ScalebarComponent
 import com.mapbox.navigation.dropin.component.marker.FreeDriveLongPressMapComponent
 import com.mapbox.navigation.dropin.component.marker.GeocodingComponent
 import com.mapbox.navigation.dropin.component.marker.MapMarkersComponent
@@ -48,8 +48,13 @@ internal class MapBinder(
 
     init {
         mapView.compass.enabled = false
-        mapView.scalebar.enabled = false
     }
+
+    private val scalebarComponent = ScalebarComponent(
+        mapView,
+        context.styles.mapScalebarParams,
+        context.systemBarsInsets
+    )
 
     private val store = context.store
 
@@ -86,7 +91,8 @@ internal class MapBinder(
                 navigationState
             ) { _, arrowOptions, navState ->
                 routeArrowComponent(navState, arrowOptions)
-            }
+            },
+            scalebarComponent
         )
     }
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehavior.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehavior.kt
@@ -9,9 +9,16 @@ internal class ManeuverBehavior {
     private val _maneuverBehavior = MutableStateFlow<MapboxManeuverViewState>(
         MapboxManeuverViewState.COLLAPSED
     )
+    private val _maneuverViewHeight = MutableStateFlow(0)
+
     val maneuverBehavior = _maneuverBehavior.asStateFlow()
+    val maneuverViewHeight = _maneuverViewHeight.asStateFlow()
 
     fun updateBehavior(newState: MapboxManeuverViewState) {
         _maneuverBehavior.value = newState
+    }
+
+    fun updateViewHeight(newHeight: Int) {
+        _maneuverViewHeight.value = newHeight
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImpl.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImpl.kt
@@ -13,4 +13,8 @@ internal class ManeuverComponentContractImpl(
     override fun onManeuverViewStateChanged(state: MapboxManeuverViewState) {
         context.maneuverBehavior.updateBehavior(state)
     }
+
+    override fun onManeuverViewHeightChanged(newHeight: Int) {
+        context.maneuverBehavior.updateViewHeight(newHeight)
+    }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/map/ScalebarComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/map/ScalebarComponent.kt
@@ -1,0 +1,49 @@
+package com.mapbox.navigation.dropin.component.map
+
+import android.view.Gravity
+import androidx.core.graphics.Insets
+import com.mapbox.maps.MapView
+import com.mapbox.maps.plugin.scalebar.scalebar
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.MapboxMapScalebarParams
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import kotlinx.coroutines.flow.StateFlow
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class ScalebarComponent(
+    private val mapView: MapView,
+    private val scalebarParams: StateFlow<MapboxMapScalebarParams>,
+    private val systemBarInsets: StateFlow<Insets>,
+) : UIComponent() {
+
+    private val defaultMarginTop = 4f
+    private val defaultMarginLeft = 4f
+
+    init {
+        setUpScalebar(scalebarParams.value)
+        mapView.scalebar.updateSettings {
+            position = Gravity.TOP or Gravity.START
+            // temporary workaround, remove after MAPSMBL-173
+            textBorderWidth = 3f
+        }
+    }
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+        scalebarParams.observe { setUpScalebar(it) }
+        systemBarInsets.observe { insets ->
+            mapView.scalebar.updateSettings {
+                marginTop = defaultMarginTop + insets.top
+                marginLeft = defaultMarginLeft + insets.left
+            }
+        }
+    }
+
+    private fun setUpScalebar(params: MapboxMapScalebarParams) {
+        mapView.scalebar.updateSettings {
+            enabled = params.enabled
+            isMetricUnits = params.isMetricUnits
+        }
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponent.kt
@@ -4,10 +4,7 @@ import android.view.View
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.MapboxMapScalebarParams
-import com.mapbox.navigation.ui.app.internal.State
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
@@ -17,15 +14,15 @@ import kotlinx.coroutines.launch
 internal class ScalebarPlaceholderComponent(
     private val scalebarPlaceholder: View,
     private val scalebarParams: StateFlow<MapboxMapScalebarParams>,
-    private val navigationState: StateFlow<State>,
+    private val maneuverHeight: StateFlow<Int>,
 ) : UIComponent() {
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
         coroutineScope.launch {
-            combine(scalebarParams, navigationState) { params, state ->
+            combine(scalebarParams, maneuverHeight) { params, height ->
                 scalebarPlaceholder.visibility =
-                    if (params.enabled && state.navigation !is NavigationState.ActiveNavigation) {
+                    if (params.enabled && height == 0) {
                         View.VISIBLE
                     } else {
                         View.GONE

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponent.kt
@@ -1,0 +1,36 @@
+package com.mapbox.navigation.dropin.component.map
+
+import android.view.View
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.MapboxMapScalebarParams
+import com.mapbox.navigation.ui.app.internal.State
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class ScalebarPlaceholderComponent(
+    private val scalebarPlaceholder: View,
+    private val scalebarParams: StateFlow<MapboxMapScalebarParams>,
+    private val navigationState: StateFlow<State>,
+) : UIComponent() {
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+        coroutineScope.launch {
+            combine(scalebarParams, navigationState) { params, state ->
+                scalebarPlaceholder.visibility =
+                    if (params.enabled && state.navigation !is NavigationState.ActiveNavigation) {
+                        View.VISIBLE
+                    } else {
+                        View.GONE
+                    }
+            }.collect()
+        }
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderBinder.kt
@@ -1,0 +1,34 @@
+package com.mapbox.navigation.dropin.coordinator
+
+import android.view.View
+import android.view.ViewGroup
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.dropin.R
+import com.mapbox.navigation.dropin.component.map.ScalebarPlaceholderComponent
+import com.mapbox.navigation.dropin.databinding.MapboxScalebarPlaceholderLayoutBinding
+import com.mapbox.navigation.ui.app.internal.extension.actionsFlowable
+import com.mapbox.navigation.ui.base.lifecycle.UIBinder
+import kotlinx.coroutines.flow.map
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+internal class ScalebarPlaceholderBinder(
+    private val context: NavigationViewContext,
+) : UIBinder {
+
+    override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
+        val binding = inflateLayout(viewGroup)
+        return ScalebarPlaceholderComponent(
+            binding.scalebarPlaceholder,
+            context.styles.mapScalebarParams,
+            context.store.state
+        )
+    }
+
+    private fun inflateLayout(viewGroup: ViewGroup): MapboxScalebarPlaceholderLayoutBinding {
+        viewGroup.removeAllViews()
+        View.inflate(viewGroup.context, R.layout.mapbox_scalebar_placeholder_layout, viewGroup)
+        return MapboxScalebarPlaceholderLayoutBinding.bind(viewGroup)
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderBinder.kt
@@ -8,9 +8,7 @@ import com.mapbox.navigation.dropin.NavigationViewContext
 import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.component.map.ScalebarPlaceholderComponent
 import com.mapbox.navigation.dropin.databinding.MapboxScalebarPlaceholderLayoutBinding
-import com.mapbox.navigation.ui.app.internal.extension.actionsFlowable
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
-import kotlinx.coroutines.flow.map
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 internal class ScalebarPlaceholderBinder(
@@ -22,7 +20,7 @@ internal class ScalebarPlaceholderBinder(
         return ScalebarPlaceholderComponent(
             binding.scalebarPlaceholder,
             context.styles.mapScalebarParams,
-            context.store.state
+            context.maneuverBehavior.maneuverViewHeight
         )
     }
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderCoordinator.kt
@@ -1,0 +1,21 @@
+package com.mapbox.navigation.dropin.coordinator
+
+import android.view.ViewGroup
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.ui.base.lifecycle.Binder
+import com.mapbox.navigation.ui.base.lifecycle.UICoordinator
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+@ExperimentalPreviewMapboxNavigationAPI
+internal class ScalebarPlaceholderCoordinator(
+    private val context: NavigationViewContext,
+    scalebarLayout: ViewGroup
+) : UICoordinator<ViewGroup>(scalebarLayout) {
+
+    override fun MapboxNavigation.flowViewBinders(): Flow<Binder<ViewGroup>> {
+        return flowOf(ScalebarPlaceholderBinder(context))
+    }
+}

--- a/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
@@ -59,13 +59,21 @@
                     tools:background="@color/mapbox_main_maneuver_background_color" />
 
                 <FrameLayout
+                    android:id="@+id/scalebarLayout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/guidanceLayout"
+                    />
+
+                <FrameLayout
                     android:id="@+id/speedLimitLayout"
                     android:layout_width="75dp"
                     android:layout_height="86dp"
                     android:layout_marginStart="4dp"
                     android:layout_marginTop="8dp"
                     app:layout_constraintStart_toEndOf="@id/guidanceLayout"
-                    app:layout_constraintTop_toTopOf="@id/guidanceLayout"
+                    app:layout_constraintTop_toBottomOf="@id/scalebarLayout"
                     tools:background="#eee"
                     tools:layout_height="60dp"
                     tools:layout_width="50dp"

--- a/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
@@ -53,13 +53,21 @@
                     tools:background="@color/mapbox_main_maneuver_background_color" />
 
                 <FrameLayout
+                    android:id="@+id/scalebarLayout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
+                    app:layout_constraintStart_toStartOf="parent"
+                    />
+
+                <FrameLayout
                     android:id="@+id/speedLimitLayout"
                     android:layout_width="75dp"
                     android:layout_height="86dp"
                     android:layout_marginStart="8dp"
                     android:layout_marginTop="8dp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
+                    app:layout_constraintTop_toBottomOf="@id/scalebarLayout"
                     tools:background="#eee"
                     tools:layout_height="60dp"
                     tools:layout_width="50dp"

--- a/libnavui-dropin/src/main/res/layout/mapbox_scalebar_placeholder_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_scalebar_placeholder_layout.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <View
+        android:id="@+id/scalebarPlaceholder"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/mapbox_scalebar_height"
+        android:visibility="gone"
+        />
+
+</merge>

--- a/libnavui-dropin/src/main/res/values/dimens.xml
+++ b/libnavui-dropin/src/main/res/values/dimens.xml
@@ -33,4 +33,6 @@
     <dimen name="mapbox_extendable_button_width">72dp</dimen>
     <dimen name="mapbox_extendable_button_height">52dp</dimen>
 
+    <dimen name="mapbox_scalebar_height">20dp</dimen>
+
 </resources>

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/MapboxMapScalebarParamsTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/MapboxMapScalebarParamsTest.kt
@@ -1,0 +1,64 @@
+package com.mapbox.navigation.dropin
+
+import android.content.Context
+import com.mapbox.navigation.base.formatter.UnitType
+import com.mapbox.navigation.base.internal.extensions.LocaleEx
+import com.mapbox.navigation.base.internal.extensions.LocaleEx.getUnitTypeForLocale
+import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+class MapboxMapScalebarParamsTest {
+
+    private val locale = mockk<Locale>(relaxed = true)
+    private val appContext = mockk<Context>(relaxed = true) {
+        every { inferDeviceLocale() } returns locale
+    }
+    private val context = mockk<Context>(relaxed = true) {
+        every { applicationContext } returns appContext
+    }
+
+    @Before
+    fun setUp() {
+        mockkStatic(LocaleEx::class)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(LocaleEx::class)
+    }
+
+    @Test
+    fun defaultMetricUnitsImperial() {
+        every { locale.getUnitTypeForLocale() } returns UnitType.IMPERIAL
+        val defaultParams = MapboxMapScalebarParams.Builder(context).build()
+        assertEquals(false, defaultParams.isMetricUnits)
+    }
+
+    @Test
+    fun defaultMetricUnitsMetrics() {
+        every { locale.getUnitTypeForLocale() } returns UnitType.METRIC
+        val defaultParams = MapboxMapScalebarParams.Builder(context).build()
+        assertEquals(true, defaultParams.isMetricUnits)
+    }
+
+    @Test
+    fun setMetricUnitsMetrics() {
+        every { locale.getUnitTypeForLocale() } returns UnitType.IMPERIAL
+        val defaultParams = MapboxMapScalebarParams.Builder(context).isMetricsUnits(true).build()
+        assertEquals(true, defaultParams.isMetricUnits)
+        verify(exactly = 0) { appContext.inferDeviceLocale() }
+        verify(exactly = 0) { locale.getUnitTypeForLocale() }
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/ScalebarPlaceholderBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/binder/ScalebarPlaceholderBinderTest.kt
@@ -1,0 +1,56 @@
+package com.mapbox.navigation.dropin.binder
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.lifecycle.viewModelScope
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.dropin.NavigationViewStyles
+import com.mapbox.navigation.dropin.R
+import com.mapbox.navigation.dropin.coordinator.ScalebarPlaceholderBinder
+import com.mapbox.navigation.dropin.util.TestStore
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.MainScope
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+internal class ScalebarPlaceholderBinderTest {
+
+    private lateinit var ctx: Context
+    private lateinit var viewGroup: ViewGroup
+
+    private lateinit var navContext: NavigationViewContext
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+        viewGroup = FrameLayout(ctx)
+        viewGroup.addView(View(ctx))
+
+        navContext = mockk(relaxed = true) {
+            every { store } returns TestStore()
+            every { styles } returns NavigationViewStyles(ctx)
+            every { viewModel } returns mockk {
+                every { viewModelScope } returns MainScope()
+            }
+        }
+    }
+
+    @Test
+    fun shouldLeaveOnlyPlaceholder() {
+        val binder = ScalebarPlaceholderBinder(navContext)
+        binder.bind(viewGroup)
+        Assert.assertEquals(1, viewGroup.childCount)
+        Assert.assertEquals(R.id.scalebarPlaceholder, viewGroup.getChildAt(0).id)
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehaviorTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehaviorTest.kt
@@ -14,4 +14,13 @@ class ManeuverBehaviorTest {
 
         assertEquals(MapboxManeuverViewState.EXPANDED, sut.maneuverBehavior.value)
     }
+
+    @Test
+    fun `when maneuver view height is updated`() {
+        val sut = ManeuverBehavior()
+
+        sut.updateViewHeight(43)
+
+        assertEquals(43, sut.maneuverViewHeight.value)
+    }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImplTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImplTest.kt
@@ -13,17 +13,26 @@ import org.junit.Test
 @ExperimentalPreviewMapboxNavigationAPI
 class ManeuverComponentContractImplTest {
 
+    private val navigationViewContext: NavigationViewContext = mockk(relaxed = true) {
+        every { maneuverBehavior.updateBehavior(any()) } just Runs
+    }
+    private val sut = ManeuverComponentContractImpl(navigationViewContext)
+
     @Test
     fun `when maneuver view state is changed, contract is notified`() {
-        val navigationViewContext: NavigationViewContext = mockk(relaxed = true) {
-            every { maneuverBehavior.updateBehavior(any()) } just Runs
-        }
-        val sut = ManeuverComponentContractImpl(navigationViewContext)
-
         sut.onManeuverViewStateChanged(MapboxManeuverViewState.EXPANDED)
 
         verify {
             navigationViewContext.maneuverBehavior.updateBehavior(MapboxManeuverViewState.EXPANDED)
+        }
+    }
+
+    @Test
+    fun `when maneuver view height is changed, contract is notified`() {
+        sut.onManeuverViewHeightChanged(23)
+
+        verify {
+            navigationViewContext.maneuverBehavior.updateViewHeight(23)
         }
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/map/ScalebarComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/map/ScalebarComponentTest.kt
@@ -41,7 +41,9 @@ internal class ScalebarComponentTest {
     private val scalebarMock = mockk<ScaleBarPlugin>(relaxed = true) {
         every { marginTop } returns 14f
         every { marginLeft } returns 14f
-        every { updateSettings(any()) } answers { (args[0] as ScaleBarSettings.() -> Unit)(settings) }
+        every { updateSettings(any()) } answers {
+            (args[0] as ScaleBarSettings.() -> Unit)(settings)
+        }
     }
     private val mapView = mockk<MapView>(relaxed = true) {
         every { scalebar } returns scalebarMock
@@ -53,7 +55,9 @@ internal class ScalebarComponentTest {
     )
     private val initialInsetTop = 3
     private val initialInsetLeft = 5
-    private val systemBarsFlow = MutableStateFlow(Insets.of(initialInsetLeft, initialInsetTop, 0, 0))
+    private val systemBarsFlow = MutableStateFlow(
+        Insets.of(initialInsetLeft, initialInsetTop, 0, 0)
+    )
     private val mapboxNavigation = mockk<MapboxNavigation>()
     private val component = ScalebarComponent(mapView, scalebarParamsFlow, systemBarsFlow)
 
@@ -75,7 +79,9 @@ internal class ScalebarComponentTest {
         val isMetricUnits = Random.nextBoolean()
         ScalebarComponent(
             mapView,
-            MutableStateFlow(MapboxMapScalebarParams.Builder(context).isMetricsUnits(isMetricUnits).build()),
+            MutableStateFlow(
+                MapboxMapScalebarParams.Builder(context).isMetricsUnits(isMetricUnits).build()
+            ),
             MutableStateFlow(Insets.NONE)
         )
         verify { settings.isMetricUnits = isMetricUnits }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/map/ScalebarComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/map/ScalebarComponentTest.kt
@@ -1,0 +1,208 @@
+package com.mapbox.navigation.dropin.component.map
+
+import android.content.Context
+import android.view.Gravity
+import androidx.core.graphics.Insets
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.maps.MapView
+import com.mapbox.maps.plugin.scalebar.ScaleBarPlugin
+import com.mapbox.maps.plugin.scalebar.generated.ScaleBarSettings
+import com.mapbox.maps.plugin.scalebar.scalebar
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.MapboxMapScalebarParams
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.random.Random
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+internal class ScalebarComponentTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val defaultMarginTop = 4f
+    private val defaultMarginLeft = 4f
+    private val settings = mockk<ScaleBarSettings>(relaxed = true) {
+        every { marginTop } returns 14f
+        every { marginLeft } returns 14f
+    }
+    private val scalebarMock = mockk<ScaleBarPlugin>(relaxed = true) {
+        every { marginTop } returns 14f
+        every { marginLeft } returns 14f
+        every { updateSettings(any()) } answers { (args[0] as ScaleBarSettings.() -> Unit)(settings) }
+    }
+    private val mapView = mockk<MapView>(relaxed = true) {
+        every { scalebar } returns scalebarMock
+    }
+    private val scalebarParamsFlow = MutableStateFlow(
+        MapboxMapScalebarParams.Builder(context)
+            .isMetricsUnits(false)
+            .build()
+    )
+    private val initialInsetTop = 3
+    private val initialInsetLeft = 5
+    private val systemBarsFlow = MutableStateFlow(Insets.of(initialInsetLeft, initialInsetTop, 0, 0))
+    private val mapboxNavigation = mockk<MapboxNavigation>()
+    private val component = ScalebarComponent(mapView, scalebarParamsFlow, systemBarsFlow)
+
+    @Test
+    fun enableFlagIsSetOnInit() {
+        clearMocks(settings)
+        val enabled = Random.nextBoolean()
+        ScalebarComponent(
+            mapView,
+            MutableStateFlow(MapboxMapScalebarParams.Builder(context).enabled(enabled).build()),
+            MutableStateFlow(Insets.NONE)
+        )
+        verify { settings.enabled = enabled }
+    }
+
+    @Test
+    fun isMetricsUnitIsSetOnInit() {
+        clearMocks(settings)
+        val isMetricUnits = Random.nextBoolean()
+        ScalebarComponent(
+            mapView,
+            MutableStateFlow(MapboxMapScalebarParams.Builder(context).isMetricsUnits(isMetricUnits).build()),
+            MutableStateFlow(Insets.NONE)
+        )
+        verify { settings.isMetricUnits = isMetricUnits }
+    }
+
+    @Test
+    fun textBorderWidthIsSetOnInit() {
+        clearMocks(settings)
+        ScalebarComponent(
+            mapView,
+            MutableStateFlow(MapboxMapScalebarParams.Builder(context).build()),
+            MutableStateFlow(Insets.NONE)
+        )
+        verify { settings.textBorderWidth = 3f }
+    }
+
+    @Test
+    fun positionIsSetOnInit() {
+        verify { settings.position = Gravity.TOP or Gravity.START }
+    }
+
+    @Test
+    fun scalebarParamsChangedBeforeOnAttached() {
+        clearMocks(settings)
+        scalebarParamsFlow.tryEmit(
+            MapboxMapScalebarParams.Builder(context)
+                .enabled(true)
+                .isMetricsUnits(false)
+                .build()
+        )
+        verify(exactly = 0) { settings.enabled = any() }
+        verify(exactly = 0) { settings.isMetricUnits = any() }
+        verify(exactly = 0) { settings.marginTop = any() }
+        verify(exactly = 0) { settings.marginLeft = any() }
+    }
+
+    @Test
+    fun systemBarInsetsChangedBeforeOnAttached() {
+        clearMocks(settings)
+        systemBarsFlow.tryEmit(Insets.of(12, 34, 56, 78))
+        verify(exactly = 0) { settings.enabled = any() }
+        verify(exactly = 0) { settings.isMetricUnits = any() }
+        verify(exactly = 0) { settings.marginTop = any() }
+        verify(exactly = 0) { settings.marginLeft = any() }
+    }
+
+    @Test
+    fun enabledFlagSetOnAttached() {
+        clearMocks(settings)
+        component.onAttached(mapboxNavigation)
+        verify(exactly = 1) { settings.enabled = false }
+    }
+
+    @Test
+    fun isMetricUnitsSetOnAttached() {
+        clearMocks(settings)
+        component.onAttached(mapboxNavigation)
+        verify(exactly = 1) { settings.isMetricUnits = false }
+    }
+
+    @Test
+    fun marginTopSetOnOnAttached() {
+        clearMocks(settings)
+        component.onAttached(mapboxNavigation)
+        verify(exactly = 1) { settings.marginTop = defaultMarginTop + initialInsetTop }
+    }
+
+    @Test
+    fun marginLeftSetOnOnAttached() {
+        clearMocks(settings)
+        component.onAttached(mapboxNavigation)
+        verify(exactly = 1) { settings.marginLeft = defaultMarginLeft + initialInsetLeft }
+    }
+
+    @Test
+    fun scalebarParamsChangedAfterOnAttached() {
+        component.onAttached(mapboxNavigation)
+        clearMocks(settings)
+        scalebarParamsFlow.tryEmit(
+            MapboxMapScalebarParams.Builder(context)
+                .enabled(true)
+                .isMetricsUnits(true)
+                .build()
+        )
+        verify(exactly = 1) { settings.enabled = true }
+        verify(exactly = 1) { settings.isMetricUnits = true }
+        verify(exactly = 0) { settings.marginTop = any() }
+        verify(exactly = 0) { settings.marginLeft = any() }
+    }
+
+    @Test
+    fun systemBarInsetsChangedAfterOnAttached() {
+        component.onAttached(mapboxNavigation)
+        clearMocks(settings)
+        systemBarsFlow.tryEmit(Insets.of(12, 34, 56, 78))
+        verify(exactly = 0) { settings.enabled = any() }
+        verify(exactly = 0) { settings.isMetricUnits = any() }
+        verify(exactly = 1) { settings.marginTop = defaultMarginTop + 34 }
+        verify(exactly = 1) { settings.marginLeft = defaultMarginLeft + 12 }
+    }
+
+    @Test
+    fun scalebarParamsChangedAfterOnDetached() {
+        component.onAttached(mapboxNavigation)
+        clearMocks(settings)
+        component.onDetached(mapboxNavigation)
+        scalebarParamsFlow.tryEmit(
+            MapboxMapScalebarParams.Builder(context)
+                .enabled(true)
+                .isMetricsUnits(true)
+                .build()
+        )
+        verify(exactly = 0) { settings.enabled = any() }
+        verify(exactly = 0) { settings.isMetricUnits = any() }
+        verify(exactly = 0) { settings.marginTop = any() }
+        verify(exactly = 0) { settings.marginLeft = any() }
+    }
+
+    @Test
+    fun systemBarInsetsChangedAfterOnDetached() {
+        component.onAttached(mapboxNavigation)
+        clearMocks(settings)
+        component.onDetached(mapboxNavigation)
+        systemBarsFlow.tryEmit(Insets.of(12, 34, 56, 78))
+        verify(exactly = 0) { settings.enabled = any() }
+        verify(exactly = 0) { settings.isMetricUnits = any() }
+        verify(exactly = 0) { settings.marginTop = any() }
+        verify(exactly = 0) { settings.marginLeft = any() }
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponentTest.kt
@@ -1,0 +1,172 @@
+package com.mapbox.navigation.dropin.component.map
+
+import android.content.Context
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.MapboxMapScalebarParams
+import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.app.internal.State
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
+import io.mockk.clearMocks
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class ScalebarPlaceholderComponentTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val mapboxNavigation = mockk<MapboxNavigation>()
+    private val scalebarPlaceholderView = mockk<View>(relaxed = true)
+    private val stateFlow = MutableStateFlow(
+        State(
+            navigation = NavigationState.FreeDrive,
+            previewRoutes = RoutePreviewState.Ready(emptyList())
+        )
+    )
+    private val mapScalebarParams = MutableStateFlow(MapboxMapScalebarParams.Builder(context).build())
+    private val component = ScalebarPlaceholderComponent(scalebarPlaceholderView, mapScalebarParams, stateFlow)
+
+    @Test
+    fun visibilityIsChangedOnOnAttachedActiveGuidance() {
+        stateFlow.tryEmit(State(navigation = NavigationState.FreeDrive))
+        component.onAttached(mapboxNavigation)
+        verify { scalebarPlaceholderView.visibility = View.GONE }
+    }
+
+    @Test
+    fun visibilityIsChangedOnOnAttachedFreeDrive() {
+        stateFlow.tryEmit(State(navigation = NavigationState.FreeDrive))
+        component.onAttached(mapboxNavigation)
+        verify { scalebarPlaceholderView.visibility = View.GONE }
+    }
+
+    @Test
+    fun visibilityIsChangedOnOnAttachedRoutePreview() {
+        stateFlow.tryEmit(State(navigation = NavigationState.RoutePreview))
+        component.onAttached(mapboxNavigation)
+        verify { scalebarPlaceholderView.visibility = View.GONE }
+    }
+
+    @Test
+    fun visibilityIsChangedOnOnAttachedDestinationPreview() {
+        stateFlow.tryEmit(State(navigation = NavigationState.RoutePreview))
+        component.onAttached(mapboxNavigation)
+        verify { scalebarPlaceholderView.visibility = View.GONE }
+    }
+
+    @Test
+    fun mapScalebarParamsChangeBeforeOnAttached() {
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        verify(exactly = 0) { scalebarPlaceholderView.visibility = any() }
+    }
+
+    @Test
+    fun stateChangeBeforeOnAttached() {
+        stateFlow.tryEmit(State(navigation = NavigationState.RoutePreview))
+        verify(exactly = 0) { scalebarPlaceholderView.visibility = any() }
+    }
+
+    @Test
+    fun mapScalebarParamsChangeAfterOnAttachedActiveGuidance() {
+        stateFlow.tryEmit(State(navigation = NavigationState.ActiveNavigation))
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        verify { scalebarPlaceholderView.visibility = View.GONE }
+    }
+
+    @Test
+    fun mapScalebarParamsChangeAfterOnAttachedFreeDrive() {
+        stateFlow.tryEmit(State(navigation = NavigationState.ActiveNavigation))
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        verify { scalebarPlaceholderView.visibility = View.GONE }
+    }
+
+    @Test
+    fun mapScalebarParamsChangeAfterOnAttachedRoutePreview() {
+        stateFlow.tryEmit(State(navigation = NavigationState.RoutePreview))
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        verify { scalebarPlaceholderView.visibility = View.VISIBLE }
+    }
+
+    @Test
+    fun mapScalebarParamsChangeAfterOnAttachedDestinationPreview() {
+        stateFlow.tryEmit(State(navigation = NavigationState.DestinationPreview))
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        verify { scalebarPlaceholderView.visibility = View.VISIBLE }
+    }
+
+    @Test
+    fun stateChangeAfterOnAttachedActiveGuidance() {
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        stateFlow.tryEmit(State(navigation = NavigationState.ActiveNavigation))
+        verify { scalebarPlaceholderView.visibility = View.GONE }
+    }
+
+    @Test
+    fun stateChangeAfterOnAttachedFreeDrive() {
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        stateFlow.tryEmit(State(navigation = NavigationState.FreeDrive))
+        verify { scalebarPlaceholderView.visibility = View.VISIBLE }
+    }
+
+    @Test
+    fun stateChangeAfterOnAttachedRoutePreview() {
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        stateFlow.tryEmit(State(navigation = NavigationState.RoutePreview))
+        verify { scalebarPlaceholderView.visibility = View.VISIBLE }
+    }
+
+    @Test
+    fun stateChangeAfterOnAttachedDestinationPreview() {
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        stateFlow.tryEmit(State(navigation = NavigationState.DestinationPreview))
+        verify { scalebarPlaceholderView.visibility = View.VISIBLE }
+    }
+
+    @Test
+    fun mapScalebarParamsChangeAfterOnDetached() {
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        component.onDetached(mapboxNavigation)
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        verify(exactly = 0) { scalebarPlaceholderView.visibility = any() }
+    }
+
+    @Test
+    fun stateChangeAfterOnDetached() {
+        mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
+        component.onAttached(mapboxNavigation)
+        clearMocks(scalebarPlaceholderView)
+        component.onDetached(mapboxNavigation)
+        stateFlow.tryEmit(State(navigation = NavigationState.FreeDrive))
+        verify(exactly = 0) { scalebarPlaceholderView.visibility = any() }
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderCoordinatorTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderCoordinatorTest.kt
@@ -1,0 +1,41 @@
+package com.mapbox.navigation.dropin.coordinator
+
+import android.view.ViewGroup
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.NavigationViewContext
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(
+    ExperimentalPreviewMapboxNavigationAPI::class,
+    ExperimentalCoroutinesApi::class,
+    InternalCoroutinesApi::class
+)
+class ScalebarPlaceholderCoordinatorTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    private val context = mockk<NavigationViewContext>()
+    private val viewGroup = mockk<ViewGroup>()
+    private val mapboxNavigation = mockk<MapboxNavigation>()
+    private val coordinator = ScalebarPlaceholderCoordinator(context, viewGroup)
+
+    @Test
+    fun flowViewBindersReturnsOnlyScalebarPlaceholderBinder() = runBlockingTest {
+        coordinator.apply {
+            val binders = mapboxNavigation.flowViewBinders().toList()
+            assertEquals(1, binders.size)
+            assertTrue(binders[0] is ScalebarPlaceholderBinder)
+        }
+    }
+}

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponent.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponent.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.launch
 
 interface ManeuverComponentContract {
     fun onManeuverViewStateChanged(state: MapboxManeuverViewState)
+    fun onManeuverViewHeightChanged(newHeight: Int)
 }
 
 @ExperimentalPreviewMapboxNavigationAPI
@@ -40,6 +41,11 @@ class ManeuverComponent(
         coroutineScope.launch {
             maneuverView.maneuverViewState.collect {
                 contract?.get()?.onManeuverViewStateChanged(it)
+            }
+        }
+        coroutineScope.launch {
+            maneuverView.heightFlow.collect {
+                contract?.get()?.onManeuverViewHeightChanged(it)
             }
         }
         coroutineScope.launch {
@@ -68,5 +74,10 @@ class ManeuverComponent(
                 }
             }.collect()
         }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        super.onDetached(mapboxNavigation)
+        contract?.get()?.onManeuverViewHeightChanged(0)
     }
 }

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverView.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverView.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 class MapboxManeuverView : ConstraintLayout {
 
+    private val _heightFlow = MutableStateFlow(0)
     private val _maneuverViewState = MutableStateFlow<MapboxManeuverViewState>(
         MapboxManeuverViewState.COLLAPSED
     )
@@ -53,6 +54,8 @@ class MapboxManeuverView : ConstraintLayout {
      * Observe on [maneuverViewState] to get notified about changes to [MapboxManeuverViewState].
      */
     val maneuverViewState = _maneuverViewState.asStateFlow()
+
+    internal val heightFlow = _heightFlow.asStateFlow()
 
     private var maneuverViewOptions = ManeuverViewOptions.Builder().build()
 
@@ -319,8 +322,12 @@ class MapboxManeuverView : ConstraintLayout {
      */
     fun updateUpcomingManeuversVisibility(visibility: Int) {
         when (visibility) {
-            VISIBLE -> { _maneuverViewState.value = MapboxManeuverViewState.EXPANDED }
-            else -> { _maneuverViewState.value = MapboxManeuverViewState.COLLAPSED }
+            VISIBLE -> {
+                _maneuverViewState.value = MapboxManeuverViewState.EXPANDED
+            }
+            else -> {
+                _maneuverViewState.value = MapboxManeuverViewState.COLLAPSED
+            }
         }
         binding.upcomingManeuverRecycler.visibility = visibility
     }
@@ -744,5 +751,12 @@ class MapboxManeuverView : ConstraintLayout {
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     internal fun getUpcomingManeuverAdapter(): MapboxUpcomingManeuverAdapter {
         return upcomingManeuverAdapter
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        if (h != oldh) {
+            _heightFlow.tryEmit(h)
+        }
     }
 }

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverViewTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverViewTest.kt
@@ -589,6 +589,19 @@ class MapboxManeuverViewTest {
         )
     }
 
+    @Test
+    fun `initial height is zero`() {
+        val view = MapboxManeuverView(ctx)
+        assertEquals(0, view.heightFlow.value)
+    }
+
+    @Test
+    fun `height is changed`() {
+        val view = MapboxManeuverView(ctx)
+        view.layout(10, 10, 50, 60)
+        assertEquals(50, view.heightFlow.value)
+    }
+
     private fun getMockPrimaryManeuver(): PrimaryManeuver {
         val textComponentNode = Component(
             BannerComponents.TEXT,

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -18,4 +18,5 @@ class CustomizedViewModel : ViewModel() {
     val fullScreen = MutableLiveData(false)
     val distanceFormatterMetric = MutableLiveData(false)
     val showCameraDebugInfo = MutableLiveData(false)
+    val enableScalebar = MutableLiveData(false)
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -31,7 +31,6 @@ import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.gestures
-import com.mapbox.maps.plugin.scalebar.scalebar
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -31,6 +31,7 @@ import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.gestures.OnMapLongClickListener
 import com.mapbox.maps.plugin.gestures.gestures
+import com.mapbox.maps.plugin.scalebar.scalebar
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
@@ -53,6 +54,7 @@ import com.mapbox.navigation.dropin.ActionButtonDescription.Position.END
 import com.mapbox.navigation.dropin.ActionButtonDescription.Position.START
 import com.mapbox.navigation.dropin.MapViewObserver
 import com.mapbox.navigation.dropin.MapboxExtendableButtonParams
+import com.mapbox.navigation.dropin.MapboxMapScalebarParams
 import com.mapbox.navigation.dropin.NavigationViewListener
 import com.mapbox.navigation.dropin.ViewOptionsCustomization.Companion.defaultRouteArrowOptions
 import com.mapbox.navigation.dropin.ViewOptionsCustomization.Companion.defaultRouteLineOptions
@@ -322,6 +324,11 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             menuBinding.showCameraDebugInfo,
             viewModel.showCameraDebugInfo,
             ::toggleShowCameraDebugInfo
+        )
+        bindSwitch(
+            menuBinding.toggleEnableScalebar,
+            viewModel.enableScalebar,
+            ::toggleEnableScalebar
         )
     }
 
@@ -649,6 +656,15 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             binding.navigationView.customizeViewOptions {
                 distanceFormatterOptions = options.toBuilder().unitType(UnitType.IMPERIAL).build()
             }
+        }
+    }
+
+    private fun toggleEnableScalebar(enabled: Boolean) {
+        binding.navigationView.customizeViewStyles {
+            mapScalebarParams = MapboxMapScalebarParams
+                .Builder(this@MapboxNavigationViewCustomizedActivity)
+                .enabled(enabled)
+                .build()
         }
     }
 

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -119,6 +119,15 @@
                 android:text="Enable Destination Preview"
                 android:textAllCaps="true" />
 
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/toggleEnableScalebar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:paddingVertical="10dp"
+                android:text="Enable scalebar"
+                android:textAllCaps="true" />
+
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #6252.
Fixes NAVAND-297.

TODO:

- [x] Explicitly set the position of compass and scalebar

I'm not very happy with the way it looks but I'm not exactly a designer so if anyone has any suggestions, I'd be glad to implement them.

Nothing:
<img width="833" alt="image" src="https://user-images.githubusercontent.com/32109537/191007181-d670481b-2044-45d7-920b-a7687634dcb9.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/32109537/191007331-e7670ce6-bcaa-4b0f-91ca-bb9d593cede7.png">

Scalebar:
<img width="830" alt="image" src="https://user-images.githubusercontent.com/32109537/191007094-6da0de9d-6147-48ee-afaf-a53acab6689f.png">
<img width="382" alt="image" src="https://user-images.githubusercontent.com/32109537/191007265-98d25582-64ad-446b-8707-107d83c08093.png">

Compass:
<img width="829" alt="image" src="https://user-images.githubusercontent.com/32109537/191007370-3961c0de-366f-4477-947e-0455c0bde22e.png">
<img width="368" alt="image" src="https://user-images.githubusercontent.com/32109537/191007408-f78f5d05-6405-45e3-988d-c6d757003c74.png">


