### PR TITLE
[Drop-In UI] do not drop actions if another one is being processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Mapbox Android Core `v5.0.2` ([release notes](https://github.com/mapbox/mapbox-events-android/releases/tag/core-5.0.2))
 -core-5.0.2))
 
+- Fixed an issue with `NavigationView` that prevented camera from going into following state after starting a trip. [#6442](https://github.com/mapbox/mapbox-navigation-android/pull/6442)
 
 ## Mapbox Navigation SDK 2.9.0-alpha.4 - 30 September, 2022
 ### Changelog

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/Store.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/Store.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.app.internal
 
 import com.mapbox.navigation.ui.utils.internal.extensions.slice
+import com.mapbox.navigation.utils.internal.logW
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -72,8 +73,16 @@ open class Store {
         if (isProcessing) return
 
         isProcessing = true
+        val processedActions = hashSetOf<Action>()
         while (actions.isNotEmpty()) {
             val head = actions.remove()
+            if (!processedActions.add(head)) {
+                logW(category = "Store") {
+                    "Possibly infinite loop detected. Current action: $action, " +
+                        "processed actions: $processedActions, pending actions: $actions"
+                }
+                break
+            }
             if (!intercept(head)) {
                 reduce(head)
             }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/CameraComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/CameraComponentTest.kt
@@ -252,6 +252,7 @@ class CameraComponentTest {
                 NavigationCameraState.IDLE to TargetCameraMode.Idle,
             ).forEach { (cameraState, mode) ->
                 observer.captured.onNavigationCameraStateChanged(cameraState)
+                advanceTimeBy(delayTimeMillis = 10)
 
                 verify { testStore.dispatch(SetCameraMode(mode)) }
             }


### PR DESCRIPTION
### Description
After #6393 it can easily happen that while an action is being processed, another one can be dispatched and we can't simply drop it, that's why we have to save it to a queue.
There is another issue with `CameraComponent` caused by the fact that not all camera transitions have their `owner` set to `NAVIGATION_CAMERA_OWNER`. This causes an intermediate `IDLE` state when starting the animation, which starts an infinite loop in `CameraComponent.syncNavigationCameraState`. For now fixing it by using `debounce`, so that this `IDLE` state is skipped, but this clearly needs a better fix. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
