### PR TITLE
[Drop-In UI] use maneuver view visibility instead of height

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehavior.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehavior.kt
@@ -9,16 +9,16 @@ internal class ManeuverBehavior {
     private val _maneuverBehavior = MutableStateFlow<MapboxManeuverViewState>(
         MapboxManeuverViewState.COLLAPSED
     )
-    private val _maneuverViewHeight = MutableStateFlow(0)
+    private val _maneuverViewVisibility = MutableStateFlow(false)
 
     val maneuverBehavior = _maneuverBehavior.asStateFlow()
-    val maneuverViewHeight = _maneuverViewHeight.asStateFlow()
+    val maneuverViewVisibility = _maneuverViewVisibility.asStateFlow()
 
     fun updateBehavior(newState: MapboxManeuverViewState) {
         _maneuverBehavior.value = newState
     }
 
-    fun updateViewHeight(newHeight: Int) {
-        _maneuverViewHeight.value = newHeight
+    fun updateViewVisibility(visibility: Boolean) {
+        _maneuverViewVisibility.value = visibility
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImpl.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImpl.kt
@@ -14,7 +14,7 @@ internal class ManeuverComponentContractImpl(
         context.maneuverBehavior.updateBehavior(state)
     }
 
-    override fun onManeuverViewHeightChanged(newHeight: Int) {
-        context.maneuverBehavior.updateViewHeight(newHeight)
+    override fun onManeuverViewVisibilityChanged(isVisible: Boolean) {
+        context.maneuverBehavior.updateViewVisibility(isVisible)
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponent.kt
@@ -14,15 +14,15 @@ import kotlinx.coroutines.launch
 internal class ScalebarPlaceholderComponent(
     private val scalebarPlaceholder: View,
     private val scalebarParams: StateFlow<MapboxMapScalebarParams>,
-    private val maneuverHeight: StateFlow<Int>,
+    private val maneuverViewVisible: StateFlow<Boolean>,
 ) : UIComponent() {
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
         coroutineScope.launch {
-            combine(scalebarParams, maneuverHeight) { params, height ->
+            combine(scalebarParams, maneuverViewVisible) { params, maneuverViewVisible ->
                 scalebarPlaceholder.visibility =
-                    if (params.enabled && height == 0) {
+                    if (params.enabled && !maneuverViewVisible) {
                         View.VISIBLE
                     } else {
                         View.GONE

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/coordinator/ScalebarPlaceholderBinder.kt
@@ -20,7 +20,7 @@ internal class ScalebarPlaceholderBinder(
         return ScalebarPlaceholderComponent(
             binding.scalebarPlaceholder,
             context.styles.mapScalebarParams,
-            context.maneuverBehavior.maneuverViewHeight
+            context.maneuverBehavior.maneuverViewVisibility
         )
     }
 

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehaviorTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverBehaviorTest.kt
@@ -16,11 +16,21 @@ class ManeuverBehaviorTest {
     }
 
     @Test
-    fun `when maneuver view height is updated`() {
+    fun `when maneuver view visibility is updated to true`() {
         val sut = ManeuverBehavior()
 
-        sut.updateViewHeight(43)
+        sut.updateViewVisibility(true)
 
-        assertEquals(43, sut.maneuverViewHeight.value)
+        assertEquals(true, sut.maneuverViewVisibility.value)
+    }
+
+    @Test
+    fun `when maneuver view visibility is updated to false`() {
+        val sut = ManeuverBehavior()
+        sut.updateViewVisibility(true)
+
+        sut.updateViewVisibility(false)
+
+        assertEquals(false, sut.maneuverViewVisibility.value)
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImplTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/maneuver/ManeuverComponentContractImplTest.kt
@@ -29,10 +29,10 @@ class ManeuverComponentContractImplTest {
 
     @Test
     fun `when maneuver view height is changed, contract is notified`() {
-        sut.onManeuverViewHeightChanged(23)
+        sut.onManeuverViewVisibilityChanged(true)
 
         verify {
-            navigationViewContext.maneuverBehavior.updateViewHeight(23)
+            navigationViewContext.maneuverBehavior.updateViewVisibility(true)
         }
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/map/ScalebarPlaceholderComponentTest.kt
@@ -27,26 +27,25 @@ class ScalebarPlaceholderComponentTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val mapboxNavigation = mockk<MapboxNavigation>()
     private val scalebarPlaceholderView = mockk<View>(relaxed = true)
-    private val initialHeight = 7
-    private val heightFlow = MutableStateFlow(initialHeight)
+    private val visibilityFlow = MutableStateFlow(false)
     private val mapScalebarParams = MutableStateFlow(
         MapboxMapScalebarParams.Builder(context).build()
     )
     private val component = ScalebarPlaceholderComponent(
         scalebarPlaceholderView,
         mapScalebarParams,
-        heightFlow
+        visibilityFlow
     )
 
     @Test
-    fun visibilityIsChangedOnOnAttachedHasHeight() {
+    fun visibilityIsChangedOnOnAttachedVisible() {
+        visibilityFlow.tryEmit(true)
         component.onAttached(mapboxNavigation)
         verify { scalebarPlaceholderView.visibility = View.GONE }
     }
 
     @Test
-    fun visibilityIsChangedOnOnAttachedNoHeight() {
-        heightFlow.tryEmit(0)
+    fun visibilityIsChangedOnOnAttachedNotVisible() {
         component.onAttached(mapboxNavigation)
         verify { scalebarPlaceholderView.visibility = View.GONE }
     }
@@ -58,13 +57,14 @@ class ScalebarPlaceholderComponentTest {
     }
 
     @Test
-    fun heightChangeBeforeOnAttached() {
-        heightFlow.tryEmit(8)
+    fun maneuverVisibilityChangeBeforeOnAttached() {
+        visibilityFlow.tryEmit(true)
         verify(exactly = 0) { scalebarPlaceholderView.visibility = any() }
     }
 
     @Test
-    fun mapScalebarParamsChangeAfterOnAttachedHasHeight() {
+    fun mapScalebarParamsChangeAfterOnAttachedVisible() {
+        visibilityFlow.tryEmit(true)
         component.onAttached(mapboxNavigation)
         clearMocks(scalebarPlaceholderView)
         mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
@@ -72,8 +72,7 @@ class ScalebarPlaceholderComponentTest {
     }
 
     @Test
-    fun mapScalebarParamsChangeAfterOnAttachedNoHeight() {
-        heightFlow.tryEmit(0)
+    fun mapScalebarParamsChangeAfterOnAttachedNotVisible() {
         component.onAttached(mapboxNavigation)
         clearMocks(scalebarPlaceholderView)
         mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
@@ -81,20 +80,22 @@ class ScalebarPlaceholderComponentTest {
     }
 
     @Test
-    fun heightChangeAfterOnAttachedHasHeight() {
+    fun maneuverVisibilityChangeAfterOnAttachedVisible() {
         mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
         component.onAttached(mapboxNavigation)
         clearMocks(scalebarPlaceholderView)
-        heightFlow.tryEmit(8)
+        visibilityFlow.tryEmit(true)
         verify { scalebarPlaceholderView.visibility = View.GONE }
     }
 
     @Test
-    fun heightChangeAfterOnAttachedNoHeight() {
+    fun maneuverVisibilityChangeAfterOnAttachedNotVisible() {
+        // so that it will <i>change</i> to false later
+        visibilityFlow.tryEmit(true)
         mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
         component.onAttached(mapboxNavigation)
         clearMocks(scalebarPlaceholderView)
-        heightFlow.tryEmit(0)
+        visibilityFlow.tryEmit(false)
         verify { scalebarPlaceholderView.visibility = View.VISIBLE }
     }
 
@@ -108,12 +109,12 @@ class ScalebarPlaceholderComponentTest {
     }
 
     @Test
-    fun heightChangeAfterOnDetached() {
+    fun maneuverVisibilityChangeAfterOnDetached() {
         mapScalebarParams.tryEmit(MapboxMapScalebarParams.Builder(context).enabled(true).build())
         component.onAttached(mapboxNavigation)
         clearMocks(scalebarPlaceholderView)
         component.onDetached(mapboxNavigation)
-        heightFlow.tryEmit(9)
+        visibilityFlow.tryEmit(true)
         verify(exactly = 0) { scalebarPlaceholderView.visibility = any() }
     }
 }

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponent.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponent.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 
 interface ManeuverComponentContract {
     fun onManeuverViewStateChanged(state: MapboxManeuverViewState)
-    fun onManeuverViewHeightChanged(newHeight: Int)
+    fun onManeuverViewVisibilityChanged(isVisible: Boolean)
 }
 
 @ExperimentalPreviewMapboxNavigationAPI
@@ -43,11 +43,7 @@ class ManeuverComponent(
                 contract?.get()?.onManeuverViewStateChanged(it)
             }
         }
-        coroutineScope.launch {
-            maneuverView.heightFlow.collect {
-                contract?.get()?.onManeuverViewHeightChanged(it)
-            }
-        }
+        contract?.get()?.onManeuverViewVisibilityChanged(true)
         coroutineScope.launch {
             combine(
                 mapboxNavigation.flowRoutesUpdated(),
@@ -78,6 +74,6 @@ class ManeuverComponent(
 
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
         super.onDetached(mapboxNavigation)
-        contract?.get()?.onManeuverViewHeightChanged(0)
+        contract?.get()?.onManeuverViewVisibilityChanged(false)
     }
 }

--- a/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverView.kt
+++ b/libnavui-maneuver/src/main/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverView.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 class MapboxManeuverView : ConstraintLayout {
 
-    private val _heightFlow = MutableStateFlow(0)
     private val _maneuverViewState = MutableStateFlow<MapboxManeuverViewState>(
         MapboxManeuverViewState.COLLAPSED
     )
@@ -54,8 +53,6 @@ class MapboxManeuverView : ConstraintLayout {
      * Observe on [maneuverViewState] to get notified about changes to [MapboxManeuverViewState].
      */
     val maneuverViewState = _maneuverViewState.asStateFlow()
-
-    internal val heightFlow = _heightFlow.asStateFlow()
 
     private var maneuverViewOptions = ManeuverViewOptions.Builder().build()
 
@@ -751,12 +748,5 @@ class MapboxManeuverView : ConstraintLayout {
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     internal fun getUpcomingManeuverAdapter(): MapboxUpcomingManeuverAdapter {
         return upcomingManeuverAdapter
-    }
-
-    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
-        super.onSizeChanged(w, h, oldw, oldh)
-        if (h != oldh) {
-            _heightFlow.tryEmit(h)
-        }
     }
 }

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponentTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/internal/ManeuverComponentTest.kt
@@ -54,7 +54,6 @@ class ManeuverComponentTest {
     @get:Rule
     var coroutineRule = MainCoroutineRule()
 
-    private val initialHeight = 53
     private val maneuverViewOptions = ManeuverViewOptions.Builder().build()
 
     @Before
@@ -309,14 +308,11 @@ class ManeuverComponentTest {
         }
 
     @Test
-    fun `maneuver view height is collected`() =
+    fun `maneuver view visibility is set to true on onAttached`() =
         coroutineRule.runBlockingTest {
             val contract = mockk<ManeuverComponentContract>(relaxed = true) {
                 every { onManeuverViewStateChanged(any()) } just Runs
             }
-            every {
-                maneuverView.heightFlow
-            } returns MutableStateFlow(initialHeight)
             val maneuverComponent =
                 ManeuverComponent(
                     maneuverView = maneuverView,
@@ -331,19 +327,16 @@ class ManeuverComponentTest {
             maneuverComponent.onAttached(mockNavigation)
 
             verify {
-                contract.onManeuverViewHeightChanged(initialHeight)
+                contract.onManeuverViewVisibilityChanged(true)
             }
         }
 
     @Test
-    fun `onDetached proxies zero height`() =
+    fun `maneuver view visibility is set to false on onDetached`() =
         coroutineRule.runBlockingTest {
             val contract = mockk<ManeuverComponentContract>(relaxed = true) {
                 every { onManeuverViewStateChanged(any()) } just Runs
             }
-            every {
-                maneuverView.heightFlow
-            } returns MutableStateFlow(initialHeight)
             val maneuverComponent =
                 ManeuverComponent(
                     maneuverView = maneuverView,
@@ -360,7 +353,7 @@ class ManeuverComponentTest {
             maneuverComponent.onDetached(mockNavigation)
 
             verify {
-                contract.onManeuverViewHeightChanged(0)
+                contract.onManeuverViewVisibilityChanged(false)
             }
         }
 }

--- a/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverViewTest.kt
+++ b/libnavui-maneuver/src/test/java/com/mapbox/navigation/ui/maneuver/view/MapboxManeuverViewTest.kt
@@ -589,19 +589,6 @@ class MapboxManeuverViewTest {
         )
     }
 
-    @Test
-    fun `initial height is zero`() {
-        val view = MapboxManeuverView(ctx)
-        assertEquals(0, view.heightFlow.value)
-    }
-
-    @Test
-    fun `height is changed`() {
-        val view = MapboxManeuverView(ctx)
-        view.layout(10, 10, 50, 60)
-        assertEquals(50, view.heightFlow.value)
-    }
-
     private fun getMockPrimaryManeuver(): PrimaryManeuver {
         val textComponentNode = Component(
             BannerComponents.TEXT,


### PR DESCRIPTION
Follow-up from https://github.com/mapbox/mapbox-navigation-android/pull/6355#discussion_r978906573.