### PR TITLE
Fix data store crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 #### Bug fixes and improvements
 - Marked `ReplayProgressObserver`, `MapboxReplayer`, `ReplayLocationEngine`, `RerouteController#RoutesCallback`, `NavigationRerouteController#RoutesCallback`, `LocationObserver`, `NavigationSessionStateObserver`, `OffRouteObserver`, `RouteProgressObserver`, `TripSessionStateObserver`, `VoiceInstructionsObserver` methods with `@UiThread` annotation. [#6266](https://github.com/mapbox/mapbox-navigation-android/pull/6266)
+- Fix crash due to multiple DataStores active. [#6392](https://github.com/mapbox/mapbox-navigation-android/pull/6392)
 
 ## Mapbox Navigation SDK 2.9.0-alpha.3 - 23 September, 2022
 ### Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Mapbox welcomes participation and contributions from everyone.
 ### Changelog
 [Changes between v2.9.0-alpha.2 and v2.9.0-alpha.3](https://github.com/mapbox/mapbox-navigation-android/compare/v2.9.0-alpha.2...v2.9.0-alpha.3)
 
+#### Known issues
+
+:bangbang: `MapboxAudioGuidance` crashes when attached to new instances of `MapboxNavigation`. This will crash `ui-androidauto` and `ui-dropin`. There is no known work around and it will be fixed in 2.9.0-alpha.4. [#6392](https://github.com/mapbox/mapbox-navigation-android/pull/6392)
+
 #### Features
 - Moved `MapboxAudioGuidance` and `MapboxAudioGuidanceState` into public api. [#6336](https://github.com/mapbox/mapbox-navigation-android/pull/6336)
 - Introduced `ViewOptionsCustomization.showCameraDebugInfo` to allow end users to enable camera debug info. [#6356](https://github.com/mapbox/mapbox-navigation-android/pull/6356)

--- a/libnavui-util/src/main/java/com/mapbox/navigation/ui/utils/internal/datastore/NavigationDataStoreOwner.kt
+++ b/libnavui-util/src/main/java/com/mapbox/navigation/ui/utils/internal/datastore/NavigationDataStoreOwner.kt
@@ -11,10 +11,9 @@ import kotlinx.coroutines.flow.map
 /**
  * Implementation for preferences that exist beyond app and car sessions.
  */
-class NavigationDataStoreOwner(context: Context, storeName: String) {
+class NavigationDataStoreOwner(context: Context) {
 
-    private val Context.dataStore by preferencesDataStore(storeName)
-    private var dataStore: DataStore<Preferences> = context.dataStore
+    private val dataStore: DataStore<Preferences> = context.dataStore
 
     fun <T> read(key: NavigationDataStoreKey<T>): Flow<T> {
         return dataStore.data.map { preferences ->
@@ -26,5 +25,10 @@ class NavigationDataStoreOwner(context: Context, storeName: String) {
         dataStore.edit { preferences ->
             preferences[key.preferenceKey] = value ?: key.defaultValue
         }
+    }
+
+    private companion object {
+        private const val NAVIGATION_DATA_STORE_NAME = "mapbox_navigation_preferences"
+        private val Context.dataStore by preferencesDataStore(name = NAVIGATION_DATA_STORE_NAME)
     }
 }

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidance.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidance.kt
@@ -54,7 +54,7 @@ internal constructor(
      */
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         val context = mapboxNavigation.navigationOptions.applicationContext
-        dataStoreOwner = audioGuidanceServices.dataStoreOwner(context, DEFAULT_DATA_STORE_NAME)
+        dataStoreOwner = audioGuidanceServices.dataStoreOwner(context)
         configOwner = audioGuidanceServices.configOwner(context)
         mapboxVoiceInstructions.registerObservers(mapboxNavigation)
         job = scope.launch {
@@ -198,7 +198,6 @@ internal constructor(
     companion object {
         private val STORE_AUDIO_GUIDANCE_MUTED =
             booleanDataStoreKey("audio_guidance_muted", false)
-        private const val DEFAULT_DATA_STORE_NAME = "mapbox_navigation_preferences"
 
         /**
          * Construct an instance without registering to [MapboxNavigationApp].

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/impl/MapboxAudioGuidanceServices.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/impl/MapboxAudioGuidanceServices.kt
@@ -46,6 +46,5 @@ class MapboxAudioGuidanceServices {
 
     fun configOwner(context: Context): NavigationConfigOwner = NavigationConfigOwner(context)
 
-    fun dataStoreOwner(context: Context, storeName: String) =
-        NavigationDataStoreOwner(context, storeName)
+    fun dataStoreOwner(context: Context) = NavigationDataStoreOwner(context)
 }

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/TestMapboxAudioGuidanceServices.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/TestMapboxAudioGuidanceServices.kt
@@ -63,7 +63,7 @@ class TestMapboxAudioGuidanceServices(
         every { mapboxVoiceInstructions() } returns mapboxVoiceInstructions
         every { mapboxAudioGuidanceVoice(any(), any()) } returns mapboxAudioGuidanceVoice
         every { configOwner(any()) } returns carAppConfigOwner
-        every { dataStoreOwner(any(), any()) } returns dataStoreOwner
+        every { dataStoreOwner(any()) } returns dataStoreOwner
     }
 
     fun emitVoiceInstruction(state: MapboxVoiceInstructions.State) {

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidanceTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidanceTest.kt
@@ -204,7 +204,7 @@ class MapboxAudioGuidanceTest {
                 mapboxAudioGuidanceServices.mapboxVoiceInstructions()
             }
             verifySequence {
-                mapboxAudioGuidanceServices.dataStoreOwner(any(), any())
+                mapboxAudioGuidanceServices.dataStoreOwner(any())
                 mapboxAudioGuidanceServices.configOwner(any())
                 mapboxAudioGuidanceServices.mapboxAudioGuidanceVoice(any(), "en")
                 mapboxAudioGuidanceServices.mapboxAudioGuidanceVoice(any(), voiceLanguage)


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

This crash was introduced in [v2.9.0-alpha.3](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.9.0-alpha.3) by https://github.com/mapbox/mapbox-navigation-android/pull/6336

Steps to reproduce
1. Open qa-test-app
2. Launch Default NavigationView
3. go back
4. Launch Default NavigationVIew
5. 💥 

Essentially, the owner of `NavigationDataStoreOwner` has always been a singleton so we never saw this issue. To ensure `NavigationDataStoreOwner` can be used by non-singleton entities. It makes sense for the DataStore lifecycle to be owned by NavigationDataStoreOwner, and it fixes the crash.

It is spelled out pretty clearly by the `preferencesDataStore` that this needs to have a lifecycle.
> Creates a property delegate for a single process DataStore. This should only be called once in a file (at the top level), and all usages of the DataStore should use a reference the same Instance. The receiver type for the property delegate must be an instance of Context.

Here's the stack trace in case anyone comes looking for the issue

```
java.lang.IllegalStateException: There are multiple DataStores active for the same file: /data/user/0/com.mapbox.navigation.qa_test_app/files/datastore/mapbox_navigation_preferences.preferences_pb. You should either maintain your DataStore as a singleton or confirm that there is no two DataStore's active on the same file (by confirming that the scope is cancelled).
    at androidx.datastore.core.SingleProcessDataStore$file$2.invoke(SingleProcessDataStore.kt:168)
    at androidx.datastore.core.SingleProcessDataStore$file$2.invoke(SingleProcessDataStore.kt:163)
    at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
    at androidx.datastore.core.SingleProcessDataStore.getFile(SingleProcessDataStore.kt:163)
    at androidx.datastore.core.SingleProcessDataStore.readData(SingleProcessDataStore.kt:380)
    at androidx.datastore.core.SingleProcessDataStore.readDataOrHandleCorruption(SingleProcessDataStore.kt:359)
    at androidx.datastore.core.SingleProcessDataStore.readAndInit(SingleProcessDataStore.kt:322)
    at androidx.datastore.core.SingleProcessDataStore.readAndInitOrPropagateFailure(SingleProcessDataStore.kt:311)
    at androidx.datastore.core.SingleProcessDataStore.handleRead(SingleProcessDataStore.kt:261)
    at androidx.datastore.core.SingleProcessDataStore.access$handleRead(SingleProcessDataStore.kt:76)
    at androidx.datastore.core.SingleProcessDataStore$actor$3.invokeSuspend(SingleProcessDataStore.kt:239)
    at androidx.datastore.core.SingleProcessDataStore$actor$3.invoke(Unknown Source:8)
    at androidx.datastore.core.SingleProcessDataStore$actor$3.invoke(Unknown Source:4)
    at androidx.datastore.core.SimpleActor$offer$2.invokeSuspend(SimpleActor.kt:122)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```