### PR TITLE
[Drop-In UI] update guideline position every time info panel top changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Marked `InfoPanelBinder`, `NavigationView`, `NavigationViewApi` methods with `@UiThread` annotation. [#6269](https://github.com/mapbox/mapbox-navigation-android/pull/6269)
 - Marked `MapboxExitText`, `MapboxLaneGuidance`, `MapboxLaneGuidanceAdapter`, `MapboxManeuverView`, `MapboxPrimaryManeuver`, `MapboxSecondaryManeuver`, `MapboxStepDistance`, `MapboxSubManeuver`, `MapboxTurnIconManeuver`, `MapboxUpcomingManeuverAdapter` methods with `@UiThread` annotation. [#6270](https://github.com/mapbox/mapbox-navigation-android/pull/6270)
 - Marked `RouteShieldCallback` methods with `@UiThread` annotation. [#6271](https://github.com/mapbox/mapbox-navigation-android/pull/6271)
+- Fixed an issue with `NavigationView` that caused road label position to not update after changing peek height of the Info Panel. [#6463](https://github.com/mapbox/mapbox-navigation-android/pull/6463)
 
 ## Mapbox Navigation SDK 2.9.0-beta.1 - 06 October, 2022
 ### Changelog

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomInfoPanelBinder.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomInfoPanelBinder.kt
@@ -11,7 +11,6 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.dropin.NavigationView
-import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelPeekHeight
 import com.mapbox.navigation.dropin.infopanel.InfoPanelBinder
 import com.mapbox.navigation.dropin.internal.extensions.updateMargins
 import com.mapbox.navigation.dropin.navigationview.NavigationViewListener
@@ -69,10 +68,6 @@ class CustomInfoPanelBinder(
             navigationView.addListener(slideOffsetObserver)
             navigationView.customizeViewBinders {
                 infoPanelBinder = this@CustomInfoPanelBinder
-            }
-            navigationView.customizeViewStyles {
-                val context = navigationView.context
-                infoPanelPeekHeight = defaultInfoPanelPeekHeight(context) + insets.bottom
             }
         } else {
             navigationView.removeListener(slideOffsetObserver)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomInfoPanelBinderWithFixedHeight.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomInfoPanelBinderWithFixedHeight.kt
@@ -12,7 +12,6 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.dropin.NavigationView
-import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelPeekHeight
 import com.mapbox.navigation.dropin.infopanel.InfoPanelBinder
 import com.mapbox.navigation.dropin.internal.extensions.updateMargins
 import com.mapbox.navigation.dropin.navigationview.NavigationViewListener
@@ -73,10 +72,6 @@ class CustomInfoPanelBinderWithFixedHeight(
             navigationView.addListener(slideOffsetObserver)
             navigationView.customizeViewBinders {
                 infoPanelBinder = this@CustomInfoPanelBinderWithFixedHeight
-            }
-            navigationView.customizeViewStyles {
-                val context = navigationView.context
-                infoPanelPeekHeight = defaultInfoPanelPeekHeight(context) + insets.bottom
             }
         } else {
             navigationView.removeListener(slideOffsetObserver)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -10,6 +10,7 @@ class CustomizedViewModel : ViewModel() {
     val customInfoPanelLayout = MutableLiveData("--")
     val useCustomInfoPanelStyles = MutableLiveData(false)
     val customInfoPanelContent = MutableLiveData("--")
+    val customInfoPanelPeekHeight = MutableLiveData("--")
     val showCustomInfoPanelEndNavButton = MutableLiveData(false)
     val showBottomSheetInFreeDrive = MutableLiveData(false)
     val enableDestinationPreview = MutableLiveData(true)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -274,6 +274,11 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             viewModel.customInfoPanelContent,
             ::setCustomInfoPanelContent
         )
+        bindSpinner(
+            menuBinding.spinnerCustomInfoPanelPeekHeight,
+            viewModel.customInfoPanelPeekHeight,
+            ::setCustomInfoPanelPeekHeight,
+        )
         bindSwitch(
             menuBinding.toggleCustomInfoPanelEndNavButton,
             viewModel.showCustomInfoPanelEndNavButton,
@@ -578,6 +583,16 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
                 else -> {
                     infoPanelContentBinder = UIBinder.USE_DEFAULT
                 }
+            }
+        }
+    }
+
+    private fun setCustomInfoPanelPeekHeight(peekHeight: String) {
+        val defaultPeekHeight = ViewStyleCustomization.defaultInfoPanelPeekHeight(context = this)
+        binding.navigationView.customizeViewStyles {
+            infoPanelPeekHeight = when (peekHeight) {
+                "LARGE" -> defaultPeekHeight * 2
+                else -> defaultPeekHeight
             }
         }
     }

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -236,6 +236,30 @@
 
             </androidx.appcompat.widget.LinearLayoutCompat>
 
+            <androidx.appcompat.widget.LinearLayoutCompat
+                android:layout_width="match_parent"
+                android:layout_height="40dp"
+                android:gravity="center_vertical"
+                android:paddingVertical="10dp">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAllCaps="true"
+                    android:textColor="@color/colorOnSurface"
+                    android:text="Custom Peek Height" />
+
+                <androidx.appcompat.widget.AppCompatSpinner
+                    android:id="@+id/spinnerCustomInfoPanelPeekHeight"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="5dp"
+                    android:entries="@array/drop_in_info_panel_custom_peek_height"
+                    android:spinnerMode="dropdown" />
+
+            </androidx.appcompat.widget.LinearLayoutCompat>
+
             <androidx.appcompat.widget.SwitchCompat
                 android:id="@+id/toggleCustomInfoPanelEndNavButton"
                 android:layout_width="match_parent"

--- a/qa-test-app/src/main/res/values/strings.xml
+++ b/qa-test-app/src/main/res/values/strings.xml
@@ -63,6 +63,10 @@
         <item>SMALL</item>
         <item>LARGE</item>
     </string-array>
+    <string-array name="drop_in_info_panel_custom_peek_height" translatable="false">
+        <item>--</item>
+        <item>LARGE</item>
+    </string-array>
     <string-array name="drop_in_routing_profile" translatable="false">
         <item>--</item>
         <item>DRIVING-TRAFFIC</item>


### PR DESCRIPTION
### Description
Since guideline position evaluation depends on `InfoPanel.top` we should update the position every time the property changes. Also updated peek height changes to be animated. 

https://user-images.githubusercontent.com/2395284/194903438-b7a5a0e1-ec07-4207-96e8-b1bc1aa21e5a.mp4

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
