### PR TITLE
don't ignore status updates when alternatives are being updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Updated `UiComponent` to use `Dispatchers.Main.Immediate`. [#6393](https://github.com/mapbox/mapbox-navigation-android/pull/6393)
 - Mitigated a rare issue that caused a crash in alternative routes fork offset calculation when using `MapboxRouteLineApi#setNavigationRoutes`. [#6404](https://github.com/mapbox/mapbox-navigation-android/pull/6404)
 - Improved `MapboxNavigation#startTripSession(withForegroundService = true)` docs to indicate that it should only be called from a foreground state. [#6405](https://github.com/mapbox/mapbox-navigation-android/pull/6405)
+- Fixed an issue where registered `RouteProgressObserver`s were not invoked, while alternative routes were updated. [#6397](https://github.com/mapbox/mapbox-navigation-android/pull/6397)
 
 ## Mapbox Navigation SDK 2.9.0-alpha.3 - 23 September, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -86,10 +86,11 @@ internal class MapboxTripSession(
                 "route IDs: ${routes.map { it.id }}) - starting",
             LOG_CATEGORY
         )
-        isUpdatingRoute = true
         val result = when (setRoutesInfo) {
             is BasicSetRoutesInfo -> {
+                isUpdatingRoute = true
                 setRouteToNativeNavigator(routes, setRoutesInfo.legIndex)
+                    .also { isUpdatingRoute = false }
             }
             is SetAlternativeRoutesInfo -> {
                 NativeSetRouteValue(
@@ -140,7 +141,6 @@ internal class MapboxTripSession(
                 }
             }
         }
-        isUpdatingRoute = false
         logD(
             "routes update (reason: ${setRoutesInfo.reason}, " +
                 "route IDs: ${routes.map { it.id }}) - finished",


### PR DESCRIPTION
### Description
While investigating the issue I found out that it is caused by 1TAP calling `setNavigationRoutes` again with the same routes after starting a trip. During that second call, NavNative sends a status update with banner instructions, which is ignored by the SDK, because all statuses are ignored while routes are being sent to NavNative. NavNative doesn't send these banner instructions again after that second call (probably because the primary route didn't change). Here are some of the options of how the issue can be fixed:
1. Remove the second `setNavigationRoutes` call in 1TAP (it was caused by the logic that manually syncs Drop-In and Android Auto states, but I wouldn't say it is an error to send the same routes again). 
2. Don't send routes to nav-native from the SDK if they didn't change. 
3. Don't ignore status updates from NavNative if routes are being sent to NavNative using `setAlternativeRoutes` function. 
4. Fix the issue on nav-native side by sending the banner instructions again after the routes were set, even if they didn't change. 

Option 3 makes the most sense to me, because the primary route hasn't changed, so all of the instructions are still valid. Implemented this option here. Opened the PR as a draft to get feedback, will update if you confirm that this is a valid approach. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
