### PR TITLE
MapboxMetricsReporter: logging fix

### DIFF
--- a/libnavigation-metrics/src/main/java/com/mapbox/navigation/metrics/MapboxMetricsReporter.kt
+++ b/libnavigation-metrics/src/main/java/com/mapbox/navigation/metrics/MapboxMetricsReporter.kt
@@ -111,7 +111,9 @@ object MapboxMetricsReporter : MetricsReporter {
             eventsService.sendEvent(
                 Event(EventPriority.IMMEDIATE, metricEvent.toValue(), null)
             ) {
-                logE("Failed to send event ${metricEvent.metricName}: $it", LOG_CATEGORY)
+                if (it != null) {
+                    logE("Failed to send event ${metricEvent.metricName}: $it", LOG_CATEGORY)
+                }
             }
 
             ioJobController.scope.launch {
@@ -126,7 +128,9 @@ object MapboxMetricsReporter : MetricsReporter {
     override fun sendTurnstileEvent(turnstileEvent: TurnstileEvent) {
         ifTelemetryIsRunning {
             eventsService.sendTurnstileEvent(turnstileEvent) {
-                logE("Failed to send Turnstile event: $it", LOG_CATEGORY)
+                if (it != null) {
+                    logE("Failed to send Turnstile event: $it", LOG_CATEGORY)
+                }
             }
         }
     }


### PR DESCRIPTION
### Description

`EventsServiceResponseCallback` is invoked at any case (success and un-success), so null-check has to be done

to address the issue `CORESDK-1363`

cc @tatiana-yan 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
