### PR TITLE
[Android Auto] Migrate CarRouteLine to MapboxNavigationApp

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -7,7 +7,8 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Removed `MapboxNavigation` from `PlaceListOnMapScreen`. [#6371](https://github.com/mapbox/mapbox-navigation-android/pull/6371)
 - Migrate `CarDistanceFormatter` to an object that works with `MapboxNavigationApp`. [#6401](https://github.com/mapbox/mapbox-navigation-android/pull/6401)
-- Removed `MainCarContext` from `CarRouteLine` and `CarLocationRenderer` constructor. [#6219](https://github.com/mapbox/mapbox-navigation-android/pull/6219)
+- Removed `MainCarContext` from `CarRouteLine` and `CarLocationRenderer` constructor. [#6406](https://github.com/mapbox/mapbox-navigation-android/pull/6406)
+- Fixed issue where style changes cause `CarRouteLine` to trigger excessive calls to the map style. [#6406](https://github.com/mapbox/mapbox-navigation-android/pull/6406)
 
 ## androidauto-v0.12.0 - Sep 26, 2022
 ### Changelog

--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Removed `MapboxNavigation` from `PlaceListOnMapScreen`. [#6371](https://github.com/mapbox/mapbox-navigation-android/pull/6371)
 - Migrate `CarDistanceFormatter` to an object that works with `MapboxNavigationApp`. [#6401](https://github.com/mapbox/mapbox-navigation-android/pull/6401)
+- Removed `MainCarContext` from `CarRouteLine` and `CarLocationRenderer` constructor. [#6219](https://github.com/mapbox/mapbox-navigation-android/pull/6219)
 
 ## androidauto-v0.12.0 - Sep 26, 2022
 ### Changelog

--- a/libnavui-androidauto/api/current.txt
+++ b/libnavui-androidauto/api/current.txt
@@ -272,7 +272,7 @@ package com.mapbox.androidauto.car.location {
   }
 
   public final class CarLocationRenderer implements com.mapbox.maps.extension.androidauto.MapboxCarMapObserver {
-    ctor public CarLocationRenderer(com.mapbox.androidauto.car.MainCarContext mainCarContext);
+    ctor public CarLocationRenderer();
   }
 
 }
@@ -630,9 +630,7 @@ package com.mapbox.androidauto.car.placeslistonmap {
 package com.mapbox.androidauto.car.preview {
 
   public final class CarRouteLine implements com.mapbox.maps.extension.androidauto.MapboxCarMapObserver {
-    ctor public CarRouteLine(com.mapbox.androidauto.car.MainCarContext mainCarContext, com.mapbox.androidauto.car.routes.CarRoutesProvider carRoutesProvider = com.mapbox.androidauto.car.routes.NavigationCarRoutesProvider());
-    method public com.mapbox.androidauto.car.MainCarContext getMainCarContext();
-    property public final com.mapbox.androidauto.car.MainCarContext mainCarContext;
+    ctor public CarRouteLine(com.mapbox.androidauto.car.routes.CarRoutesProvider carRoutesProvider = com.mapbox.androidauto.car.routes.NavigationCarRoutesProvider());
   }
 
   public fun interface CarRouteOptionsInterceptor {

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/MainCarScreen.kt
@@ -24,8 +24,8 @@ class MainCarScreen @UiThread constructor(
     private val mainCarContext: MainCarContext
 ) : Screen(mainCarContext.carContext) {
 
-    val carRouteLine = CarRouteLine(mainCarContext)
-    val carLocationRenderer = CarLocationRenderer(mainCarContext)
+    val carRouteLine = CarRouteLine()
+    val carLocationRenderer = CarLocationRenderer()
     val carSpeedLimitRenderer = CarSpeedLimitRenderer(mainCarContext)
     val carNavigationCamera = CarNavigationCamera(
         initialCarCameraMode = CarCameraMode.FOLLOWING,

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/location/CarLocationRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/location/CarLocationRenderer.kt
@@ -1,7 +1,6 @@
 package com.mapbox.androidauto.car.location
 
 import com.mapbox.androidauto.MapboxCarApp
-import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.androidauto.internal.logAndroidAuto
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
@@ -13,14 +12,12 @@ import com.mapbox.maps.plugin.locationcomponent.location
  * create a renderer. To Create a new location experience, try creating a new class.
  */
 @OptIn(MapboxExperimental::class)
-class CarLocationRenderer(
-    private val mainCarContext: MainCarContext
-) : MapboxCarMapObserver {
+class CarLocationRenderer : MapboxCarMapObserver {
 
     override fun onAttached(mapboxCarMapSurface: MapboxCarMapSurface) {
         logAndroidAuto("CarLocationRenderer carMapSurface loaded")
         mapboxCarMapSurface.mapSurface.location.apply {
-            locationPuck = CarLocationPuck.navigationPuck2D(mainCarContext.carContext)
+            locationPuck = CarLocationPuck.navigationPuck2D(mapboxCarMapSurface.carContext)
             enabled = true
             pulsingEnabled = true
             setLocationProvider(MapboxCarApp.carAppLocationService().navigationLocationProvider)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/ActiveGuidanceScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/navigation/ActiveGuidanceScreen.kt
@@ -30,8 +30,8 @@ class ActiveGuidanceScreen(
     private val actionProviders: List<MapboxActionProvider>,
 ) : Screen(mainCarContext.carContext) {
 
-    val carRouteLine = CarRouteLine(mainCarContext)
-    val carLocationRenderer = CarLocationRenderer(mainCarContext)
+    val carRouteLine = CarRouteLine()
+    val carLocationRenderer = CarLocationRenderer()
     val carSpeedLimitRenderer = CarSpeedLimitRenderer(mainCarContext)
     val carNavigationCamera = CarNavigationCamera(
         initialCarCameraMode = CarCameraMode.FOLLOWING,

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/placeslistonmap/PlacesListOnMapScreen.kt
@@ -40,7 +40,7 @@ class PlacesListOnMapScreen @UiThread constructor(
     var itemList = buildErrorItemList(R.string.car_search_no_results)
 
     private val carNavigationCamera = CarLocationsOverviewCamera()
-    private var carLocationRenderer = CarLocationRenderer(searchCarContext.mainCarContext)
+    private var carLocationRenderer = CarLocationRenderer()
     private val placesListOnMapManager = PlacesListOnMapManager(placesProvider)
 
     init {

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteLine.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRouteLine.kt
@@ -150,7 +150,7 @@ class CarRouteLine(
         logAndroidAuto("CarRouteLine onRoutesChanged ${routes.size}")
         carMapSurface?.getStyle()?.let { style ->
             val routesMetadata = MapboxNavigationApp.current()?.getAlternativeMetadataFor(routes)
-            if (routesMetadata != null) {
+            if (!routesMetadata.isNullOrEmpty()) {
                 routeLineApi.setNavigationRoutes(routes, routesMetadata) { value ->
                     routeLineView.renderRouteDrawData(style, value)
                 }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRoutePreviewScreen.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/car/preview/CarRoutePreviewScreen.kt
@@ -52,11 +52,8 @@ class CarRoutePreviewScreen @UiThread constructor(
 
     private val carRoutesProvider = PreviewCarRoutesProvider(navigationRoutes)
     private var selectedIndex = 0
-    private val carRouteLine = CarRouteLine(
-        routePreviewCarContext.mainCarContext,
-        carRoutesProvider
-    )
-    private val carLocationRenderer = CarLocationRenderer(routePreviewCarContext.mainCarContext)
+    private val carRouteLine = CarRouteLine(carRoutesProvider)
+    private val carLocationRenderer = CarLocationRenderer()
     private val carSpeedLimitRenderer = CarSpeedLimitRenderer(routePreviewCarContext.mainCarContext)
     private val carNavigationCamera = CarNavigationCamera(
         initialCarCameraMode = CarCameraMode.OVERVIEW,


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Fixing `CarRouteLine` to use `MapboxNavigationObserver`. Am also removing `MainCarContext` from the `CarLocationRenderer` constructor as it is no longer needed.