### PR TITLE
Bump resource class for androidauto test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,7 +723,7 @@ jobs:
   androidauto-test:
     executor:
       name: android/android-machine
-      resource-class: large
+      resource-class: xlarge
       tag: 2022.04.1
     steps:
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -735,8 +735,8 @@ jobs:
           steps:
             - checkout
             - android/start-emulator-and-run-tests:
-                post-emulator-launch-assemble-command: ./gradlew libnavui-androidauto:assembleDebugAndroidTest
-                test-command: ./gradlew libnavui-androidauto:connectedDebugAndroidTest
+                post-emulator-launch-assemble-command: ./gradlew libnavui-androidauto:assembleDebugAndroidTest -Dorg.gradle.jvmargs=-Xmx3g
+                test-command: ./gradlew libnavui-androidauto:connectedDebugAndroidTest -Dorg.gradle.jvmargs=-Xmx3g
                 system-image: system-images;android-30;google_apis_playstore;x86
                 wait-for-emulator: false
                 save-gradle-cache: false


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://github.com/mapbox/mapbox-navigation-android/issues/5880

Hitting resource maximums here https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/20650/workflows/dcd0e31b-6a36-4243-ad4c-582bcc05cd12/jobs/104204/resources

> Thank you for adding these. We can indeed see that it's hitting [CPU maximum](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/20650/workflows/dcd0e31b-6a36-4243-ad4c-582bcc05cd12/jobs/104204/resources) on the build - can you please try re-running with an XLarge machine resource > to see how this affects the run?
> 
> Thank you in advance.

^ CircleCi support says to bump the resource class https://support.circleci.com/hc/en-us/requests/116053

Also taking after this jvm bump here this https://github.com/mapbox/1tap-android/pull/2251
