### PR TITLE
Fixed drawing of restrictions on multi-leg routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Fixed an issue where restrictions were drawn only on the first leg of the route, if independent leg styling was not used (default behavior). [#6440](https://github.com/mapbox/mapbox-navigation-android/pull/6440)
 
 ## Mapbox Navigation SDK 2.9.0-beta.1 - 06 October, 2022
 ### Changelog
@@ -33,7 +34,6 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Mapbox Java `v6.8.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.8.0))
 - Mapbox Android Core `v5.0.2` ([release notes](https://github.com/mapbox/mapbox-events-android/releases/tag/core-5.0.2))
 -core-5.0.2))
-
 
 ## Mapbox Navigation SDK 2.9.0-alpha.4 - 30 September, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApi.kt
@@ -1313,7 +1313,7 @@ class MapboxRouteLineApi(
                     getRestrictedLineExpressionProducer(
                         extractedRouteData,
                         vanishingPointOffset = 0.0,
-                        activeLegIndex = 0,
+                        activeLegIndex = activeLegIndex,
                         routeLineOptions.resourceProvider.routeLineColorResources
                     )
                 } else {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtilsTest.kt
@@ -2087,6 +2087,26 @@ class MapboxRouteLineUtilsTest {
     }
 
     @Test
+    fun `getRestrictedLineExpression with restriction across two legs`() {
+        val expectedExpression = "[step, [line-progress], [rgba, 0.0, 0.0, 0.0, 0.0], 0.0, " +
+            "[rgba, 0.0, 0.0, 0.0, 0.0], 0.3956457979751531, " +
+            "[rgba, 0.0, 255.0, 255.0, 1.0], 0.5540039481345271, [rgba, 0.0, 0.0, 0.0, 0.0]]"
+        val route = loadRoute("multileg_route_two_legs_with_restrictions.json").toNavigationRoute(
+            RouterOrigin.Offboard
+        )
+        val expressionData = MapboxRouteLineUtils.extractRouteRestrictionData(route)
+
+        val result = MapboxRouteLineUtils.getRestrictedLineExpression(
+            vanishingPointOffset = 0.0,
+            activeLegIndex = -1,
+            Color.CYAN,
+            expressionData
+        )
+
+        assertEquals(expectedExpression, result.toString())
+    }
+
+    @Test
     fun routeHasRestrictions_when_routeNull() {
         val result = MapboxRouteLineUtils.routeHasRestrictions(null)
 

--- a/libnavui-maps/src/test/resources/multileg_route_two_legs_with_restrictions.json
+++ b/libnavui-maps/src/test/resources/multileg_route_two_legs_with_restrictions.json
@@ -1,0 +1,1830 @@
+{
+  "routeIndex": "0",
+  "distance": 980.784,
+  "duration": 207.031,
+  "duration_typical": 212.296,
+  "geometry": "qzxlgAt`fuhF|\\fIfKdC|KrBtB^dF~@l^tGrVtDdR`DfDj@tDj@rTpDn\\lFdC`@rDj@x`@rGnInAlEb@??f@wMz@oTZeGJyCR_F^gMtAmMPuDlBe]dC{^JeGI{G?oDHcDXwDS{G~@mF`A}Sf@kKf@qKFcBdAgUl@iMp@mOJuFY}HmA_LeLy@",
+  "weight": 295.884,
+  "weight_name": "auto",
+  "legs": [
+    {
+      "distance": 479.784,
+      "duration": 120.071,
+      "duration_typical": 120.389,
+      "summary": "Lincoln Avenue",
+      "admins": [
+        {
+          "iso_3166_1": "US",
+          "iso_3166_1_alpha3": "USA"
+        }
+      ],
+      "steps": [
+        {
+          "distance": 479.784,
+          "duration": 120.071,
+          "duration_typical": 120.389,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "qzxlgAt`fuhF|\\fIfKdC|KrBtB^dF~@l^tGrVtDdR`DfDj@tDj@rTpDn\\lFdC`@rDj@x`@rGnInAlEb@",
+          "name": "Lincoln Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.523163,
+              37.974969
+            ],
+            "bearing_before": 0.0,
+            "bearing_after": 195.0,
+            "instruction": "Drive south on Lincoln Avenue.",
+            "type": "depart"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 479.784,
+              "announcement": "Drive south on Lincoln Avenue. Then, in a quarter mile, You will arrive at your destination.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive south on Lincoln Avenue. Then, in a quarter mile, You will arrive at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            },
+            {
+              "distanceAlongGeometry": 66.667,
+              "announcement": "You have arrived at your destination.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYou have arrived at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 479.784,
+              "primary": {
+                "text": "You will arrive at your destination",
+                "components": [
+                  {
+                    "text": "You will arrive at your destination",
+                    "type": "text"
+                  }
+                ],
+                "type": "arrive",
+                "modifier": "straight"
+              }
+            },
+            {
+              "distanceAlongGeometry": 66.667,
+              "primary": {
+                "text": "You have arrived at your destination",
+                "components": [
+                  {
+                    "text": "You have arrived at your destination",
+                    "type": "text"
+                  }
+                ],
+                "type": "arrive",
+                "modifier": "straight"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 150.386,
+          "intersections": [
+            {
+              "location": [
+                -122.523163,
+                37.974969
+              ],
+              "bearings": [
+                195
+              ],
+              "entry": [
+                true
+              ],
+              "out": 0,
+              "geometry_index": 0,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523394,
+                37.974294
+              ],
+              "bearings": [
+                15,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 2,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523452,
+                37.974087
+              ],
+              "bearings": [
+                12,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 3,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.5235,
+                37.973913
+              ],
+              "bearings": [
+                12,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 5,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523639,
+                37.97341
+              ],
+              "bearings": [
+                12,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 6,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.52373,
+                37.973032
+              ],
+              "bearings": [
+                11,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 7,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523811,
+                37.972725
+              ],
+              "bearings": [
+                12,
+                192
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 8,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523833,
+                37.972641
+              ],
+              "bearings": [
+                12,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 9,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523855,
+                37.97255
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 10,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.523944,
+                37.972204
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 11,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.524063,
+                37.971732
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 12,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.52408,
+                37.971665
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 13,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.524102,
+                37.971575
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "classes": [
+                "restricted",
+                "secondary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 14,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.52424,
+                37.971034
+              ],
+              "bearings": [
+                11,
+                191
+              ],
+              "classes": [
+                "restricted",
+                "secondary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 15,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.52428,
+                37.970866
+              ],
+              "bearings": [
+                11,
+                188
+              ],
+              "classes": [
+                "restricted",
+                "secondary"
+              ],
+              "entry": [
+                false,
+                true
+              ],
+              "in": 0,
+              "out": 1,
+              "geometry_index": 16,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 0.0,
+          "duration": 0.0,
+          "duration_typical": 0.0,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "usplgArghuhF??",
+          "name": "Lincoln Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.524298,
+              37.970763
+            ],
+            "bearing_before": 188.0,
+            "bearing_after": 0.0,
+            "instruction": "You have arrived at your destination.",
+            "type": "arrive"
+          },
+          "voiceInstructions": [],
+          "bannerInstructions": [],
+          "driving_side": "right",
+          "weight": 0.0,
+          "intersections": [
+            {
+              "location": [
+                -122.524298,
+                37.970763
+              ],
+              "bearings": [
+                8
+              ],
+              "entry": [
+                true
+              ],
+              "in": 0,
+              "geometry_index": 17,
+              "admin_index": 0
+            }
+          ]
+        }
+      ],
+      "annotation": {
+        "distance": [
+          55.2,
+          22.6,
+          23.6,
+          6.7,
+          13.1,
+          57.3,
+          42.8,
+          34.9,
+          9.5,
+          10.3,
+          39.3,
+          53.6,
+          7.6,
+          10.2,
+          61.4,
+          19.0,
+          11.6
+        ],
+        "duration": [
+          7.641,
+          3.129,
+          4.72,
+          1.511,
+          2.949,
+          13.754,
+          7.342,
+          8.976,
+          2.455,
+          6.188,
+          23.58,
+          9.643,
+          1.369,
+          1.531,
+          9.214,
+          4.893,
+          2.976
+        ],
+        "speed": [
+          7.2,
+          7.2,
+          5.0,
+          4.4,
+          4.4,
+          4.2,
+          5.8,
+          3.9,
+          3.9,
+          1.7,
+          1.7,
+          5.6,
+          5.6,
+          6.7,
+          6.7,
+          3.9,
+          3.9
+        ],
+        "maxspeed": [
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 48,
+            "unit": "km/h"
+          }
+        ],
+        "congestion": [
+          "low",
+          "low",
+          "unknown",
+          "moderate",
+          "moderate",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "moderate",
+          "moderate",
+          "low",
+          "low",
+          "low",
+          "low",
+          "unknown",
+          "unknown"
+        ]
+      }
+    },
+    {
+      "distance": 501.0,
+      "duration": 86.96,
+      "duration_typical": 91.907,
+      "summary": "Lincoln Avenue, Grand Avenue",
+      "admins": [
+        {
+          "iso_3166_1": "US",
+          "iso_3166_1_alpha3": "USA"
+        }
+      ],
+      "steps": [
+        {
+          "distance": 477.0,
+          "duration": 77.504,
+          "duration_typical": 82.451,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "usplgArghuhF??f@wMz@oTZeGJyCR_F^gMtAmMPuDlBe]dC{^JeGI{G?oDHcDXwDS{G~@mF`A}Sf@kKf@qKFcBdAgUl@iMp@mOJuFY}HmA_L",
+          "name": "Lincoln Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.524298,
+              37.970763
+            ],
+            "bearing_before": 0.0,
+            "bearing_after": 96.0,
+            "instruction": "Drive east on Lincoln Avenue.",
+            "type": "depart"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 477.0,
+              "announcement": "Drive east on Lincoln Avenue.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eDrive east on Lincoln Avenue.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            },
+            {
+              "distanceAlongGeometry": 461.0,
+              "announcement": "In a quarter mile, Turn left onto Grand Avenue.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eIn a quarter mile, Turn left onto Grand Avenue.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            },
+            {
+              "distanceAlongGeometry": 84.444,
+              "announcement": "Turn left onto Grand Avenue. Then You will arrive at your destination.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eTurn left onto Grand Avenue. Then You will arrive at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 477.0,
+              "primary": {
+                "text": "Grand Avenue",
+                "components": [
+                  {
+                    "text": "Grand Avenue",
+                    "type": "text"
+                  }
+                ],
+                "type": "turn",
+                "modifier": "left"
+              },
+              "sub": {
+                "text": "",
+                "components": [
+                  {
+                    "text": "",
+                    "type": "lane",
+                    "directions": [
+                      "left"
+                    ],
+                    "active": true
+                  },
+                  {
+                    "text": "",
+                    "type": "lane",
+                    "directions": [
+                      "straight"
+                    ],
+                    "active": false
+                  },
+                  {
+                    "text": "",
+                    "type": "lane",
+                    "directions": [
+                      "straight",
+                      "right"
+                    ],
+                    "active": false
+                  }
+                ]
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 125.154,
+          "intersections": [
+            {
+              "location": [
+                -122.524298,
+                37.970763
+              ],
+              "bearings": [
+                96
+              ],
+              "classes": [
+                "restricted",
+                "secondary"
+              ],
+              "entry": [
+                true
+              ],
+              "out": 0,
+              "geometry_index": 0,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.524298,
+                37.970763
+              ],
+              "bearings": [
+                96,
+                276
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 1,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.524062,
+                37.970743
+              ],
+              "bearings": [
+                96,
+                276
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 2,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.523718,
+                37.970713
+              ],
+              "bearings": [
+                98,
+                276
+              ],
+              "classes": [
+                "restricted",
+                "primary"
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 3,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.523587,
+                37.970699
+              ],
+              "bearings": [
+                96,
+                278
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 4,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.52351,
+                37.970693
+              ],
+              "bearings": [
+                96,
+                276
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 5,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.523398,
+                37.970683
+              ],
+              "bearings": [
+                95,
+                276
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "left",
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 6,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.52317,
+                37.970667
+              ],
+              "bearings": [
+                103,
+                275
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 7,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.522848,
+                37.970615
+              ],
+              "bearings": [
+                98,
+                281
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight",
+                    "right"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 9,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.522365,
+                37.97056
+              ],
+              "bearings": [
+                99,
+                278
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight",
+                    "right"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 10,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "primary"
+              }
+            },
+            {
+              "location": [
+                -122.521178,
+                37.970484
+              ],
+              "bearings": [
+                109,
+                271
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                }
+              ],
+              "geometry_index": 17,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.521059,
+                37.970452
+              ],
+              "bearings": [
+                97,
+                289
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 18,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.520724,
+                37.970419
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 19,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.520526,
+                37.970399
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 20,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.520325,
+                37.970379
+              ],
+              "bearings": [
+                96,
+                277
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight",
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 21,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.520275,
+                37.970375
+              ],
+              "bearings": [
+                97,
+                276
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 22,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.519919,
+                37.97034
+              ],
+              "bearings": [
+                97,
+                277
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "geometry_index": 23,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            },
+            {
+              "location": [
+                -122.519304,
+                37.970286
+              ],
+              "bearings": [
+                82,
+                275
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "left"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": true,
+                  "active": false,
+                  "valid_indication": "straight",
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 26,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "secondary"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 24.0,
+          "duration": 9.456,
+          "duration_typical": 9.456,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "cyolgApx}thFeLy@",
+          "name": "Grand Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.518937,
+              37.970338
+            ],
+            "bearing_before": 77.0,
+            "bearing_after": 6.0,
+            "instruction": "Turn left onto Grand Avenue.",
+            "type": "turn",
+            "modifier": "left"
+          },
+          "voiceInstructions": [
+            {
+              "distanceAlongGeometry": 24.0,
+              "announcement": "You have arrived at your destination.",
+              "ssmlAnnouncement": "\u003cspeak\u003e\u003camazon:effect name\u003d\"drc\"\u003e\u003cprosody rate\u003d\"1.08\"\u003eYou have arrived at your destination.\u003c/prosody\u003e\u003c/amazon:effect\u003e\u003c/speak\u003e"
+            }
+          ],
+          "bannerInstructions": [
+            {
+              "distanceAlongGeometry": 24.0,
+              "primary": {
+                "text": "You have arrived at your destination",
+                "components": [
+                  {
+                    "text": "You have arrived at your destination",
+                    "type": "text"
+                  }
+                ],
+                "type": "arrive",
+                "modifier": "straight"
+              }
+            }
+          ],
+          "driving_side": "right",
+          "weight": 20.343,
+          "intersections": [
+            {
+              "location": [
+                -122.518937,
+                37.970338
+              ],
+              "bearings": [
+                6,
+                257
+              ],
+              "entry": [
+                true,
+                false
+              ],
+              "in": 1,
+              "out": 0,
+              "lanes": [
+                {
+                  "valid": true,
+                  "active": true,
+                  "valid_indication": "left",
+                  "indications": [
+                    "left"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "straight"
+                  ]
+                },
+                {
+                  "valid": false,
+                  "active": false,
+                  "indications": [
+                    "straight",
+                    "right"
+                  ]
+                }
+              ],
+              "geometry_index": 28,
+              "is_urban": true,
+              "admin_index": 0,
+              "mapbox_streets_v8": {
+                "class": "tertiary"
+              }
+            }
+          ]
+        },
+        {
+          "distance": 0.0,
+          "duration": 0.0,
+          "duration_typical": 0.0,
+          "speedLimitUnit": "mph",
+          "speedLimitSign": "mutcd",
+          "geometry": "ifplgAvv}thF??",
+          "name": "Grand Avenue",
+          "mode": "driving",
+          "maneuver": {
+            "location": [
+              -122.518908,
+              37.970549
+            ],
+            "bearing_before": 6.0,
+            "bearing_after": 0.0,
+            "instruction": "You have arrived at your destination.",
+            "type": "arrive"
+          },
+          "voiceInstructions": [],
+          "bannerInstructions": [],
+          "driving_side": "right",
+          "weight": 0.0,
+          "intersections": [
+            {
+              "location": [
+                -122.518908,
+                37.970549
+              ],
+              "bearings": [
+                186
+              ],
+              "entry": [
+                true
+              ],
+              "in": 0,
+              "geometry_index": 29,
+              "admin_index": 0
+            }
+          ]
+        }
+      ],
+      "annotation": {
+        "distance": [
+          0.0,
+          20.8,
+          30.4,
+          11.6,
+          6.8,
+          9.9,
+          20.1,
+          20.8,
+          8.0,
+          42.8,
+          45.4,
+          11.5,
+          12.5,
+          7.7,
+          7.2,
+          8.2,
+          12.5,
+          11.0,
+          29.6,
+          17.5,
+          17.8,
+          4.4,
+          31.5,
+          20.3,
+          23.2,
+          10.8,
+          14.0,
+          18.8,
+          23.6
+        ],
+        "duration": [
+          0.0,
+          3.408,
+          4.97,
+          2.088,
+          1.111,
+          1.619,
+          3.616,
+          3.26,
+          1.26,
+          6.703,
+          4.084,
+          1.036,
+          1.123,
+          0.695,
+          0.65,
+          0.738,
+          1.126,
+          1.324,
+          3.555,
+          1.911,
+          1.94,
+          0.547,
+          4.928,
+          1.823,
+          2.092,
+          0.973,
+          2.971,
+          3.973,
+          4.476
+        ],
+        "speed": [
+          0.0,
+          6.1,
+          6.1,
+          5.6,
+          6.1,
+          6.1,
+          5.6,
+          6.4,
+          6.4,
+          6.4,
+          11.1,
+          11.1,
+          11.1,
+          11.1,
+          11.1,
+          11.1,
+          11.1,
+          8.3,
+          8.3,
+          9.2,
+          9.2,
+          8.1,
+          6.4,
+          11.1,
+          11.1,
+          11.1,
+          4.7,
+          4.7,
+          5.3
+        ],
+        "maxspeed": [
+          {
+            "speed": 48,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "speed": 40,
+            "unit": "km/h"
+          },
+          {
+            "unknown": true
+          }
+        ],
+        "congestion": [
+          "severe",
+          "moderate",
+          "moderate",
+          "unknown",
+          "low",
+          "low",
+          "moderate",
+          "low",
+          "low",
+          "low",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "unknown",
+          "low",
+          "low",
+          "low",
+          "low",
+          "unknown",
+          "low",
+          "moderate",
+          "moderate",
+          "moderate",
+          "unknown",
+          "unknown",
+          "unknown"
+        ]
+      }
+    }
+  ],
+  "routeOptions": {
+    "baseUrl": "https://api.mapbox.com",
+    "user": "mapbox",
+    "profile": "driving-traffic",
+    "coordinates": "-122.523179,37.974972;-122.524257,37.970785;-122.518925,37.970548",
+    "alternatives": true,
+    "language": "en",
+    "continue_straight": true,
+    "roundabout_exits": true,
+    "geometries": "polyline6",
+    "overview": "full",
+    "steps": true,
+    "annotations": "congestion,maxspeed,speed,duration,distance,closure",
+    "voice_instructions": true,
+    "banner_instructions": true,
+    "voice_units": "imperial",
+    "access_token": "omitted",
+    "uuid": "XG3zTka4ub-AUGlYzj4qX_NNjD8bX5oh88qzhmwv5bxibaFV_P0XOg\u003d\u003d"
+  },
+  "voiceLocale": "en-US"
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Builds on top of https://github.com/mapbox/mapbox-navigation-android/pull/6399.

Fixes an issue where restrictions were drawn only on the first leg of the route, if independent leg styling was not used (default behavior).

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
_before_
<img alt="Screenshot_20221005_145022" height="540" src="https://user-images.githubusercontent.com/16925074/194064704-7efae79e-26a7-41f6-856b-22af86f76053.png"/>

_after_
<img alt="Screenshot_20221005_145156" height="540" src="https://user-images.githubusercontent.com/16925074/194064777-3e58aa77-1461-444e-8e67-e31354d29080.png"/>

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
