### PR TITLE
[Drop-In UI] add option to override route options used by drop-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+- Introduced `NavigationView.setRouteOptionsInterceptor` that allows to override `RouteOptions` used by `NavigationView`. [#6391](https://github.com/mapbox/mapbox-navigation-android/pull/6391)
 #### Bug fixes and improvements
 - Marked `ReplayProgressObserver`, `MapboxReplayer`, `ReplayLocationEngine`, `RerouteController#RoutesCallback`, `NavigationRerouteController#RoutesCallback`, `LocationObserver`, `NavigationSessionStateObserver`, `OffRouteObserver`, `RouteProgressObserver`, `TripSessionStateObserver`, `VoiceInstructionsObserver` methods with `@UiThread` annotation. [#6266](https://github.com/mapbox/mapbox-navigation-android/pull/6266)
 - Fix crash due to multiple DataStores active. [#6392](https://github.com/mapbox/mapbox-navigation-android/pull/6392)

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -760,12 +760,13 @@ package com.mapbox.navigation.core.routerefresh {
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class RouteRefreshExtra {
     field public static final com.mapbox.navigation.core.routerefresh.RouteRefreshExtra INSTANCE;
+    field public static final String REFRESH_STATE_CANCELED = "CANCELED";
     field public static final String REFRESH_STATE_FINISHED_FAILED = "FINISHED_FAILED";
     field public static final String REFRESH_STATE_FINISHED_SUCCESS = "FINISHED_SUCCESS";
     field public static final String REFRESH_STATE_STARTED = "STARTED";
   }
 
-  @StringDef({com.mapbox.navigation.core.routerefresh.RouteRefreshExtra.REFRESH_STATE_STARTED, com.mapbox.navigation.core.routerefresh.RouteRefreshExtra.REFRESH_STATE_FINISHED_SUCCESS, com.mapbox.navigation.core.routerefresh.RouteRefreshExtra.REFRESH_STATE_FINISHED_FAILED}) @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public static @interface RouteRefreshExtra.RouteRefreshState {
+  @StringDef({com.mapbox.navigation.core.routerefresh.RouteRefreshExtra.REFRESH_STATE_STARTED, com.mapbox.navigation.core.routerefresh.RouteRefreshExtra.REFRESH_STATE_FINISHED_SUCCESS, com.mapbox.navigation.core.routerefresh.RouteRefreshExtra.REFRESH_STATE_FINISHED_FAILED, com.mapbox.navigation.core.routerefresh.RouteRefreshExtra.REFRESH_STATE_CANCELED}) @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) public static @interface RouteRefreshExtra.RouteRefreshState {
   }
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class RouteRefreshStateResult {

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/RoutePreviewStateController.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/RoutePreviewStateController.kt
@@ -1,10 +1,7 @@
 package com.mapbox.navigation.ui.app.internal.controller
 
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
-import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
-import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.NavigationRouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
@@ -59,7 +56,6 @@ class RoutePreviewStateController(private val store: Store) : StateController() 
 
     private fun processRoutesAction(action: RoutePreviewAction): RoutePreviewState {
         return when (action) {
-            is RoutePreviewAction.FetchPoints,
             is RoutePreviewAction.FetchOptions -> {
                 RoutePreviewState.Fetching(0)
             }
@@ -85,13 +81,11 @@ class RoutePreviewStateController(private val store: Store) : StateController() 
     private suspend fun MapboxNavigation.fetchRouteSaga() {
         store.actionsFlowable()
             .filter {
-                it is RoutePreviewAction.FetchPoints ||
-                    it is RoutePreviewAction.FetchOptions ||
+                it is RoutePreviewAction.FetchOptions ||
                     it is DestinationAction.SetDestination
             }
             .map {
                 when (it) {
-                    is RoutePreviewAction.FetchPoints -> routeOptions(it.points)
                     is RoutePreviewAction.FetchOptions -> it.options
                     else -> null
                 }
@@ -113,16 +107,6 @@ class RoutePreviewStateController(private val store: Store) : StateController() 
                     }
                 }
             }
-    }
-
-    private fun MapboxNavigation.routeOptions(points: List<Point>): RouteOptions {
-        return RouteOptions.builder()
-            .applyDefaultNavigationOptions()
-            .applyLanguageAndVoiceUnitOptions(navigationOptions.applicationContext)
-            .layersList(listOf(getZLevel(), null))
-            .coordinatesList(points)
-            .alternatives(true)
-            .build()
     }
 
     private suspend fun MapboxNavigation.fetchRoute(

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RouteOptionsProvider.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RouteOptionsProvider.kt
@@ -1,0 +1,31 @@
+package com.mapbox.navigation.ui.app.internal.routefetch
+
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
+import com.mapbox.navigation.core.MapboxNavigation
+
+class RouteOptionsProvider {
+
+    private var interceptor: (RouteOptions.Builder) -> RouteOptions.Builder = { it }
+
+    fun setInterceptor(interceptor: (RouteOptions.Builder) -> RouteOptions.Builder) {
+        this.interceptor = interceptor
+    }
+
+    fun getOptions(
+        mapboxNavigation: MapboxNavigation,
+        origin: Point,
+        destination: Point,
+    ): RouteOptions {
+        return RouteOptions.builder()
+            .applyDefaultNavigationOptions()
+            .applyLanguageAndVoiceUnitOptions(mapboxNavigation.navigationOptions.applicationContext)
+            .layersList(listOf(mapboxNavigation.getZLevel(), null))
+            .coordinatesList(listOf(origin, destination))
+            .alternatives(true)
+            .let(interceptor)
+            .build()
+    }
+}

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutePreviewAction.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutePreviewAction.kt
@@ -1,18 +1,12 @@
 package com.mapbox.navigation.ui.app.internal.routefetch
 
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.ui.app.internal.Action
 
 sealed class RoutePreviewAction : Action {
-    /**
-     * The action is used to fetch route based on the list of [points].
-     * @param points list of points
-     */
-    data class FetchPoints(val points: List<Point>) : RoutePreviewAction()
 
     /**
      * The action is used to request and set routes based on [RouteOptions].

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/RoutePreviewStateControllerTest.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/RoutePreviewStateControllerTest.kt
@@ -1,9 +1,6 @@
 package com.mapbox.navigation.ui.app.internal.controller
 
 import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.geojson.Point
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
-import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.NavigationRouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
@@ -20,7 +17,6 @@ import com.mapbox.navigation.ui.app.testing.TestStore
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.unmockkAll
@@ -33,26 +29,22 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.util.Locale
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalPreviewMapboxNavigationAPI::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class RoutePreviewStateControllerTest {
 
     @get:Rule
     val loggerRule = LoggingFrontendTestRule()
 
     @get:Rule
-    var coroutineRule = MainCoroutineRule()
+    val coroutineRule = MainCoroutineRule()
 
-    private lateinit var store: TestStore
-    private lateinit var sut: RoutePreviewStateController
+    private val store = spyk(TestStore())
+    private val sut = RoutePreviewStateController(store)
 
     @Before
     fun setUp() {
-        mockkStatic("com.mapbox.navigation.base.internal.extensions.ContextEx")
         mockkObject(MapboxNavigationApp)
-        store = spyk(TestStore())
-        sut = RoutePreviewStateController(store)
     }
 
     @After
@@ -62,37 +54,15 @@ internal class RoutePreviewStateControllerTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `onAttached should cancel previous route requests when FetchPoints action is dispatched`() {
-        val points = listOf(
-            Point.fromLngLat(1.0, 1.0),
-            Point.fromLngLat(2.0, 2.0)
-        )
-        val mapboxNavigation = mockMapboxNavigation()
-        every {
-            mapboxNavigation.requestRoutes(any(), ofType(NavigationRouterCallback::class))
-        } returnsMany listOf(1L, 2L, 3L)
-
-        sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchPoints(points))
-        store.dispatch(RoutePreviewAction.FetchPoints(points))
-
-        verify { mapboxNavigation.cancelRouteRequest(1L) }
-    }
-
-    @Test
-    @Suppress("MaxLineLength")
     fun `onAttached should cancel previous route requests when SetDestination action is dispatched`() {
-        val points = listOf(
-            Point.fromLngLat(1.0, 1.0),
-            Point.fromLngLat(2.0, 2.0)
-        )
+        val options = mockk<RouteOptions>()
         val mapboxNavigation = mockMapboxNavigation()
         every {
-            mapboxNavigation.requestRoutes(any(), ofType(NavigationRouterCallback::class))
+            mapboxNavigation.requestRoutes(options, ofType(NavigationRouterCallback::class))
         } returnsMany listOf(1L, 2L, 3L)
 
         sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchPoints(points))
+        store.dispatch(RoutePreviewAction.FetchOptions(options))
         store.dispatch(DestinationAction.SetDestination(null))
 
         verify { mapboxNavigation.cancelRouteRequest(1L) }
@@ -151,99 +121,6 @@ internal class RoutePreviewStateControllerTest {
         sut.onAttached(mapboxNavigation)
 
         assertTrue(store.state.value.previewRoutes is RoutePreviewState.Empty)
-    }
-
-    @Test
-    fun `RoutePreviewAction FetchPoints will request routes with default options`() {
-        val mapboxNavigation = mockMapboxNavigation()
-
-        sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchPoints(mockRoutePoints()))
-
-        assertTrue(store.state.value.previewRoutes is RoutePreviewState.Fetching)
-        verify { mapboxNavigation.requestRoutes(any(), any<NavigationRouterCallback>()) }
-    }
-
-    @Test
-    fun `RoutePreviewAction FetchPoints is canceled when onDetached is called`() {
-        val mapboxNavigation = mockMapboxNavigation()
-        every { mapboxNavigation.requestRoutes(any(), any<NavigationRouterCallback>()) } answers {
-            123L
-        }
-
-        sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchPoints(mockRoutePoints()))
-        sut.onDetached(mapboxNavigation)
-
-        verify { mapboxNavigation.cancelRouteRequest(123L) }
-    }
-
-    @Test
-    fun `RoutePreviewAction FetchPoints will cancel previous`() {
-        val mapboxNavigation = mockMapboxNavigation()
-
-        sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchPoints(mockRoutePoints()))
-
-        assertTrue(store.state.value.previewRoutes is RoutePreviewState.Fetching)
-        verify { mapboxNavigation.requestRoutes(any(), any<NavigationRouterCallback>()) }
-    }
-
-    @Test
-    fun `RoutePreviewAction FetchPoints will go to Ready state when onRoutesReady`() {
-        val mapboxNavigation = mockMapboxNavigation()
-        val routes = listOf<NavigationRoute>(mockk())
-        val callbackSlot = slot<NavigationRouterCallback>()
-        every { mapboxNavigation.requestRoutes(any(), capture(callbackSlot)) } returns 123L
-
-        sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchPoints(mockRoutePoints()))
-        callbackSlot.captured.onRoutesReady(routes, mockk())
-        sut.onDetached(mapboxNavigation)
-
-        val readyState = store.state.value.previewRoutes as? RoutePreviewState.Ready
-        assertNotNull(readyState)
-        assertEquals(readyState?.routes, routes)
-        verify(exactly = 0) { mapboxNavigation.cancelRouteRequest(123L) }
-    }
-
-    @Test
-    fun `RoutePreviewAction FetchPoints will go to Failed state when onFailure`() {
-        val mapboxNavigation = mockMapboxNavigation()
-        val reasons = listOf<RouterFailure>(mockk())
-        val routeOptions = mockk<RouteOptions>()
-        val callbackSlot = slot<NavigationRouterCallback>()
-        every { mapboxNavigation.requestRoutes(any(), capture(callbackSlot)) } returns 123L
-
-        sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchPoints(mockRoutePoints()))
-        callbackSlot.captured.onFailure(reasons, routeOptions)
-        sut.onDetached(mapboxNavigation)
-
-        val readyState = store.state.value.previewRoutes as? RoutePreviewState.Failed
-        assertNotNull(readyState)
-        assertEquals(readyState?.reasons, reasons)
-        assertEquals(readyState?.routeOptions, routeOptions)
-        verify(exactly = 0) { mapboxNavigation.cancelRouteRequest(123L) }
-    }
-
-    @Test
-    fun `RoutePreviewAction FetchPoints will go to Canceled state when onCanceled`() {
-        val mapboxNavigation = mockMapboxNavigation()
-        val routeOptions = mockk<RouteOptions>()
-        val routerOrigin = mockk<RouterOrigin>()
-        val callbackSlot = slot<NavigationRouterCallback>()
-        every { mapboxNavigation.requestRoutes(any(), capture(callbackSlot)) } returns 123L
-
-        sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchPoints(mockRoutePoints()))
-        callbackSlot.captured.onCanceled(routeOptions, routerOrigin)
-        sut.onDetached(mapboxNavigation)
-
-        val readyState = store.state.value.previewRoutes as? RoutePreviewState.Canceled
-        assertNotNull(readyState)
-        assertEquals(readyState?.routeOptions, routeOptions)
-        assertEquals(readyState?.routerOrigin, routerOrigin)
     }
 
     @Test
@@ -326,25 +203,8 @@ internal class RoutePreviewStateControllerTest {
     }
 
     private fun mockMapboxNavigation(): MapboxNavigation {
-        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
-            every { getZLevel() } returns 9
-            every { navigationOptions } returns mockk {
-                every { navigationOptions } returns mockk {
-                    every { applicationContext } returns mockk {
-                        every { inferDeviceLocale() } returns Locale.ENGLISH
-                        every { resources } returns mockk {
-                            every { configuration } returns mockk()
-                        }
-                    }
-                }
-            }
-        }
+        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
         every { MapboxNavigationApp.current() } returns mapboxNavigation
         return mapboxNavigation
     }
-
-    private fun mockRoutePoints() = listOf(
-        Point.fromLngLat(-122.2750659, 37.8052036),
-        Point.fromLngLat(-122.2647245, 37.8138895)
-    )
 }

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -56,6 +56,7 @@ package com.mapbox.navigation.dropin {
     method public androidx.lifecycle.Lifecycle getLifecycle();
     method public void registerMapObserver(com.mapbox.navigation.dropin.MapViewObserver observer);
     method public void removeListener(com.mapbox.navigation.dropin.NavigationViewListener listener);
+    method public void setRouteOptionsInterceptor(com.mapbox.navigation.dropin.RouteOptionsInterceptor? routeOptionsInterceptor);
     method public void unregisterMapObserver(com.mapbox.navigation.dropin.MapViewObserver observer);
     property public final com.mapbox.navigation.dropin.NavigationViewApi api;
   }
@@ -124,6 +125,10 @@ package com.mapbox.navigation.dropin {
     method public void onRouteFetchSuccessful(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
     method public void onRouteFetching(long requestId);
     method public void onRoutePreview();
+  }
+
+  public fun interface RouteOptionsInterceptor {
+    method public com.mapbox.api.directions.v5.models.RouteOptions.Builder intercept(com.mapbox.api.directions.v5.models.RouteOptions.Builder builder);
   }
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class ViewBinderCustomization {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
+import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.maps.MapView
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.options.NavigationOptions
@@ -217,6 +218,19 @@ class NavigationView @JvmOverloads constructor(
      */
     fun unregisterMapObserver(observer: MapViewObserver) {
         navigationContext.mapViewOwner.unregisterObserver(observer)
+    }
+
+    /**
+     * Set [RouteOptionsInterceptor]. It allows to modify default [RouteOptions.Builder].
+     */
+    fun setRouteOptionsInterceptor(routeOptionsInterceptor: RouteOptionsInterceptor?) {
+        if (routeOptionsInterceptor != null) {
+            navigationContext.routeOptionsProvider.setInterceptor { routeOptions ->
+                routeOptionsInterceptor.intercept(routeOptions)
+            }
+        } else {
+            navigationContext.routeOptionsProvider.setInterceptor { it }
+        }
     }
 
     private inline fun <reified T : ViewModel> lazyViewModel(): Lazy<T> = lazy {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewContext.kt
@@ -14,6 +14,7 @@ import com.mapbox.navigation.dropin.util.BitmapMemoryCache
 import com.mapbox.navigation.dropin.util.BitmapMemoryCache.Companion.MB_IN_BYTES
 import com.mapbox.navigation.ui.app.internal.SharedApp
 import com.mapbox.navigation.ui.app.internal.Store
+import com.mapbox.navigation.ui.app.internal.routefetch.RouteOptionsProvider
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.utils.internal.Provider
 import com.mapbox.navigation.ui.utils.internal.getValue
@@ -58,6 +59,7 @@ internal class NavigationViewContext(
         )
     }
     val locationProvider = NavigationLocationProvider()
+    val routeOptionsProvider = RouteOptionsProvider()
 
     fun mapAnnotationFactory() = MapMarkerFactory(
         context,

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/RouteOptionsInterceptor.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/RouteOptionsInterceptor.kt
@@ -1,0 +1,16 @@
+package com.mapbox.navigation.dropin
+
+import com.mapbox.api.directions.v5.models.RouteOptions
+
+/**
+ * Interface allowing to modify [RouteOptions.Builder] during a route request with [NavigationView].
+ */
+fun interface RouteOptionsInterceptor {
+
+    /**
+     * Allows to modify [RouteOptions.Builder] before a route request is sent.
+     *
+     * @param builder with initial route options
+     */
+    fun intercept(builder: RouteOptions.Builder): RouteOptions.Builder
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/RoutePreviewButtonComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/RoutePreviewButtonComponent.kt
@@ -9,6 +9,7 @@ import com.mapbox.navigation.dropin.internal.extensions.recreateButton
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.extension.dispatch
 import com.mapbox.navigation.ui.app.internal.fetchRouteAndShowRoutePreview
+import com.mapbox.navigation.ui.app.internal.routefetch.RouteOptionsProvider
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import kotlinx.coroutines.flow.StateFlow
 
@@ -17,6 +18,7 @@ internal class RoutePreviewButtonComponent(
     private val store: Store,
     private val buttonContainer: ViewGroup,
     private val buttonParams: StateFlow<MapboxExtendableButtonParams>,
+    private val routeOptionsProvider: RouteOptionsProvider,
 ) : UIComponent() {
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
@@ -25,7 +27,9 @@ internal class RoutePreviewButtonComponent(
         buttonParams.observe { params ->
             buttonContainer.recreateButton(params).let {
                 it.onClick(coroutineScope) {
-                    store.dispatch(fetchRouteAndShowRoutePreview())
+                    store.dispatch(
+                        fetchRouteAndShowRoutePreview(routeOptionsProvider, mapboxNavigation),
+                    )
                 }
             }
         }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/StartNavigationButtonComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/component/infopanel/StartNavigationButtonComponent.kt
@@ -9,6 +9,7 @@ import com.mapbox.navigation.dropin.internal.extensions.recreateButton
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.extension.dispatch
 import com.mapbox.navigation.ui.app.internal.fetchRouteAndStartActiveNavigation
+import com.mapbox.navigation.ui.app.internal.routefetch.RouteOptionsProvider
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import kotlinx.coroutines.flow.StateFlow
 
@@ -17,6 +18,7 @@ internal class StartNavigationButtonComponent(
     private val store: Store,
     private val buttonContainer: ViewGroup,
     private val buttonParams: StateFlow<MapboxExtendableButtonParams>,
+    private val routeOptionsProvider: RouteOptionsProvider,
 ) : UIComponent() {
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
@@ -25,7 +27,9 @@ internal class StartNavigationButtonComponent(
         buttonParams.observe { params ->
             buttonContainer.recreateButton(params).let {
                 it.onClick(coroutineScope) {
-                    store.dispatch(fetchRouteAndStartActiveNavigation())
+                    store.dispatch(
+                        fetchRouteAndStartActiveNavigation(routeOptionsProvider, mapboxNavigation),
+                    )
                 }
             }
         }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/NavigationViewContextEx.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/NavigationViewContextEx.kt
@@ -22,11 +22,21 @@ internal fun NavigationViewContext.poiNameComponent(textView: AppCompatTextView)
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal fun NavigationViewContext.routePreviewButtonComponent(buttonContainer: ViewGroup) =
-    RoutePreviewButtonComponent(store, buttonContainer, styles.routePreviewButtonParams)
+    RoutePreviewButtonComponent(
+        store,
+        buttonContainer,
+        styles.routePreviewButtonParams,
+        routeOptionsProvider,
+    )
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal fun NavigationViewContext.startNavigationButtonComponent(buttonContainer: ViewGroup) =
-    StartNavigationButtonComponent(store, buttonContainer, styles.startNavigationButtonParams)
+    StartNavigationButtonComponent(
+        store,
+        buttonContainer,
+        styles.startNavigationButtonParams,
+        routeOptionsProvider,
+    )
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal fun NavigationViewContext.endNavigationButtonComponent(

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/infopanel/StartNavigationButtonComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/component/infopanel/StartNavigationButtonComponentTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.dropin.component.infopanel
 
-import android.content.Context
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.test.core.app.ApplicationProvider
@@ -42,14 +41,7 @@ import org.robolectric.RobolectricTestRunner
 class StartNavigationButtonComponentTest {
 
     @get:Rule
-    var coroutineRule = MainCoroutineRule()
-
-    private lateinit var store: TestStore
-    private lateinit var button: MapboxExtendableButton
-    private lateinit var buttonParams: MutableStateFlow<MapboxExtendableButtonParams>
-    private lateinit var buttonContainer: ViewGroup
-    private lateinit var mapboxNavigation: MapboxNavigation
-    private lateinit var sut: StartNavigationButtonComponent
+    val coroutineRule = MainCoroutineRule()
 
     private val layoutParams: LinearLayout.LayoutParams = mockk(relaxed = true)
     private val initialParams =
@@ -57,19 +49,17 @@ class StartNavigationButtonComponentTest {
     private val updatedParams =
         MapboxExtendableButtonParams(R.style.DropInStyleRecenterButton, layoutParams)
 
+    private val store = spyk(TestStore())
+    private val button = spyk(MapboxExtendableButton(ApplicationProvider.getApplicationContext()))
+    private val buttonParams = MutableStateFlow(initialParams)
+    private val buttonContainer = mockk<ViewGroup>(relaxed = true)
+    private val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+    private val sut = StartNavigationButtonComponent(store, buttonContainer, buttonParams, mockk())
+
     @Before
     fun setUp() {
-        val context: Context = ApplicationProvider.getApplicationContext()
-        mapboxNavigation = mockk(relaxed = true)
-        store = spyk(TestStore())
-        button = spyk(MapboxExtendableButton(context))
-        buttonParams = MutableStateFlow(initialParams)
-        buttonContainer = mockk(relaxed = true)
-
         mockkStatic("com.mapbox.navigation.dropin.internal.extensions.ViewGroupExKt")
         every { buttonContainer.recreateButton(any()) } returns button
-
-        sut = StartNavigationButtonComponent(store, buttonContainer, buttonParams)
     }
 
     @Test
@@ -116,7 +106,7 @@ class StartNavigationButtonComponentTest {
     }
 
     @Test
-    fun `onClick startNavigation should NOT FetchPoints when already in Ready state`() =
+    fun `onClick startNavigation should NOT FetchOptions when already in Ready state`() =
         runBlockingTest {
             val origPoint = Point.fromLngLat(1.0, 2.0)
             val destPoint = Point.fromLngLat(2.0, 3.0)
@@ -139,8 +129,7 @@ class StartNavigationButtonComponentTest {
             button.performClick()
 
             verify(exactly = 0) {
-                val action = RoutePreviewAction.FetchPoints(listOf(origPoint, destPoint))
-                store.dispatch(action)
+                store.dispatch(ofType<RoutePreviewAction.FetchOptions>())
             }
         }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/ui/app/internal/routefetch/RouteOptionsProviderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/ui/app/internal/routefetch/RouteOptionsProviderTest.kt
@@ -1,0 +1,70 @@
+package com.mapbox.navigation.ui.app.internal.routefetch
+
+import android.content.Context
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
+import com.mapbox.navigation.core.MapboxNavigation
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+class RouteOptionsProviderTest {
+
+    private val routeOptionsProvider = RouteOptionsProvider()
+    private val mapboxNavigation by lazy {
+        mockk<MapboxNavigation> {
+            every { getZLevel() } returns Z_LEVEL
+            every { navigationOptions } returns mockk {
+                every { applicationContext } returns mockk {
+                    every { inferDeviceLocale() } returns Locale.ENGLISH
+                }
+            }
+        }
+    }
+    private val origin = Point.fromLngLat(1.0, 2.0)
+    private val destination = Point.fromLngLat(3.0, 4.0)
+    private val routeOptions = mockk<RouteOptions>()
+    private val optionsBuilder = mockk<RouteOptions.Builder> {
+        every { build() } returns routeOptions
+    }
+    private val interceptor: (RouteOptions.Builder) -> RouteOptions.Builder = { optionsBuilder }
+
+    @Before
+    fun `set up`() {
+        mockkStatic(Context::inferDeviceLocale)
+    }
+
+    @After
+    fun `tear down`() {
+        unmockkStatic(Context::inferDeviceLocale)
+    }
+
+    @Test
+    fun `provider returns default options if interceptor is not set`() {
+        val options = routeOptionsProvider.getOptions(mapboxNavigation, origin, destination)
+
+        assertEquals(listOf(Z_LEVEL, null), options.layersList())
+        assertEquals(listOf(origin, destination), options.coordinatesList())
+        assertEquals(true, options.alternatives())
+    }
+
+    @Test
+    fun `provider returns options from interceptor if set`() {
+        routeOptionsProvider.setInterceptor(interceptor)
+
+        val options = routeOptionsProvider.getOptions(mapboxNavigation, origin, destination)
+
+        assertEquals(options, routeOptions)
+    }
+
+    private companion object {
+        private const val Z_LEVEL = 9
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -19,4 +19,5 @@ class CustomizedViewModel : ViewModel() {
     val distanceFormatterMetric = MutableLiveData(false)
     val showCameraDebugInfo = MutableLiveData(false)
     val enableScalebar = MutableLiveData(false)
+    val routingProfile = MutableLiveData("--")
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -22,6 +22,7 @@ import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.MutableLiveData
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
 import com.mapbox.maps.MapView
@@ -324,10 +325,17 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             viewModel.showCameraDebugInfo,
             ::toggleShowCameraDebugInfo
         )
+
         bindSwitch(
             menuBinding.toggleEnableScalebar,
             viewModel.enableScalebar,
             ::toggleEnableScalebar
+        )
+
+        bindSpinner(
+            menuBinding.spinnerProfile,
+            viewModel.routingProfile,
+            ::setRoutingProfile,
         )
     }
 
@@ -667,13 +675,25 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
         }
     }
 
+    private fun setRoutingProfile(profile: String) {
+        val routingProfile = when (profile) {
+            "DRIVING-TRAFFIC" -> DirectionsCriteria.PROFILE_DRIVING_TRAFFIC
+            "DRIVING" -> DirectionsCriteria.PROFILE_DRIVING
+            "WALKING" -> DirectionsCriteria.PROFILE_WALKING
+            "CYCLING" -> DirectionsCriteria.PROFILE_CYCLING
+            else -> {
+                binding.navigationView.setRouteOptionsInterceptor(null)
+                return
+            }
+        }
+        binding.navigationView.setRouteOptionsInterceptor { defaultBuilder ->
+            defaultBuilder.layers(null).applyDefaultNavigationOptions(routingProfile)
+        }
+    }
+
     private fun customActionButton(text: String): View {
         return AppCompatTextView(this).apply {
-            val w = resources.getDimensionPixelSize(R.dimen.mapbox_actionList_width)
-            layoutParams = ViewGroup.MarginLayoutParams(
-                72.dp,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-            )
+            layoutParams = ViewGroup.MarginLayoutParams(72.dp, WRAP_CONTENT)
             setPadding(0, 20.dp, 0, 20.dp)
             gravity = Gravity.CENTER
             setTextColor(Color.BLACK)

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -38,6 +38,30 @@
                 android:text="enable replay"
                 android:textAllCaps="true" />
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="40dp"
+                android:gravity="center_vertical"
+                android:paddingVertical="10dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAllCaps="true"
+                    android:textColor="@color/colorOnSurface"
+                    android:text="Routing profile" />
+
+                <androidx.appcompat.widget.AppCompatSpinner
+                    android:id="@+id/spinnerProfile"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="5dp"
+                    android:entries="@array/drop_in_routing_profile"
+                    android:spinnerMode="dropdown" />
+
+            </LinearLayout>
+
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/toggleTheme"
                 android:layout_width="match_parent"

--- a/qa-test-app/src/main/res/values/strings.xml
+++ b/qa-test-app/src/main/res/values/strings.xml
@@ -63,4 +63,11 @@
         <item>SMALL</item>
         <item>LARGE</item>
     </string-array>
+    <string-array name="drop_in_routing_profile" translatable="false">
+        <item>--</item>
+        <item>DRIVING-TRAFFIC</item>
+        <item>DRIVING</item>
+        <item>WALKING</item>
+        <item>CYCLING</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
### Description
Closes #6017. 
In `MapboxNavigationViewCustomizedActivity` I added an example of how customers can change routing profile. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
