### PR TITLE
[Android Auto] Fix incorrect coroutine scope

### DIFF
--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapManager.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapManager.kt
@@ -85,6 +85,8 @@ class PlacesListOnMapManager(
         styleLoadedListener = null
         MapboxNavigationApp.unregisterObserver(navigationObserver)
         carMapSurface = null
+        coroutineScope?.cancel()
+        coroutineScope = null
     }
 
     private fun onAttached(mapboxNavigation: MapboxNavigation) {
@@ -99,8 +101,6 @@ class PlacesListOnMapManager(
 
     private fun onDetached() {
         placesListItemMapper = null
-        coroutineScope?.cancel()
-        coroutineScope = null
     }
 
     private fun loadPlaceRecords() {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

@Zayankovsky caught an issue here https://github.com/mapbox/mapbox-navigation-android/pull/6371#discussion_r981690420

Skipping the changelog because this bug is not released. It would also be difficult to reproduce at the moment.

I looked into adding tests to PlacesListOnMapManager, but that requires a lot of changes at the moment.

