### PR TITLE
better control coroutine scopes in MapboxNavigation test

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -133,7 +133,6 @@ import com.mapbox.navigator.PollingConfig
 import com.mapbox.navigator.RouterInterface
 import com.mapbox.navigator.TileEndpointConfiguration
 import com.mapbox.navigator.TilesConfig
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
@@ -1813,7 +1812,7 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         }
     }
 
-    private fun createChildScope() = CoroutineScope(threadController.getMainScopeAndRootJob().job)
+    private fun createChildScope() = threadController.getMainScopeAndRootJob().scope
 
     private fun restartRouteScope() {
         routeScope.cancel()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -454,11 +454,11 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `new routes are set after reroute`() {
-        val newRoutes = listOf(mockk<NavigationRoute>(), mockk())
+        val newRoutes = listOf(mockk<NavigationRoute>(relaxed = true), mockk(relaxed = true))
         val navigationRerouteController: NavigationRerouteController = mockk(relaxed = true) {
             every { reroute(any<NavigationRerouteController.RoutesCallback>()) } answers {
                 (firstArg() as NavigationRerouteController.RoutesCallback)
-                    .onNewRoutes(newRoutes, mockk())
+                    .onNewRoutes(newRoutes, mockk(relaxed = true))
             }
         }
         coEvery {
@@ -483,11 +483,11 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `new routes are not set after reroute if they are invalid`() {
-        val newRoutes = listOf(mockk<NavigationRoute>(), mockk())
+        val newRoutes = listOf(mockk<NavigationRoute>(relaxed = true), mockk(relaxed = true))
         val navigationRerouteController: NavigationRerouteController = mockk(relaxed = true) {
             every { reroute(any<NavigationRerouteController.RoutesCallback>()) } answers {
                 (firstArg() as NavigationRerouteController.RoutesCallback)
-                    .onNewRoutes(newRoutes, mockk())
+                    .onNewRoutes(newRoutes, mockk(relaxed = true))
             }
         }
         coEvery {
@@ -509,14 +509,14 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `set reroute controller in fetching state sets routes to session`() {
-        val newRoutes = listOf(mockk<NavigationRoute>(), mockk())
+        val newRoutes = listOf(mockk<NavigationRoute>(relaxed = true), mockk(relaxed = true))
         val oldController = mockk<RerouteController>(relaxed = true) {
             every { state } returns RerouteState.FetchingRoute
         }
         val navigationRerouteController: NavigationRerouteController = mockk(relaxed = true) {
             every { reroute(any<NavigationRerouteController.RoutesCallback>()) } answers {
                 (firstArg() as NavigationRerouteController.RoutesCallback)
-                    .onNewRoutes(newRoutes, mockk())
+                    .onNewRoutes(newRoutes, mockk(relaxed = true))
             }
         }
         coEvery {
@@ -536,14 +536,14 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `set reroute controller in fetching state does not set invalid routes to session`() {
-        val newRoutes = listOf(mockk<NavigationRoute>(), mockk())
+        val newRoutes = listOf(mockk<NavigationRoute>(relaxed = true), mockk(relaxed = true))
         val oldController = mockk<RerouteController>(relaxed = true) {
             every { state } returns RerouteState.FetchingRoute
         }
         val navigationRerouteController: NavigationRerouteController = mockk(relaxed = true) {
             every { reroute(any<NavigationRerouteController.RoutesCallback>()) } answers {
                 (firstArg() as NavigationRerouteController.RoutesCallback)
-                    .onNewRoutes(newRoutes, mockk())
+                    .onNewRoutes(newRoutes, mockk(relaxed = true))
             }
         }
         coEvery {
@@ -888,7 +888,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     fun `setRoute does not push the invalid route to the directions session`() =
         coroutineRule.runBlockingTest {
             createMapboxNavigation()
-            val route: NavigationRoute = mockk()
+            val route: NavigationRoute = mockk(relaxed = true)
             val routeOptions = createRouteOptions()
             every { route.routeOptions } returns routeOptions
             every { route.directionsRoute.geometry() } returns "geometry"
@@ -1407,8 +1407,8 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     fun `route refresh - empty native alternatives returned doesn't clear alternatives metadata`() =
         coroutineRule.runBlockingTest {
             createMapboxNavigation()
-            val primary: NavigationRoute = mockk {
-                every { directionsRoute } returns mockk()
+            val primary: NavigationRoute = mockk(relaxed = true) {
+                every { directionsRoute } returns mockk(relaxed = true)
             }
             val routes = listOf(primary)
             val currentIndices = CurrentIndicesFactory.createIndices(5, 12, 43)
@@ -1418,7 +1418,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
                 currentIndicesProvider.getFilledIndicesOrWait()
             } returns currentIndices
 
-            val refreshedRoutes = listOf(mockk<NavigationRoute>())
+            val refreshedRoutes = listOf(mockk<NavigationRoute>(relaxed = true))
             coEvery {
                 tripSession.setRoutes(
                     refreshedRoutes,
@@ -1541,7 +1541,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     fun `refreshed route is not set to directions session if it is invalid`() =
         coroutineRule.runBlockingTest {
             createMapboxNavigation()
-            val primary: NavigationRoute = mockk {
+            val primary: NavigationRoute = mockk(relaxed = true) {
                 every { directionsRoute } returns mockk()
             }
             val routes = listOf(primary)
@@ -1551,7 +1551,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             every { tripSession.getState() } returns TripSessionState.STARTED
             verify { directionsSession.registerRoutesObserver(capture(routeObserversSlot)) }
 
-            val refreshedRoutes = listOf(mockk<NavigationRoute>())
+            val refreshedRoutes = listOf(mockk<NavigationRoute>(relaxed = true))
             coEvery {
                 routeRefreshController.refresh(routes)
             } returns RefreshedRouteInfo(refreshedRoutes, usedIndicesSnapshot)


### PR DESCRIPTION
Follow-up from https://github.com/mapbox/mapbox-navigation-android/pull/6387#issuecomment-1259648280.

##### Problem
`routeScope.launch`  is not run in the test coroutine scope because it does not use `Dispatchers.Main` while in the MainCoroutineRule  we only set Dispatchers.Main . So the runBlockingTest  does not know anything about the code inside routeScope.launch{}  block. And the test succeeds when the timings are "good" and fails otherwise.

##### Solution
Control the creation of `routeScope` - make it a test coroutine scope.
