### PR TITLE
Resets route arrow related layers when initialization is done.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed a rare `java.lang.NullPointerException: Attempt to read from field 'SpeechAnnouncement PlayCallback.announcement' on a null object reference` crash in `PlayCallback.getAnnouncement`. [#6760](https://github.com/mapbox/mapbox-navigation-android/pull/6760)
 - Fixed standalone `MapboxManeuverView` appearance when the app also integrates Drop-In UI. [#6774](https://github.com/mapbox/mapbox-navigation-android/pull/6774)
 - Introduced `NavigationViewListener.onSpeedInfoClicked` that would be triggered when `MapboxSpeedInfoView` is clicked upon. [#6770](https://github.com/mapbox/mapbox-navigation-android/pull/6770)
+- Each newly instantiated MapboxRouteArrowView class will initialize the layers with the provided options on the first render call. Previously this would only be done if the layers hadn't already been initialized.  [#6466](https://github.com/mapbox/mapbox-navigation-android/pull/6466)
 
 ## Mapbox Navigation SDK 2.10.0-rc.1 - 16 December, 2022
 ### Changelog
@@ -64,7 +65,6 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Mapbox Navigation Native `v123.1.0`
 - Mapbox Core Common `v23.2.1`
 - Mapbox Java `v6.10.0-beta.3` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.10.0-beta.3))
-
 
 ## Mapbox Navigation SDK 2.9.5 - 13 December, 2022
 ### Changelog
@@ -256,7 +256,6 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Mapbox Core Common `v23.1.1`
 - Mapbox Java `v6.9.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.9.0))
 - Mapbox Android Core `v5.0.2` ([release notes](https://github.com/mapbox/mapbox-events-android/releases/tag/core-5.0.2))
-
 
 ## Mapbox Navigation SDK 2.9.2 - 18 November, 2022
 ### Changelog
@@ -586,7 +585,6 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Mapbox Java `v6.8.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.8.0))
 - Mapbox Android Core `v5.0.2` ([release notes](https://github.com/mapbox/mapbox-events-android/releases/tag/core-5.0.2))
 
-
 ## Mapbox Navigation SDK 2.9.0-beta.2 - 14 October, 2022
 ### Changelog
 [Changes between v2.9.0-beta.1 and v2.9.0-beta.2](https://github.com/mapbox/mapbox-navigation-android/compare/v2.9.0-beta.1...v2.9.0-beta.2)
@@ -630,7 +628,6 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Mapbox Core Common `v23.1.0-rc.2`
 - Mapbox Java `v6.8.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.8.0))
 - Mapbox Android Core `v5.0.2` ([release notes](https://github.com/mapbox/mapbox-events-android/releases/tag/core-5.0.2))
-
 
 ## Mapbox Navigation SDK 2.9.0-beta.1 - 06 October, 2022
 ### Changelog

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -1017,7 +1017,7 @@ package com.mapbox.navigation.ui.maps.route.line.api {
     method public void renderClearRouteLineValue(com.mapbox.maps.Style style, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineClearValue> clearRouteLineValue);
     method public void renderRouteDrawData(com.mapbox.maps.Style style, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue> routeDrawData);
     method public void renderRouteLineUpdate(com.mapbox.maps.Style style, com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue> update);
-    method public void setOptions(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions);
+    method @Deprecated public void setOptions(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions);
     method public void showAlternativeRoutes(com.mapbox.maps.Style style);
     method public void showOriginAndDestinationPoints(com.mapbox.maps.Style style);
     method public void showPrimaryRoute(com.mapbox.maps.Style style);

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponent.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponent.kt
@@ -5,7 +5,6 @@ import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.internal.extensions.flowRouteProgress
 import com.mapbox.navigation.core.internal.extensions.flowRoutesUpdated
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
-import com.mapbox.navigation.ui.maps.route.arrow.RouteArrowUtils
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
 import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
@@ -44,7 +43,6 @@ class RouteArrowComponent(
         super.onDetached(mapboxNavigation)
         mapboxMap.getStyle()?.also { style ->
             routeArrowView.render(style, routeArrowApi.clearArrows())
-            RouteArrowUtils.removeLayers(style)
         }
     }
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtils.kt
@@ -261,7 +261,7 @@ internal object RouteArrowUtils {
             style.styleLayerExists(RouteLayerConstants.ARROW_HEAD_LAYER_ID)
     }
 
-    internal fun removeLayers(style: Style) {
+    internal fun removeLayersAndSources(style: Style) {
         style.removeStyleImage(RouteLayerConstants.ARROW_HEAD_ICON_CASING)
         style.removeStyleImage(RouteLayerConstants.ARROW_HEAD_ICON)
         style.removeStyleLayer(RouteLayerConstants.ARROW_SHAFT_CASING_LINE_LAYER_ID)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -76,11 +76,22 @@ import org.jetbrains.annotations.TestOnly
  * @param options resource options used rendering the route line on the map
  */
 @UiThread
-class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
+class MapboxRouteLineView(options: MapboxRouteLineOptions) {
 
     private companion object {
         private const val TAG = "MbxRouteLineView"
     }
+
+    /**
+     * Resource options used rendering the route line on the map
+     */
+    var options: MapboxRouteLineOptions = options
+        @Deprecated(
+            message = "Avoid using this setter as it will not correctly " +
+                "re-apply all mutated parameters."
+        )
+        set
+
     private val sourceToFeatureMap = mutableMapOf<RouteLineSourceKey, RouteLineFeatureId>(
         Pair(MapboxRouteLineUtils.layerGroup1SourceKey, RouteLineFeatureId(null)),
         Pair(MapboxRouteLineUtils.layerGroup2SourceKey, RouteLineFeatureId(null)),
@@ -127,7 +138,7 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
     }
 
     /**
-     * Will initialize the route line related layers. Other calls in this class will initialize
+     * Initializes the route line related layers. Other calls in this class will initialize
      * the layers if they have not yet been initialized. If you have a use case for initializing
      * the layers in advance of any API calls this method may be used.
      *

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/VanishingRouteLine.kt
@@ -100,9 +100,6 @@ internal class VanishingRouteLine {
         /**
          * Calculate the percentage of the route traveled and update the expression.
          */
-        /**
-         * Calculate the percentage of the route traveled and update the expression.
-         */
         val offset = if (granularDistances.completeDistance >= remainingDistance) {
             (1.0 - remainingDistance / granularDistances.completeDistance)
         } else {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponentTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/RouteArrowComponentTest.kt
@@ -49,7 +49,7 @@ class RouteArrowComponentTest {
             every { intrinsicHeight } returns 24
             every { intrinsicWidth } returns 24
         }
-        every { RouteArrowUtils.removeLayers(any()) } just Runs
+        every { RouteArrowUtils.removeLayersAndSources(any()) } just Runs
     }
 
     @After
@@ -136,7 +136,6 @@ class RouteArrowComponentTest {
         sut.onDetached(mockMapboxNavigation)
 
         verify { mockView.render(mockStyle, clearValue) }
-        verify { RouteArrowUtils.removeLayers(mockStyle) }
     }
 
     private fun mockMapWithStyleLoaded(style: Style): MapboxMap = mockk {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/arrow/RouteArrowUtilsTest.kt
@@ -403,7 +403,7 @@ class RouteArrowUtilsTest {
             every { removeStyleImage(ARROW_HEAD_ICON) } returns mockk()
         }
 
-        RouteArrowUtils.removeLayers(style)
+        RouteArrowUtils.removeLayersAndSources(style)
 
         verifySequence {
             style.removeStyleImage(ARROW_HEAD_ICON_CASING)


### PR DESCRIPTION
### Description
When layers are initialized via the `MapboxRouteArrowView` and `MapboxRouteLineView` the layers are reset and removed so that they can be reinitialized with the options that may have change so that the layer configuration can change. Previously once the layers were initialized in the map style there was no way to adjust them. 

### Screenshots or Gifs
