### PR TITLE
fixes an issue where `NavigationRoute#upcomingRoadObjects` was not refreshed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed `RoadNameLabel` position issues by making sure that it updates when expanding and collapsing the info panel. [#6361](https://github.com/mapbox/mapbox-navigation-android/pull/6361)
 - Fixed `InfoPanel` overlapping the `RoadNameLabel` in free drive state with the device being in landscape orientation. [#6361](https://github.com/mapbox/mapbox-navigation-android/pull/6361)
 - Introduced `ViewStyleCustomization#mapScalebarParams` that allows for configuring map scalebar. [#6355](https://github.com/mapbox/mapbox-navigation-android/pull/6355)
+- Fixed an issue where `NavigationRoute#upcomingRoadObjects` was not refreshed. This issue did not impact the deprecated `RoadObjectsOnRouteObserver`. [#6378](https://github.com/mapbox/mapbox-navigation-android/pull/6378)
 
 ## Mapbox Navigation SDK 2.9.0-alpha.2 - 16 September, 2022
 ### Changelog

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -139,10 +139,10 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
             val initialRoutes = routeUpdates[0]
             val refreshedRoutes = routeUpdates[1]
 
-            mapboxNavigation.routeProgressUpdates()
+            val routeProgress = mapboxNavigation.routeProgressUpdates()
                 .filter { routeProgress -> isRefreshedRouteDistance(routeProgress) }
                 .first()
-            mapboxNavigation.roadObjectsOnRoute()
+            val roadObjectsFromObserver = mapboxNavigation.roadObjectsOnRoute()
                 .filter { upcomingRoadObjects ->
                     upcomingRoadObjects.size == 2 &&
                         upcomingRoadObjects.map { it.roadObject.id }
@@ -150,6 +150,11 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                 }
                 .first()
 
+            assertEquals(roadObjectsFromObserver, refreshedRoutes.first().upcomingRoadObjects)
+            assertEquals(
+                routeProgress.navigationRoute.upcomingRoadObjects,
+                refreshedRoutes.first().upcomingRoadObjects
+            )
             assertEquals(
                 "the test works only with 2 routes",
                 2,

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/Adapters.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/Adapters.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package com.mapbox.navigation.instrumentation_tests.utils.coroutines
 
 import com.mapbox.api.directions.v5.models.BannerInstructions
@@ -20,6 +22,7 @@ import com.mapbox.navigation.core.trip.session.BannerInstructionsObserver
 import com.mapbox.navigation.core.trip.session.RoadObjectsOnRouteObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
@@ -120,6 +120,13 @@ fun NavigationRoute.updateDirectionsRouteOnly(
 }
 
 /**
+ * Used to rebuild any [NavigationRoute] fields that are backed by a native peer, which might've been refreshed.
+ *
+ * At the moment, all fields are `val`s, so a simple re-instantiation is enough.
+ */
+fun NavigationRoute.refreshNativePeer(): NavigationRoute = copy()
+
+/**
  * Internal API used for testing purposes. Needed to avoid calling native parser from unit tests.
  */
 @TestOnly

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -877,7 +877,7 @@ class MapboxNavigation @VisibleForTesting internal constructor(
                                     processedRoute.route.routeId == passedRoute.id
                                 }
                             }
-                        directionsSession.setRoutes(routes, setRoutesInfo)
+                        directionsSession.setRoutes(processedRoutes.routes, setRoutesInfo)
                         routesSetResult = ExpectedFactory.createValue(
                             RoutesSetSuccess(
                                 ignoredAlternatives.associate {
@@ -927,7 +927,7 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         return tripSession.setRoutes(routes, setRoutesInfo).apply {
             if (this is NativeSetRouteValue) {
                 routeAlternativesController.processAlternativesMetadata(
-                    routes,
+                    this.routes,
                     nativeAlternatives
                 )
             }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NativeSetRouteResult.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/NativeSetRouteResult.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.core.trip.session
 
+import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigator.RouteAlternative
 
 /**
@@ -13,11 +14,12 @@ internal sealed class NativeSetRouteResult
  * @param nativeAlternatives Set routes.
  */
 internal class NativeSetRouteValue(
+    val routes: List<NavigationRoute>,
     val nativeAlternatives: List<RouteAlternative>
 ) : NativeSetRouteResult() {
 
     override fun toString(): String {
-        return "NativeSetRouteValue(nativeAlternatives=$nativeAlternatives)"
+        return "NativeSetRouteValue(routes=$routes, nativeAlternatives=$nativeAlternatives)"
     }
 
     override fun equals(other: Any?): Boolean {
@@ -26,13 +28,16 @@ internal class NativeSetRouteValue(
 
         other as NativeSetRouteValue
 
+        if (routes != other.routes) return false
         if (nativeAlternatives != other.nativeAlternatives) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        return nativeAlternatives.hashCode()
+        var result = routes.hashCode()
+        result = 31 * result + nativeAlternatives.hashCode()
+        return result
     }
 }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationBaseTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationBaseTest.kt
@@ -294,9 +294,12 @@ internal open class MapboxNavigationBaseTest {
             )
         } returns tripSession
         every { tripSession.getRouteProgress() } returns routeProgress
-        coEvery { tripSession.setRoutes(any(), any()) } returns NativeSetRouteValue(
-            nativeAlternatives = emptyList()
-        )
+        coEvery { tripSession.setRoutes(any(), any()) } answers {
+            NativeSetRouteValue(
+                routes = firstArg(),
+                nativeAlternatives = emptyList()
+            )
+        }
     }
 
     private fun mockDirectionSession() {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationSetNavigationRoutesCallbackTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationSetNavigationRoutesCallbackTest.kt
@@ -53,6 +53,7 @@ internal class MapboxNavigationSetNavigationRoutesCallbackTest : MapboxNavigatio
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, initialLegIndex)
                 )
             } returns NativeSetRouteValue(
+                routes,
                 listOf(
                     routeAlternativeWithId(alternativeId1),
                     routeAlternativeWithId(alternativeId2),
@@ -78,7 +79,7 @@ internal class MapboxNavigationSetNavigationRoutesCallbackTest : MapboxNavigatio
                     routes,
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, initialLegIndex)
                 )
-            } returns NativeSetRouteValue(emptyList())
+            } returns NativeSetRouteValue(routes, emptyList())
 
             mapboxNavigation.setNavigationRoutes(routes, initialLegIndex, callback)
 
@@ -121,7 +122,7 @@ internal class MapboxNavigationSetNavigationRoutesCallbackTest : MapboxNavigatio
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP, initialLegIndex),
 
                 )
-            } returns NativeSetRouteValue(emptyList())
+            } returns NativeSetRouteValue(routes, emptyList())
 
             mapboxNavigation.setNavigationRoutes(routes, initialLegIndex, callback)
 
@@ -142,7 +143,7 @@ internal class MapboxNavigationSetNavigationRoutesCallbackTest : MapboxNavigatio
                     routes,
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, initialLegIndex)
                 )
-            } returns NativeSetRouteValue(emptyList())
+            } returns NativeSetRouteValue(routes, emptyList())
 
             mapboxNavigation.setNavigationRoutes(routes, initialLegIndex, callback)
 
@@ -170,6 +171,7 @@ internal class MapboxNavigationSetNavigationRoutesCallbackTest : MapboxNavigatio
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, initialLegIndex)
                 )
             } returns NativeSetRouteValue(
+                routes,
                 listOf(routeAlternativeWithId("bad id 1"), routeAlternativeWithId("bad id 2"))
             )
 
@@ -198,7 +200,10 @@ internal class MapboxNavigationSetNavigationRoutesCallbackTest : MapboxNavigatio
                     routes,
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, initialLegIndex)
                 )
-            } returns NativeSetRouteValue(listOf(routeAlternativeWithId(alternativeId2)))
+            } returns NativeSetRouteValue(
+                routes,
+                listOf(routeAlternativeWithId(alternativeId2))
+            )
 
             mapboxNavigation.setNavigationRoutes(routes, initialLegIndex, callback)
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationSetNavigationRoutesHistoryRecordingTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationSetNavigationRoutesHistoryRecordingTest.kt
@@ -35,7 +35,7 @@ internal class MapboxNavigationSetNavigationRoutesHistoryRecordingTest :
                 routes,
                 BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, initialLegIndex)
             )
-        } returns NativeSetRouteValue(emptyList())
+        } returns NativeSetRouteValue(routes, emptyList())
 
         mapboxNavigation.setNavigationRoutes(routes, initialLegIndex)
 
@@ -69,7 +69,7 @@ internal class MapboxNavigationSetNavigationRoutesHistoryRecordingTest :
                 routes,
                 BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, initialLegIndex)
             )
-        } returns NativeSetRouteValue(emptyList())
+        } returns NativeSetRouteValue(routes, emptyList())
 
         mapboxNavigation.setNavigationRoutes(routes, initialLegIndex)
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -463,7 +463,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         }
         coEvery {
             tripSession.setRoutes(any(), any())
-        } returns NativeSetRouteValue(emptyList())
+        } returns NativeSetRouteValue(newRoutes, emptyList())
 
         createMapboxNavigation()
         mapboxNavigation.setRerouteController(navigationRerouteController)
@@ -521,7 +521,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         }
         coEvery {
             tripSession.setRoutes(any(), any())
-        } returns NativeSetRouteValue(emptyList())
+        } returns NativeSetRouteValue(newRoutes, emptyList())
 
         createMapboxNavigation()
         mapboxNavigation.setRerouteController(oldController)
@@ -571,7 +571,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         }
         coEvery {
             tripSession.setRoutes(any(), any())
-        } returns NativeSetRouteValue(emptyList())
+        } returns NativeSetRouteValue(emptyList(), emptyList())
 
         createMapboxNavigation()
         mapboxNavigation.setRerouteController(oldController)
@@ -858,12 +858,14 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     fun `setRoute pushes the route to the directions session`() = coroutineRule.runBlockingTest {
         createMapboxNavigation()
         val route: NavigationRoute = mockk()
+        val processedRoute: NavigationRoute = mockk()
         val routeOptions = createRouteOptions()
         every { route.routeOptions } returns routeOptions
         every { route.directionsRoute.geometry() } returns "geometry"
         every { route.directionsRoute.legs() } returns emptyList()
 
         val routes = listOf(route)
+        val processedRoutes = listOf(processedRoute)
         val initialLegIndex = 2
 
         coEvery {
@@ -871,12 +873,12 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
                 routes,
                 BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, initialLegIndex)
             )
-        } returns NativeSetRouteValue(emptyList())
+        } returns NativeSetRouteValue(processedRoutes, emptyList())
         mapboxNavigation.setNavigationRoutes(routes, initialLegIndex)
 
         verify(exactly = 1) {
             directionsSession.setRoutes(
-                routes,
+                processedRoutes,
                 BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, initialLegIndex)
             )
         }
@@ -913,16 +915,22 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         coroutineRule.runBlockingTest {
             createMapboxNavigation()
 
-            val routes = emptyList<DirectionsRoute>()
+            val route: DirectionsRoute = createDirectionsRoute(requestUuid = "test1")
+            val processedRoute: NavigationRoute = mockk()
+            val routes = listOf(route)
+            val processedRoutes = listOf(processedRoute)
             val initialLegIndex = 2
 
             coEvery {
                 tripSession.setRoutes(any(), any())
-            } returns NativeSetRouteValue(listOf(mockk()))
+            } returns NativeSetRouteValue(processedRoutes, listOf(mockk()))
             mapboxNavigation.setRoutes(routes, initialLegIndex)
 
             verify(exactly = 1) {
-                directionsSession.setRoutes(any(), match { it.legIndex == initialLegIndex })
+                directionsSession.setRoutes(
+                    processedRoutes,
+                    match { it.legIndex == initialLegIndex }
+                )
             }
         }
 
@@ -1277,11 +1285,11 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         val shortRoutes = listOf<NavigationRoute>(mockk())
         coEvery { tripSession.setRoutes(longRoutes, any()) } coAnswers {
             delay(100L)
-            NativeSetRouteValue(emptyList())
+            NativeSetRouteValue(longRoutes, emptyList())
         }
         coEvery { tripSession.setRoutes(shortRoutes, any()) } coAnswers {
             delay(50L)
-            NativeSetRouteValue(emptyList())
+            NativeSetRouteValue(shortRoutes, emptyList())
         }
 
         pauseDispatcher {
@@ -1323,7 +1331,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
                 )
             }
             coEvery { tripSession.setRoutes(second, any()) } coAnswers {
-                NativeSetRouteValue(emptyList())
+                NativeSetRouteValue(second, emptyList())
             }
 
             val routesUpdates = mutableListOf<RoutesUpdatedResult>()
@@ -1352,7 +1360,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         val shortRoutes = listOf<NavigationRoute>(mockk())
         coEvery { tripSession.setRoutes(shortRoutes, any()) } coAnswers {
             delay(50L)
-            NativeSetRouteValue(emptyList())
+            NativeSetRouteValue(shortRoutes, emptyList())
         }
 
         pauseDispatcher {
@@ -1366,13 +1374,14 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         coroutineRule.runBlockingTest {
             createMapboxNavigation()
             val routes = listOf<NavigationRoute>(mockk())
+            val processedRoutes = listOf<NavigationRoute>(mockk())
             val nativeAlternatives = listOf<RouteAlternative>(mockk())
             coEvery {
                 tripSession.setRoutes(
                     routes,
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, 0)
                 )
-            } returns NativeSetRouteValue(nativeAlternatives)
+            } returns NativeSetRouteValue(processedRoutes, nativeAlternatives)
 
             mapboxNavigation.setNavigationRoutes(routes)
 
@@ -1382,10 +1391,13 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
                     routes,
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, 0)
                 )
-                routeAlternativesController.processAlternativesMetadata(routes, nativeAlternatives)
+                routeAlternativesController.processAlternativesMetadata(
+                    processedRoutes,
+                    nativeAlternatives
+                )
                 routeAlternativesController.resumeUpdates()
                 directionsSession.setRoutes(
-                    routes,
+                    processedRoutes,
                     BasicSetRoutesInfo(RoutesExtra.ROUTES_UPDATE_REASON_NEW, 0)
                 )
             }
@@ -1443,7 +1455,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
                 )
             } coAnswers {
                 delay(100)
-                NativeSetRouteValue(emptyList())
+                NativeSetRouteValue(routes, emptyList())
             }
             every { directionsSession.setRoutes(any(), any()) } answers {
                 every { directionsSession.routes } returns firstArg()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
During the route refresh process all of the `DirectionsRoute` references were refreshed under the `NavigationRoute`'s hood, however, the `NavigationRoute#upcomingRoadObjects` was recreated before the native peer has been updated in `MapboxTripSession`. This PR recreates the `NavigationRoute` again after the native peer is updated so that the data in fields backed by the native peer is up-to-date.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
