### PR TITLE
[Drop-In UI] NAVAND-690: fix a potential crash when adding action buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fix crash due to multiple DataStores active. [#6392](https://github.com/mapbox/mapbox-navigation-android/pull/6392)
 - Replaced `NavigationViewApiError` error classes with single error class that accepts `NavigationViewApiErrorTypes`. [#6390](https://github.com/mapbox/mapbox-navigation-android/pull/6390)
 - Fixed the issue where `AlternativeRouteMetadata` instances were not updated when alternative routes were refreshed. The issue did not impact the primary route. [#6389](https://github.com/mapbox/mapbox-navigation-android/pull/6389)
+- Updated `UiComponent` to use `Dispatchers.Main.Immediate`. [#6393](https://github.com/mapbox/mapbox-navigation-android/pull/6393)
 
 ## Mapbox Navigation SDK 2.9.0-alpha.3 - 23 September, 2022
 ### Changelog

--- a/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/lifecycle/UIComponent.kt
+++ b/libnavui-base/src/main/java/com/mapbox/navigation/ui/base/lifecycle/UIComponent.kt
@@ -5,14 +5,16 @@ import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 /**
- * Using the [UIComponent] gives you access to a [coroutineScope]. All coroutines that you
+ * Using the [UIComponent] gives you access to a [coroutineScope] which uses
+ * `Dispatchers.Main.immediate`. All coroutines that you
  * launch inside onAttached will be canceled when the observer is detached. You do not need to
  * implement onDetached for your flowable components.
  * @property coroutineScope Defines a scope for new coroutine
@@ -28,7 +30,7 @@ open class UIComponent : MapboxNavigationObserver {
      */
     @CallSuper
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
-        coroutineScope = MainScope()
+        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     }
 
     /**


### PR DESCRIPTION
Closes NAVAND-690.

Steps to trigger the crash:
1. In `ActionButtonsBinder` change
```
            reloadOnChange(context.styles.cameraModeButtonParams) { params ->
                cameraModeButtonComponent(binding, params, store)
            }
```
into 
```
            reloadOnChange(context.styles.cameraModeButtonParams, context.styles.audioGuidanceButtonParams) { params, _ ->
                cameraModeButtonComponent(binding, params, store)
            },
```
2. Launch qa-test-app;
3. Open Customized NavigationView.

To learn more about the nature of the crash see the ticket.