### PR TITLE
[Drop-In UI] do not reset navigation camera state after view recreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Marked `RouteShieldCallback` methods with `@UiThread` annotation. [#6271](https://github.com/mapbox/mapbox-navigation-android/pull/6271)
 - Fixed an issue with `NavigationView` that caused road label position to not update after changing peek height of the Info Panel. [#6463](https://github.com/mapbox/mapbox-navigation-android/pull/6463)
 - Updated `Store` to allow `Action` dispatch from `State` observers. [#6455](https://github.com/mapbox/mapbox-navigation-android/pull/6455)
+- Improved `NavigationView` to restore navigation camera state after the view is recreated, e.g. due to a configuration change. [#6472](https://github.com/mapbox/mapbox-navigation-android/pull/6472)
 
 ## Mapbox Navigation SDK 2.9.0-beta.1 - 06 October, 2022
 ### Changelog

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/CameraStateController.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/CameraStateController.kt
@@ -1,19 +1,39 @@
 package com.mapbox.navigation.ui.app.internal.controller
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.ui.app.internal.Action
 import com.mapbox.navigation.ui.app.internal.State
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.camera.CameraAction
 import com.mapbox.navigation.ui.app.internal.camera.CameraState
 import com.mapbox.navigation.ui.app.internal.camera.TargetCameraMode
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class CameraStateController(
-    store: Store
+    private val store: Store,
 ) : StateController() {
     init {
         store.register(this)
+    }
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+
+        store.select { it.navigation }.observe { navigationState ->
+            when (navigationState) {
+                NavigationState.FreeDrive, NavigationState.RoutePreview -> {
+                    store.dispatch(CameraAction.SetCameraMode(TargetCameraMode.Overview))
+                }
+                NavigationState.DestinationPreview -> {
+                    store.dispatch(CameraAction.SetCameraMode(TargetCameraMode.Idle))
+                }
+                NavigationState.ActiveNavigation, NavigationState.Arrival -> {
+                    store.dispatch(CameraAction.SetCameraMode(TargetCameraMode.Following))
+                }
+            }
+        }
     }
 
     override fun process(state: State, action: Action): State {


### PR DESCRIPTION
### Description
Moved the logic that updates camera state based on navigation state to `CameraStateController` as it does not get reattached on view recreations. 

### Screenshots or Gifs

https://user-images.githubusercontent.com/2395284/195155473-0e0b3101-b1c0-41b6-8df0-6bc54ae43a8b.mp4



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
