### PR TITLE
[Drop-In] Show action buttons in all navigation state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Updated `RecenterButtonComponent` and `CameraModeButtonComponent` to show in `RoutePreview` state. [#6465](https://github.com/mapbox/mapbox-navigation-android/pull/6465)
 - Fixed an issue where restrictions were drawn only on the first leg of the route, if independent leg styling was not used (default behavior). [#6440](https://github.com/mapbox/mapbox-navigation-android/pull/6440)
 - Fixed a crash in `MapboxJunctionApi` that happens when a junction contains an invalid bitmap. [#6459](https://github.com/mapbox/mapbox-navigation-android/pull/6459)
 - Updated `MapboxJunctionApi` to ignore banner components with subtype `signboard`. `MapboxSignboardApi` should be used to handle such components. [#6459](https://github.com/mapbox/mapbox-navigation-android/pull/6459)

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/Store.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/Store.kt
@@ -5,6 +5,7 @@ import com.mapbox.navigation.utils.internal.logW
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -63,8 +64,12 @@ open class Store {
         return state.map { selector(it) }.distinctUntilChanged()
     }
 
-    fun <T> slice(scope: CoroutineScope, selector: (State) -> T): StateFlow<T> {
-        return state.slice(scope, selector = selector)
+    fun <T> slice(
+        scope: CoroutineScope,
+        started: SharingStarted = SharingStarted.WhileSubscribed(),
+        selector: (State) -> T
+    ): StateFlow<T> {
+        return state.slice(scope, started = started, selector = selector)
     }
 
     fun dispatch(action: Action) {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/camera/CameraModeButtonComponentContractImpl.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/camera/CameraModeButtonComponentContractImpl.kt
@@ -6,7 +6,6 @@ import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.camera.CameraAction
 import com.mapbox.navigation.ui.app.internal.camera.TargetCameraMode
 import com.mapbox.navigation.ui.app.internal.camera.toNavigationCameraState
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
 import com.mapbox.navigation.ui.maps.internal.ui.CameraModeButtonComponentContract
 import kotlinx.coroutines.CoroutineScope
@@ -27,9 +26,6 @@ internal class CameraModeButtonComponentContractImpl(
                 cameraState.cameraMode.toNavigationCameraState()
             }
         }
-
-    override val isVisible: StateFlow<Boolean> =
-        store.slice(coroutineScope) { it.navigation != NavigationState.RoutePreview }
 
     override fun onClick(view: View) {
         val cameraMode = store.state.value.camera.cameraMode.let {

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/CameraModeButtonComponentContractImplTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/CameraModeButtonComponentContractImplTest.kt
@@ -6,7 +6,6 @@ import com.mapbox.navigation.dropin.util.TestStore
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.app.internal.camera.CameraAction
 import com.mapbox.navigation.ui.app.internal.camera.TargetCameraMode
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
 import com.mapbox.navigation.ui.maps.internal.ui.CameraModeButtonComponentContract
 import io.mockk.mockk
@@ -79,24 +78,6 @@ class CameraModeButtonComponentContractImplTest {
         val navCamState = sut.buttonState.take(1).toList().first()
 
         assertEquals(NavigationCameraState.FOLLOWING, navCamState)
-    }
-
-    @Test
-    fun `isVisible use NavigationState to determine visibility`() = runBlockingTest {
-        testStore.updateState {
-            it.copy(navigation = NavigationState.RoutePreview)
-        }
-        val visibility = mutableListOf<Boolean>()
-        val job = launch {
-            sut.isVisible.take(2).toList(visibility)
-            yield()
-        }
-        testStore.updateState {
-            it.copy(navigation = NavigationState.ActiveNavigation)
-        }
-
-        job.join()
-        assertEquals(listOf(false, true), visibility)
     }
 
     @Test

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/RecenterButtonComponentContractImplTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/RecenterButtonComponentContractImplTest.kt
@@ -32,7 +32,7 @@ class RecenterButtonComponentContractImplTest {
     }
 
     @Test
-    fun `isVisible - should return TRUE when camera is Idle and not in RoutePreview`() =
+    fun `isVisible - should return TRUE when camera is Idle`() =
         coroutineRule.runBlockingTest {
             store.updateState {
                 it.copy(
@@ -42,7 +42,7 @@ class RecenterButtonComponentContractImplTest {
             }
             coroutineRule.testDispatcher.advanceUntilIdle()
             assertTrue(
-                "expected TRUE when camera is Idle and not in RoutePreview",
+                "expected TRUE when camera is Idle",
                 sut.isVisible.value
             )
         }
@@ -58,19 +58,6 @@ class RecenterButtonComponentContractImplTest {
             }
             coroutineRule.testDispatcher.advanceUntilIdle()
             assertFalse("expected FALSE when camera not Idle", sut.isVisible.value)
-        }
-
-    @Test
-    fun `isVisible - should return FALSE when camera in RoutePreview`() =
-        coroutineRule.runBlockingTest {
-            store.updateState {
-                it.copy(
-                    camera = it.camera.copy(cameraMode = TargetCameraMode.Idle),
-                    navigation = NavigationState.RoutePreview
-                )
-            }
-            coroutineRule.testDispatcher.advanceUntilIdle()
-            assertFalse("expected FALSE when NavigationState not RoutePreview", sut.isVisible.value)
         }
 
     @Test

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/ui/CameraModeButtonComponent.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/ui/CameraModeButtonComponent.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.ui.maps.internal.ui
 
 import android.view.View
-import androidx.core.view.isVisible
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
@@ -17,8 +16,6 @@ import kotlinx.coroutines.flow.asStateFlow
 @ExperimentalPreviewMapboxNavigationAPI
 interface CameraModeButtonComponentContract {
 
-    val isVisible: StateFlow<Boolean>
-
     val buttonState: StateFlow<NavigationCameraState>
 
     fun onClick(view: View)
@@ -33,7 +30,6 @@ class CameraModeButtonComponent(
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
         val contract = contractProvider.get()
-        contract.isVisible.observe { cameraModeButton.isVisible = it }
         contract.buttonState.observe { cameraModeButton.setState(it) }
         cameraModeButton.setOnClickListener(contract::onClick)
     }
@@ -49,8 +45,6 @@ internal class MapboxCameraModeButtonComponentContract(
     private val navigationCameraProvider: Provider<NavigationCamera?>
 ) : UIComponent(),
     CameraModeButtonComponentContract {
-
-    override val isVisible: StateFlow<Boolean> = MutableStateFlow(true)
 
     private val _buttonState = MutableStateFlow(NavigationCameraState.OVERVIEW)
     override val buttonState: StateFlow<NavigationCameraState> = _buttonState.asStateFlow()

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/CameraModeButtonComponentTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/CameraModeButtonComponentTest.kt
@@ -2,7 +2,6 @@ package com.mapbox.navigation.ui.maps.internal.ui
 
 import android.content.Context
 import android.view.View
-import androidx.core.view.isVisible
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
@@ -15,8 +14,6 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runBlockingTest
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -45,17 +42,6 @@ class CameraModeButtonComponentTest {
     }
 
     @Test
-    fun `should update button visibility`() = runBlockingTest {
-        sut.onAttached(mapboxNavigation)
-
-        contract.isVisible.value = false
-        assertFalse(cameraModeButton.isVisible)
-
-        contract.isVisible.value = true
-        assertTrue(cameraModeButton.isVisible)
-    }
-
-    @Test
     fun `should update button state`() = runBlockingTest {
         sut.onAttached(mapboxNavigation)
 
@@ -76,7 +62,6 @@ class CameraModeButtonComponentTest {
     }
 
     private class StubContract : CameraModeButtonComponentContract {
-        override var isVisible = MutableStateFlow(false)
         override var buttonState = MutableStateFlow(NavigationCameraState.IDLE)
         override fun onClick(view: View) = Unit
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes #6246 
To maintain parity with iOS implementation, action buttons - cameraMode and recenter should also show in `RoutePreview` state.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

<img src="https://user-images.githubusercontent.com/9770186/194937276-d7ed6b77-3a13-419a-8680-75d05e49a96f.png" width="250" />

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->

cc @Zayankovsky 