### PR TITLE
Lazy logs

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
@@ -184,10 +184,9 @@ class NavigationRoute internal constructor(
                 }
                 val deferredRouteOptionsParsing = async(ThreadController.DefaultDispatcher) {
                     RouteOptions.fromUrl(URL(routeRequestUrl)).also {
-                        logD(
-                            "parsed request url to RouteOptions: ${it.toUrl("***")}",
-                            LOG_CATEGORY
-                        )
+                        logD(LOG_CATEGORY) {
+                            "parsed request url to RouteOptions: ${it.toUrl("***")}"
+                        }
                     }
                 }
                 create(

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/LoggerFrontend.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/LoggerFrontend.kt
@@ -1,5 +1,7 @@
 package com.mapbox.navigation.utils.internal
 
+import com.mapbox.common.LogConfiguration
+import com.mapbox.common.LoggingLevel
 import com.mapbox.common.NativeLoggerWrapper
 
 private const val NAV_SDK_CATEGORY = "nav-sdk"
@@ -7,6 +9,7 @@ private const val NAV_SDK_CATEGORY = "nav-sdk"
 interface LoggerFrontend {
     fun logV(msg: String, category: String? = null)
     fun logD(msg: String, category: String? = null)
+    fun logD(category: String? = null, lazyMsg: () -> String)
     fun logI(msg: String, category: String? = null)
     fun logE(msg: String, category: String? = null)
     fun logW(msg: String, category: String? = null)
@@ -22,6 +25,13 @@ internal class MapboxCommonLoggerFrontend : LoggerFrontend {
     override fun logD(msg: String, category: String?) {
         val message = createMessage(msg, category)
         NativeLoggerWrapper.debug(message, NAV_SDK_CATEGORY)
+    }
+
+    override fun logD(category: String?, lazyMsg: () -> String) {
+        when (LogConfiguration.getLoggingLevel()) {
+            LoggingLevel.DEBUG -> logD(lazyMsg(), category)
+            LoggingLevel.ERROR, LoggingLevel.INFO, LoggingLevel.WARNING -> { }
+        }
     }
 
     override fun logI(msg: String, category: String?) {

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/LoggerProvider.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/LoggerProvider.kt
@@ -40,6 +40,16 @@ fun logD(msg: String, category: String? = null) {
 }
 
 /**
+ * @param category optional string to identify the source or category of the log message.
+ * @param lazyMsg is a lazy message to log. Isn't executed if current log level less verbose then Debug.
+ * Noting that the category is appended to the log message to give extra context along with the `[nav-sdk]` parent category.
+ * As an example, this is how the logs would look like `D/Mapbox: [nav-sdk] [ConnectivityHandler] NetworkStatus=ReachableViaWiFi`.
+ */
+fun logD(category: String? = null, lazyMsg: () -> String) {
+    LoggerProvider.frontend.logD(category, lazyMsg)
+}
+
+/**
  * @param msg to log.
  * @param category optional string to identify the source or category of the log message.
  * Noting that the category is appended to the log message to give extra context along with the `[nav-sdk]` parent category.

--- a/libtesting-navigation-util/src/main/java/com/mapbox/navigation/testing/LoggingFrontendTestRule.kt
+++ b/libtesting-navigation-util/src/main/java/com/mapbox/navigation/testing/LoggingFrontendTestRule.kt
@@ -14,6 +14,9 @@ private object NoLoggingFrontend : LoggerFrontend {
     override fun logD(msg: String, category: String?) {
     }
 
+    override fun logD(category: String?, lazyMsg: () -> String) {
+    }
+
     override fun logI(msg: String, category: String?) {
     }
 


### PR DESCRIPTION
### Description
I'd like to add many debug logs to https://github.com/mapbox/mapbox-navigation-android/pull/6434. For example I want to logs ids of passed routes: `routes.map { it.id }.joinToString(separator = ", ") {it} `. But I worry that extensive logging with all this list transformations and concatenations may reduce performance for users who doesn't want to read them. What do you think about lazy logging where passed lazy messages are executed only if it makes sense for current log level? 
