### PR TITLE
[Drop-In UI] add changes to how margins are assigned to custom buttons

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/ActionButtonBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/ActionButtonBinder.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
-import androidx.core.view.children
 import androidx.lifecycle.viewModelScope
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
@@ -74,22 +73,18 @@ internal class ActionButtonBinder(
     private fun installCustomButtons(buttonContainer: LinearLayout) {
         val spacing = buttonContainer.resources
             .getDimensionPixelSize(R.dimen.mapbox_actionList_spacing)
-        customButtons.filter { it.position == ActionButtonDescription.Position.START }
-            .reversed()
-            .also {
-                startCustomButtonsCount = it.size
-            }
-            .forEach {
-                buttonContainer.children.firstOrNull()?.setMargins(top = spacing)
-                it.view.setMargins(bottom = spacing)
-                buttonContainer.addView(it.view, 0)
-            }
-        customButtons.filter { it.position == ActionButtonDescription.Position.END }
-            .forEach {
-                buttonContainer.children.lastOrNull()?.setMargins(bottom = spacing)
-                it.view.setMargins(top = spacing)
-                buttonContainer.addView(it.view)
-            }
+        customButtons
+            .filter { it.position == ActionButtonDescription.Position.START }
+            .asReversed()
+            .also { startCustomButtonsCount = it.size }
+            .onEach { buttonContainer.addView(it.view, 0) }
+            .dropLast(1)
+            .forEach { it.view.setMargins(top = spacing) }
+        customButtons
+            .filter { it.position == ActionButtonDescription.Position.END }
+            .onEach { buttonContainer.addView(it.view) }
+            .dropLast(1)
+            .forEach { it.view.setMargins(bottom = spacing) }
     }
 
     private fun audioGuidanceButtonComponent(


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
The changes introduced in the PR, modify the logic to how margins are assigned to custom action buttons. Changes include: 
The custom action buttons that are added at 
- `POSITION.START` are applied with a `marginTop` except for the top most button.
- `POSITION.END` are applied with a `marginBottom` except for the bottom most button.

| <img src="https://user-images.githubusercontent.com/9770186/191404868-b8b2cbf6-4926-4d8d-9d23-b814d8897054.jpg" width="200" /> | <img src="https://user-images.githubusercontent.com/9770186/191404987-37827ad0-bd3e-4486-936b-e31a8e1d254c.jpg" width="200" /> |

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
