### PR TITLE
add INTERNET and ACCESS_NETWORK_STATE permissions

### DIFF
--- a/libnavigation-core/src/main/AndroidManifest.xml
+++ b/libnavigation-core/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application>
 


### PR DESCRIPTION
### Description
We don't add these permissions as a library because we ourselves don't do any network requests. Please correct me if I'm wrong @mapbox/navigation-android.
The failing test (`TripServiceTest`) is part of libnavigation-core module. This module or any of its dependencies does not have these permissions. It was working before because the permissions were added from `mapbox-android-telemetry` (removed from `libnavigationmetrics` in PR #6423). 
I added the permissions only to androidTest Manifest because I don't think we should add them as part of the SDK for the reason described above. Any objections?