### PR TITLE
Fixed crash caused by ConstantVelocityInterpolator creating PathInterpolator with an invalid path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Replaced `ViewStyleCustomization.defaultMarkerAnnotationOptions` with `ViewStyleCustomization.defaultDestinationMarkerAnnotationOptions`. [#6365](https://github.com/mapbox/mapbox-navigation-android/pull/6365)
 - Fixed the issue with incorrect geometry indices for `RouteLeg#incidents` and `RouteLeg#closures` after refresh. [#6364](https://github.com/mapbox/mapbox-navigation-android/pull/6364)
 - Introduced `NavigationViewListener#onMapClicked` to inform when a map was clicked, but the event was not processed by `NavigationView`. [#6360](https://github.com/mapbox/mapbox-navigation-android/pull/6360)
+- Fixed crash caused by `ConstantVelocityInterpolator` creating `PathInterpolator` with an invalid path. [#6367](https://github.com/mapbox/mapbox-navigation-android/pull/6367)
 
 ## Mapbox Navigation SDK 2.9.0-alpha.2 - 16 September, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolator.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolator.kt
@@ -20,22 +20,16 @@ class ConstantVelocityInterpolator(
         val distances = mutableListOf<Double>()
         var total = 0.0
         keyPoints.fold(startPoint) { prevPoint, point ->
-            val d = distanceTo(prevPoint, point)
-            distances.add(d)
-            total += d
+            val d = distance(prevPoint, point)
+            if (0.0 < d) {
+                distances.add(d)
+                total += d
+            }
             point
         }
 
         innerInterpolator = if (0 < total) {
-            val path = Path()
-            val step = 1.0f / keyPoints.size
-            var pathTime = 0.0
-            keyPoints.forEachIndexed { index, _ ->
-                // simplified from (distances[index] / velocity) where (velocity = total / duration) and duration = 1.0
-                val deltaTime = distances[index] / total
-                pathTime += deltaTime
-                path.lineTo(pathTime.toFloat(), step * (index + 1))
-            }
+            val path = timingPath(distances, total)
             PathInterpolator(path)
         } else {
             TimeInterpolator { it }
@@ -45,7 +39,23 @@ class ConstantVelocityInterpolator(
     override fun getInterpolation(input: Float): Float =
         innerInterpolator.getInterpolation(input)
 
-    private fun distanceTo(p1: Point, p2: Point): Double {
+    private fun distance(p1: Point, p2: Point): Double {
         return hypot(p2.latitude() - p1.latitude(), p2.longitude() - p1.longitude())
+    }
+
+    private fun timingPath(distances: List<Double>, total: Double): Path {
+        val path = Path()
+        val step = 1.0f / distances.size
+        var pathTime = 0.0f
+        // NOTE: The Path must start at (0,0) and end at (1,1)
+        // To avoid PathInterpolator IllegalArgException, we ignore last keypoint distance value
+        // and manually add line to (1,1).
+        for (i in 0..distances.size - 2) {
+            val deltaTime = distances[i] / total
+            pathTime += deltaTime.toFloat()
+            path.lineTo(pathTime, (step * (i + 1)))
+        }
+        path.lineTo(1f, 1f)
+        return path
     }
 }


### PR DESCRIPTION
Fix for NAVAND-238

### Problem

One of our customers detected a crash in one of their applications.
 
```
Happened on calling NavigationLocationProvider.changePosition() with LocationMatcherResult given by Mapbox LocationObserver onNewLocationMatcherResult()
java.lang.IllegalArgumentException: The Path must start at (0,0) and end at (1,1)
	at android.view.animation.PathInterpolator.initPath(PathInterpolator.java:168)
	at android.view.animation.PathInterpolator.<init>(PathInterpolator.java:65)
	at com.mapbox.navigation.ui.maps.internal.location.ConstantVelocityInterpolator.<init>(ConstantVelocityInterpolator.kt:39)
	at com.mapbox.navigation.ui.maps.internal.location.PuckAnimationEvaluator.evaluate(PuckAnimationEvaluator.kt:28)
	at com.mapbox.navigation.ui.maps.internal.location.PuckAnimationEvaluator.evaluate(PuckAnimationEvaluator.kt:16)
	at android.animation.KeyframeSet.getValue(KeyframeSet.java:214)
	at android.animation.PropertyValuesHolder.calculateValue(PropertyValuesHolder.java:1017)
	at android.animation.ValueAnimator.animateValue(ValueAnimator.java:1553)
	at android.animation.ValueAnimator.setCurrentFraction(ValueAnimator.java:684)
	at android.animation.ValueAnimator.setCurrentPlayTime(ValueAnimator.java:647)
	at android.animation.ValueAnimator.start(ValueAnimator.java:1079)
	at android.animation.ValueAnimator.start(ValueAnimator.java:1098)
	at com.mapbox.maps.plugin.locationcomponent.animators.PuckAnimator.animate(PuckAnimator.kt:96)
	at com.mapbox.maps.plugin.locationcomponent.animators.PuckAnimatorManager.animatePosition(PuckAnimatorManager.kt:89)
	at com.mapbox.maps.plugin.locationcomponent.LocationPuckManager.updateCurrentPosition(LocationPuckManager.kt:166)
	at com.mapbox.maps.plugin.locationcomponent.LocationComponentPluginImpl.onLocationUpdated(LocationComponentPluginImpl.kt:278)
	at com.mapbox.navigation.ui.maps.location.NavigationLocationProvider.notifyLocationUpdates(NavigationLocationProvider.kt:160)
	at com.mapbox.navigation.ui.maps.location.NavigationLocationProvider.changePosition(NavigationLocationProvider.kt:132)
	at com.mapbox.navigation.ui.maps.location.NavigationLocationProvider.changePosition$default(NavigationLocationProvider.kt:125)
```

### Investigation and solution introduced in this PR

After a detailed examination of the provided stack trace, we identified the potential root cause. The ConstantVelocityInterpolator is creating PathInterpolator with an invalid path (path must start a (0,0) and end at (1,1)), causing the crash.

Amending the ConstantVelocityInterpolator to always create a path that start at (0,0) and ends at (1,1) should fix the problem.


