### PR TITLE
[Drop-In UI] Implemented logic to refactor margins for action buttons

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
@@ -250,8 +250,8 @@ class ViewStyleCustomization {
         fun defaultCameraModeButtonParams(context: Context) = MapboxExtendableButtonParams(
             R.style.MapboxStyleCameraModeButton,
             context.defaultLayoutParams().apply {
-                bottomMargin = context.defaultSpacing()
                 topMargin = context.defaultSpacing()
+                bottomMargin = context.defaultSpacing()
             },
         )
 
@@ -261,8 +261,19 @@ class ViewStyleCustomization {
         fun defaultRecenterButtonParams(context: Context) = MapboxExtendableButtonParams(
             R.style.DropInStyleRecenterButton,
             context.defaultLayoutParams().apply {
-                bottomMargin = context.defaultSpacing()
                 topMargin = context.defaultSpacing()
+                bottomMargin = context.defaultSpacing()
+            },
+        )
+
+        /**
+         * Default [MapboxAudioGuidanceButton] params.
+         */
+        fun defaultAudioGuidanceButtonParams(context: Context) = MapboxExtendableButtonParams(
+            R.style.MapboxStyleAudioGuidanceButton,
+            context.defaultLayoutParams().apply {
+                topMargin = context.defaultSpacing()
+                bottomMargin = context.defaultSpacing()
             },
         )
 
@@ -291,14 +302,6 @@ class ViewStyleCustomization {
         fun defaultStartNavigationButtonParams(context: Context) = MapboxExtendableButtonParams(
             R.style.DropInStyleStartButton,
             context.defaultLayoutParams(),
-        )
-
-        /**
-         * Default [MapboxAudioGuidanceButton] params.
-         */
-        fun defaultAudioGuidanceButtonParams(context: Context) = MapboxExtendableButtonParams(
-            R.style.MapboxStyleAudioGuidanceButton,
-            context.defaultLayoutParams().apply { bottomMargin = context.defaultSpacing() },
         )
 
         /**

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/ActionButtonBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/binder/ActionButtonBinder.kt
@@ -50,11 +50,11 @@ internal class ActionButtonBinder(
 
         val store = context.store
         return navigationListOf(
-            reloadOnChange(context.styles.audioGuidanceButtonParams) { params ->
-                audioGuidanceButtonComponent(binding, params, store)
-            },
             reloadOnChange(context.styles.cameraModeButtonParams) { params ->
                 cameraModeButtonComponent(binding, params, store)
+            },
+            reloadOnChange(context.styles.audioGuidanceButtonParams) { params ->
+                audioGuidanceButtonComponent(binding, params, store)
             },
             reloadOnChange(context.styles.recenterButtonParams) { params ->
                 recenterButtonComponent(binding, params, store)
@@ -78,13 +78,11 @@ internal class ActionButtonBinder(
             .asReversed()
             .also { startCustomButtonsCount = it.size }
             .onEach { buttonContainer.addView(it.view, 0) }
-            .dropLast(1)
-            .forEach { it.view.setMargins(top = spacing) }
+            .forEach { it.view.setMargins(top = spacing, bottom = spacing) }
         customButtons
             .filter { it.position == ActionButtonDescription.Position.END }
             .onEach { buttonContainer.addView(it.view) }
-            .dropLast(1)
-            .forEach { it.view.setMargins(bottom = spacing) }
+            .forEach { it.view.setMargins(top = spacing, bottom = spacing) }
     }
 
     private fun audioGuidanceButtonComponent(
@@ -168,8 +166,8 @@ internal class ActionButtonBinder(
     }
 
     private companion object {
-        private const val AUDIO_BUTTON_POSITION = 0
-        private const val CAMERA_BUTTON_POSITION = 1
+        private const val AUDIO_BUTTON_POSITION = 1
+        private const val CAMERA_BUTTON_POSITION = 0
         private const val RECENTER_BUTTON_POSITION = 2
     }
 }

--- a/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
@@ -107,7 +107,8 @@
                     android:layout_height="wrap_content"
                     android:gravity="top|right"
                     android:layout_marginEnd="8dp"
-                    app:layout_constraintTop_toTopOf="@id/speedLimitLayout"
+                    android:layout_marginTop="5dp"
+                    app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     tools:layout_height="200dp"
                     tools:background="#eee" />

--- a/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
@@ -99,7 +99,7 @@
                     android:layout_width="@dimen/mapbox_actionList_width"
                     android:layout_height="wrap_content"
                     android:gravity="top|right"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="5dp"
                     android:layout_marginEnd="8dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/guidanceLayout"

--- a/libnavui-dropin/src/main/res/values/dimens.xml
+++ b/libnavui-dropin/src/main/res/values/dimens.xml
@@ -19,7 +19,7 @@
 
     <!-- This width is mapbox_button_size + padding * 2. mapbox_button_size is 56 -->
     <dimen name="mapbox_actionList_width">76dp</dimen>
-    <dimen name="mapbox_actionList_spacing">5dp</dimen>
+    <dimen name="mapbox_actionList_spacing">3dp</dimen>
 
     <!-- Maneuver view -->
     <dimen name="mapbox_maneuver_view_padding">4dp</dimen>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Refs https://github.com/mapbox/mapbox-navigation-android/pull/6355#issuecomment-1255565642

Implementation details:

- Assgined `CameraModeButton` to index 0 and moved `AudioGuidanceButton` to index 1.
- Assigned all action buttons `top` and `bottom` margin of 3dp each
- Assigned `FrameLayout` with id `actionListLayout` a `marginTop=5dp`. Therefore the first action button will be 8dp from parent because of 5dp to the `FrameLayout` + 3dp `marginTop` of the action button.
- Assigned each custom button a `top` and `bottom` margin of 3dp each.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
