### PR TITLE
[Drop-IN] Expose voiceInstructionsPlayer in drop-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed an issue with `NavigationView` that caused unexpected camera movements when switching between navigation states. [#6487](https://github.com/mapbox/mapbox-navigation-android/pull/6487)
 - Supported changing `MapboxVoiceInstructionsPlayer` language in runtime via `updateLanguage` method. [#6491](https://github.com/mapbox/mapbox-navigation-android/pull/6491)
 - Deprecated `MapboxVoiceInstructionsPlayer` constructors that accept access token and introduced the ones without it. [#6491](https://github.com/mapbox/mapbox-navigation-android/pull/6491)
+- Updated `NavigationViewApi` and `MapboxAudioGuidance`. Introduced `currentVoiceInstructionsPlayer` which allows playing customers voice instructions. [#6475](https://github.com/mapbox/mapbox-navigation-android/pull/6475)
 
 ## Mapbox Navigation SDK 2.9.0-beta.2 - 14 October, 2022
 ### Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed an issue with `NavigationView` that caused unexpected camera movements when switching between navigation states. [#6487](https://github.com/mapbox/mapbox-navigation-android/pull/6487)
 - Supported changing `MapboxVoiceInstructionsPlayer` language in runtime via `updateLanguage` method. [#6491](https://github.com/mapbox/mapbox-navigation-android/pull/6491)
 - Deprecated `MapboxVoiceInstructionsPlayer` constructors that accept access token and introduced the ones without it. [#6491](https://github.com/mapbox/mapbox-navigation-android/pull/6491)
-- Updated `NavigationViewApi` and `MapboxAudioGuidance`. Introduced `currentVoiceInstructionsPlayer` which allows playing customers voice instructions. [#6475](https://github.com/mapbox/mapbox-navigation-android/pull/6475)
+- Introduced `NavigationViewApi.getCurrentVoiceInstructionsPlayer()` which can be used to play custom voice instructions. [#6475](https://github.com/mapbox/mapbox-navigation-android/pull/6475)
 
 ## Mapbox Navigation SDK 2.9.0-beta.2 - 14 October, 2022
 ### Changelog

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -37,6 +37,7 @@ package com.mapbox.navigation.dropin {
 
   @UiThread @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public abstract class NavigationViewApi {
     ctor public NavigationViewApi();
+    method public abstract com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer? getCurrentVoiceInstructionsPlayer();
     method public abstract boolean isReplayEnabled();
     method public abstract void routeReplayEnabled(boolean enabled);
     method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startActiveGuidance();
@@ -47,6 +48,7 @@ package com.mapbox.navigation.dropin {
     method public abstract void startFreeDrive();
     method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startRoutePreview();
     method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startRoutePreview(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
+    property public abstract com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer? currentVoiceInstructionsPlayer;
   }
 
   public final class NavigationViewApiError extends java.lang.Throwable {

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -48,7 +48,6 @@ package com.mapbox.navigation.dropin {
     method public abstract void startFreeDrive();
     method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startRoutePreview();
     method public abstract com.mapbox.bindgen.Expected<com.mapbox.navigation.dropin.NavigationViewApiError,kotlin.Unit> startRoutePreview(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes);
-    property public abstract com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer? currentVoiceInstructionsPlayer;
   }
 
   public final class NavigationViewApiError extends java.lang.Throwable {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewApi.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewApi.kt
@@ -8,6 +8,7 @@ import com.mapbox.bindgen.Expected
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer
 
 /**
  * Api that gives you the ability to change the state for navigation apps.
@@ -112,4 +113,9 @@ abstract class NavigationViewApi {
      * Enable/Disable replay trip session based on simulated locations.
      */
     abstract fun routeReplayEnabled(enabled: Boolean)
+
+    /**
+     * Current instance of a voice instructions player.
+     */
+    abstract val currentVoiceInstructionsPlayer: MapboxVoiceInstructionsPlayer?
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewApi.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationViewApi.kt
@@ -115,7 +115,7 @@ abstract class NavigationViewApi {
     abstract fun routeReplayEnabled(enabled: Boolean)
 
     /**
-     * Current instance of a voice instructions player.
+     * Access the current instance of [MapboxVoiceInstructionsPlayer] created by [NavigationView].
      */
-    abstract val currentVoiceInstructionsPlayer: MapboxVoiceInstructionsPlayer?
+    abstract fun getCurrentVoiceInstructionsPlayer(): MapboxVoiceInstructionsPlayer?
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/MapboxNavigationViewApi.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/MapboxNavigationViewApi.kt
@@ -20,6 +20,7 @@ import com.mapbox.navigation.ui.app.internal.startActiveNavigation
 import com.mapbox.navigation.ui.app.internal.startArrival
 import com.mapbox.navigation.ui.app.internal.tripsession.TripSessionStarterAction
 import com.mapbox.navigation.ui.voice.api.MapboxAudioGuidance
+import com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal class MapboxNavigationViewApi(
@@ -101,8 +102,9 @@ internal class MapboxNavigationViewApi(
         }
     }
 
-    override val currentVoiceInstructionsPlayer
-        get() = MapboxAudioGuidance.getRegisteredInstance().currentVoiceInstructionsPlayer
+    override fun getCurrentVoiceInstructionsPlayer(): MapboxVoiceInstructionsPlayer? {
+        return MapboxAudioGuidance.getRegisteredInstance().getCurrentVoiceInstructionsPlayer()
+    }
 
     @Throws(NavigationViewApiError::class)
     private fun checkDestination() {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/MapboxNavigationViewApi.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/MapboxNavigationViewApi.kt
@@ -19,6 +19,7 @@ import com.mapbox.navigation.ui.app.internal.showRoutePreview
 import com.mapbox.navigation.ui.app.internal.startActiveNavigation
 import com.mapbox.navigation.ui.app.internal.startArrival
 import com.mapbox.navigation.ui.app.internal.tripsession.TripSessionStarterAction
+import com.mapbox.navigation.ui.voice.api.MapboxAudioGuidance
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal class MapboxNavigationViewApi(
@@ -99,6 +100,9 @@ internal class MapboxNavigationViewApi(
             store.dispatch(TripSessionStarterAction.EnableTripSession)
         }
     }
+
+    override val currentVoiceInstructionsPlayer
+        get() = MapboxAudioGuidance.getRegisteredInstance().currentVoiceInstructionsPlayer
 
     @Throws(NavigationViewApiError::class)
     private fun checkDestination() {

--- a/libnavui-voice/api/current.txt
+++ b/libnavui-voice/api/current.txt
@@ -23,6 +23,7 @@ package com.mapbox.navigation.ui.voice.api {
 
   public final class MapboxAudioGuidance implements com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver {
     method public static com.mapbox.navigation.ui.voice.api.MapboxAudioGuidance create();
+    method public com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer? getCurrentVoiceInstructionsPlayer();
     method public static com.mapbox.navigation.ui.voice.api.MapboxAudioGuidance getRegisteredInstance();
     method public void mute();
     method public void onAttached(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
@@ -30,6 +31,7 @@ package com.mapbox.navigation.ui.voice.api {
     method public kotlinx.coroutines.flow.StateFlow<com.mapbox.navigation.ui.voice.api.MapboxAudioGuidanceState> stateFlow();
     method public void toggle();
     method public void unmute();
+    property public final com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer? currentVoiceInstructionsPlayer;
     field public static final com.mapbox.navigation.ui.voice.api.MapboxAudioGuidance.Companion Companion;
   }
 

--- a/libnavui-voice/api/current.txt
+++ b/libnavui-voice/api/current.txt
@@ -31,7 +31,6 @@ package com.mapbox.navigation.ui.voice.api {
     method public kotlinx.coroutines.flow.StateFlow<com.mapbox.navigation.ui.voice.api.MapboxAudioGuidanceState> stateFlow();
     method public void toggle();
     method public void unmute();
-    property public final com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer? currentVoiceInstructionsPlayer;
     field public static final com.mapbox.navigation.ui.voice.api.MapboxAudioGuidance.Companion Companion;
   }
 

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidance.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidance.kt
@@ -50,6 +50,11 @@ internal constructor(
     private var job: Job? = null
 
     /**
+     * Current instance of a [VoiceInstructionsPlayer].
+     */
+    val currentVoiceInstructionsPlayer get() = audioGuidanceServices.voiceInstructionsPlayer
+
+    /**
      * @see [MapboxNavigationApp]
      */
     override fun onAttached(mapboxNavigation: MapboxNavigation) {

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidance.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidance.kt
@@ -52,7 +52,7 @@ internal constructor(
     /**
      * Current instance of a [VoiceInstructionsPlayer].
      */
-    val currentVoiceInstructionsPlayer get() = audioGuidanceServices.voiceInstructionsPlayer
+    fun getCurrentVoiceInstructionsPlayer() = audioGuidanceServices.voiceInstructionsPlayer
 
     /**
      * @see [MapboxNavigationApp]

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/impl/MapboxAudioGuidanceServices.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/impl/MapboxAudioGuidanceServices.kt
@@ -11,7 +11,7 @@ import com.mapbox.navigation.ui.voice.internal.MapboxVoiceInstructions
 
 class MapboxAudioGuidanceServices {
 
-    private var voiceInstructionsPlayer: MapboxVoiceInstructionsPlayer? = null
+    var voiceInstructionsPlayer: MapboxVoiceInstructionsPlayer? = null
 
     fun mapboxAudioGuidanceVoice(
         mapboxNavigation: MapboxNavigation,

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/impl/MapboxAudioGuidanceServices.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/impl/MapboxAudioGuidanceServices.kt
@@ -12,6 +12,7 @@ import com.mapbox.navigation.ui.voice.internal.MapboxVoiceInstructions
 class MapboxAudioGuidanceServices {
 
     var voiceInstructionsPlayer: MapboxVoiceInstructionsPlayer? = null
+        private set
 
     fun mapboxAudioGuidanceVoice(
         mapboxNavigation: MapboxNavigation,

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidanceTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidanceTest.kt
@@ -211,4 +211,17 @@ class MapboxAudioGuidanceTest {
             }
             carAppAudioGuidance.onDetached(mapboxNavigation)
         }
+
+    @Test
+    fun `getCurrentVoiceInstructionsPlayer returns valid player instance`() {
+        val mapboxAudioGuidanceServices =
+            testMapboxAudioGuidanceServices.mapboxAudioGuidanceServices
+
+        every { mapboxAudioGuidanceServices.voiceInstructionsPlayer } returns null
+        assertNull(carAppAudioGuidance.getCurrentVoiceInstructionsPlayer())
+
+        val player: MapboxVoiceInstructionsPlayer = mockk()
+        every { mapboxAudioGuidanceServices.voiceInstructionsPlayer } returns player
+        assertEquals(player, carAppAudioGuidance.getCurrentVoiceInstructionsPlayer())
+    }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -85,6 +85,7 @@ import com.mapbox.navigation.qa_test_app.view.base.DrawerActivity
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import com.mapbox.navigation.ui.maps.NavigationStyles
+import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
 import com.mapbox.navigation.utils.internal.toPoint
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
@@ -147,6 +148,13 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
                 binding.navigationView.api.routeReplayEnabled(isChecked)
             }
         )
+        menuBinding.buttonVoiceInstruction.setOnClickListener {
+            binding.navigationView.api.getCurrentVoiceInstructionsPlayer()?.play(
+                SpeechAnnouncement.Builder("This is a test voice instruction").build()
+            ) {
+                // no op
+            }
+        }
         initActivityOptions()
         initGeneralOptions()
         initMapOptions()

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -423,6 +423,12 @@
 
             </androidx.appcompat.widget.LinearLayoutCompat>
 
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/buttonVoiceInstruction"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Play voice instruction" />
+
         </androidx.appcompat.widget.LinearLayoutCompat>
 
     </androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

need to expose as a flow because `MapboxAudioGuidanceVoice` is created in `MapboxAudioGuidance` when some flows are combined, so we have some delay. If we don't use a flow, and expose a player directly, it will be null until combine is triggered ^^, i.e. it will be null if we use it in `activity::onCreate`

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
