### PR TITLE
fix MapboxJunctionApi crash with invalid bitmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Fixed an issue where restrictions were drawn only on the first leg of the route, if independent leg styling was not used (default behavior). [#6440](https://github.com/mapbox/mapbox-navigation-android/pull/6440)
 - Fixed a crash in `MapboxJunctionApi` that happens when a junction contains an invalid bitmap. [#6459](https://github.com/mapbox/mapbox-navigation-android/pull/6459)
+- Updated `MapboxJunctionApi` to ignore banner components with subtype `signboard`. `MapboxSignboardApi` should be used to handle such components. [#6459](https://github.com/mapbox/mapbox-navigation-android/pull/6459)
 
 ## Mapbox Navigation SDK 2.9.0-beta.1 - 06 October, 2022
 ### Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 #### Bug fixes and improvements
 - Fixed an issue where restrictions were drawn only on the first leg of the route, if independent leg styling was not used (default behavior). [#6440](https://github.com/mapbox/mapbox-navigation-android/pull/6440)
+- Fixed a crash in `MapboxJunctionApi` that happens when a junction contains an invalid bitmap. [#6459](https://github.com/mapbox/mapbox-navigation-android/pull/6459)
 
 ## Mapbox Navigation SDK 2.9.0-beta.1 - 06 October, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/junction/JunctionProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/junction/JunctionProcessor.kt
@@ -52,7 +52,6 @@ internal object JunctionProcessor {
                     it.subType() == BannerComponents.JCT ||
                         it.subType() == BannerComponents.SAPA ||
                         it.subType() == BannerComponents.CITYREAL ||
-                        it.subType() == BannerComponents.SIGNBOARD ||
                         it.subType() == BannerComponents.AFTERTOLL ||
                         it.subType() == BannerComponents.TOLLBRANCH ||
                         it.subType() == BannerComponents.EXPRESSWAY_EXIT ||

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxRasterToBitmapParser.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxRasterToBitmapParser.kt
@@ -19,9 +19,9 @@ internal object MapboxRasterToBitmapParser {
     @JvmStatic
     fun parse(raster: ByteArray): Expected<String, Bitmap> {
         return when {
-            raster.isNotEmpty() -> ExpectedFactory.createValue(
-                BitmapFactory.decodeByteArray(raster, 0, raster.size)
-            )
+            raster.isNotEmpty() -> BitmapFactory.decodeByteArray(raster, 0, raster.size)
+                ?.let { ExpectedFactory.createValue(it) }
+                ?: ExpectedFactory.createError("Raster is not a valid bitmap")
             else -> ExpectedFactory.createError("Error parsing raster to bitmap as raster is empty")
         }
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/junction/JunctionProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/junction/JunctionProcessorTest.kt
@@ -299,17 +299,18 @@ class JunctionProcessorTest {
 
     @Test
     fun `process action junction process raster to bitmap failure`() {
-        mockkStatic(MapboxRasterToBitmapParser::class)
-        val mockData = byteArrayOf()
-        val action = JunctionAction.ParseRasterToBitmap(mockData)
-        every { MapboxRasterToBitmapParser.parse(any()) } returns
-            ExpectedFactory.createError(
-                "Error parsing raster to bitmap as raster is empty"
-            )
+        mockkStatic(MapboxRasterToBitmapParser::class) {
+            val mockData = byteArrayOf()
+            val action = JunctionAction.ParseRasterToBitmap(mockData)
+            every { MapboxRasterToBitmapParser.parse(any()) } returns
+                ExpectedFactory.createError(
+                    "Error parsing raster to bitmap as raster is empty"
+                )
 
-        val result = JunctionProcessor.process(action) as JunctionResult.JunctionBitmap.Failure
+            val result = JunctionProcessor.process(action) as JunctionResult.JunctionBitmap.Failure
 
-        assertEquals("Error parsing raster to bitmap as raster is empty", result.message)
+            assertEquals("Error parsing raster to bitmap as raster is empty", result.message)
+        }
     }
 
     private fun getComponentGuidanceViewType(): BannerComponents {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/junction/JunctionProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/junction/JunctionProcessorTest.kt
@@ -109,19 +109,19 @@ class JunctionProcessorTest {
     }
 
     @Test
-    fun `process action junction signboard availability result available`() {
+    fun `process action junction signboard availability result unavailable`() {
         val bannerInstructions: BannerInstructions = mockk()
         val bannerView: BannerView = mockk()
         val bannerComponentsList: MutableList<BannerComponents> = mutableListOf()
         bannerComponentsList.add(getGuidanceViewSubType(BannerComponents.SIGNBOARD))
         every { bannerInstructions.view() } returns bannerView
         every { bannerView.components() } returns bannerComponentsList
-        val expected = JunctionResult.JunctionAvailable("https://abc.mapbox.com")
+        val expected = JunctionResult.JunctionUnavailable
         val action = JunctionAction.CheckJunctionAvailability(bannerInstructions)
 
-        val result = JunctionProcessor.process(action) as JunctionResult.JunctionAvailable
+        val result = JunctionProcessor.process(action)
 
-        assertEquals(expected.junctionUrl, result.junctionUrl)
+        assertEquals(expected, result)
     }
 
     @Test

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxRasterToBitmapParserTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxRasterToBitmapParserTest.kt
@@ -1,28 +1,28 @@
 package com.mapbox.navigation.ui.maps.guidance.junction.api
 
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import androidx.test.core.app.ApplicationProvider
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class MapboxRasterToBitmapParserTest {
 
-    private lateinit var ctx: Context
-
     @Before
-    fun setUp() {
-        ctx = ApplicationProvider.getApplicationContext()
+    fun `set up`() {
+        mockkStatic(BitmapFactory::class)
+    }
+
+    @After
+    fun `tear down`() {
+        unmockkStatic(BitmapFactory::class)
     }
 
     @Test
@@ -37,10 +37,21 @@ class MapboxRasterToBitmapParserTest {
     }
 
     @Test
+    fun `when raster invalid parse fail`() {
+        val mockRaster = byteArrayOf(34, 87, 88, 45, 22, 90, 77)
+
+        every { BitmapFactory.decodeByteArray(mockRaster, 0, mockRaster.size) } returns null
+        val expected = ExpectedFactory.createError<String, Bitmap>("Raster is not a valid bitmap")
+
+        val actual = MapboxRasterToBitmapParser.parse(mockRaster)
+
+        assertEquals(expected.error!!, actual.error!!)
+    }
+
+    @Test
     fun `when raster not empty parse success`() {
         val mockRaster = byteArrayOf(34, 87, 88, 45, 22, 90, 77)
         val mockBitmap = mockk<Bitmap>()
-        mockkStatic(BitmapFactory::class)
         every { BitmapFactory.decodeByteArray(mockRaster, 0, mockRaster.size) } returns mockBitmap
         val expected: Expected<String, Bitmap> = ExpectedFactory.createValue(mockBitmap)
 


### PR DESCRIPTION
### Description
This is the bitmap, that causes a crash: ![junction](https://user-images.githubusercontent.com/2395284/194583865-56575200-0c3b-4b50-bc6f-a10d2d7c58ed.svg)
This is actually SVG, that's why weren't able to parse it. Should we add support for SVGs in Junctions?

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
