### PR TITLE
[Drop-In UI] synchronize drop-in navigation routes with mapbox navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed an issue that prevented any registered `OnBackPressedCallback`s to fire when `NavigationView` is attached. [#6483](https://github.com/mapbox/mapbox-navigation-android/pull/6483)
 - Removed `NavigationViewListener.onBackPressed()`. You can register your own [OnBackPressedCallback](https://developer.android.com/reference/androidx/activity/OnBackPressedCallback) to intercept any `NavigationView` BACK press events. [#6483](https://github.com/mapbox/mapbox-navigation-android/pull/6483)
 - Fixed an issue with `NavigationView` that caused trip session not to start after granting location permissions that were requested outside of Drop-In UI by an application. [#6489](https://github.com/mapbox/mapbox-navigation-android/pull/6489)
+- Fixed an issue with `NavigationView` that caused unexpected camera movements when switching between navigation states. [#6487](https://github.com/mapbox/mapbox-navigation-android/pull/6487)
 
 ## Mapbox Navigation SDK 2.9.0-beta.2 - 14 October, 2022
 ### Changelog

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/RouteStateController.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/RouteStateController.kt
@@ -3,13 +3,14 @@ package com.mapbox.navigation.ui.app.internal.controller
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.extensions.flowRoutesUpdated
 import com.mapbox.navigation.ui.app.internal.Action
 import com.mapbox.navigation.ui.app.internal.State
 import com.mapbox.navigation.ui.app.internal.Store
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutesAction
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
-class RouteStateController(store: Store) : StateController() {
+class RouteStateController(private val store: Store) : StateController() {
     init {
         store.register(this)
     }
@@ -19,6 +20,9 @@ class RouteStateController(store: Store) : StateController() {
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
         this.mapboxNavigation = mapboxNavigation
+        mapboxNavigation.flowRoutesUpdated().observe { result ->
+            store.dispatch(RoutesAction.SynchronizeRoutes(result.navigationRoutes))
+        }
     }
 
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
@@ -44,6 +48,9 @@ class RouteStateController(store: Store) : StateController() {
         return when (action) {
             is RoutesAction.SetRoutes -> {
                 mapboxNavigation.setNavigationRoutes(action.routes, action.legIndex)
+                action.routes
+            }
+            is RoutesAction.SynchronizeRoutes -> {
                 action.routes
             }
         }

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutesAction.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutesAction.kt
@@ -2,6 +2,7 @@ package com.mapbox.navigation.ui.app.internal.routefetch
 
 import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.ui.app.internal.Action
 
 /**
@@ -15,4 +16,11 @@ sealed class RoutesAction : Action {
      * @param legIndex optional index of [RouteLeg]
      */
     data class SetRoutes(val routes: List<NavigationRoute>, val legIndex: Int = 0) : RoutesAction()
+
+    /**
+     * The action is used to synchronize the [NavigationRoute]
+     * supplied to [MapboxNavigation] and NavigationView.
+     * @param routes list of [NavigationRoute]
+     */
+    data class SynchronizeRoutes(val routes: List<NavigationRoute>) : RoutesAction()
 }

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/RouteStateControllerTest.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/RouteStateControllerTest.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.ui.app.internal.controller
 
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
@@ -8,53 +7,50 @@ import com.mapbox.navigation.ui.app.internal.routefetch.RoutesAction
 import com.mapbox.navigation.ui.app.testing.TestStore
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.spyk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-@OptIn(ExperimentalCoroutinesApi::class, ExperimentalPreviewMapboxNavigationAPI::class)
 internal class RouteStateControllerTest {
+
+    private val store = TestStore()
+    private val sut = RouteStateController(store)
+    private val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+    private val routes = listOf(mockk<NavigationRoute>())
 
     @Test
     fun `when RoutesAction SetRoute it sets route to mapboxNavigation`() {
-        val store = spyk(TestStore())
-        val sut = RouteStateController(store)
-        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
-        val routes = listOf(mockk<NavigationRoute>())
-        every { mapboxNavigation.registerRoutesObserver(any()) } answers {
-            firstArg<RoutesObserver>().onRoutesChanged(
-                mockk {
-                    every { navigationRoutes } returns routes
-                }
-            )
-        }
-
         sut.onAttached(mapboxNavigation)
 
-        store.dispatch(RoutesAction.SetRoutes(routes))
+        store.dispatch(RoutesAction.SetRoutes(routes, legIndex = 1))
 
-        assertEquals(store.state.value.routes.size, routes.size)
+        assertEquals(store.state.value.routes, routes)
+        verify(exactly = 1) { mapboxNavigation.setNavigationRoutes(routes, initialLegIndex = 1) }
     }
 
     @Test
-    fun `when RoutesAction SetRouteIndex it sets route to mapboxNavigation`() {
-        val store = spyk(TestStore())
-        val sut = RouteStateController(store)
-        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
-        val routes = listOf(mockk<NavigationRoute>())
+    fun `when RoutesAction SynchronizeRoutes it does not set route to mapboxNavigation`() {
+        sut.onAttached(mapboxNavigation)
+
+        store.dispatch(RoutesAction.SynchronizeRoutes(routes))
+
+        assertEquals(store.state.value.routes, routes)
+        verify(exactly = 0) { mapboxNavigation.setNavigationRoutes(any(), any(), any()) }
+    }
+
+    @Test
+    fun `when RoutesObserver is invoked it does not set route to mapboxNavigation`() {
         every { mapboxNavigation.registerRoutesObserver(any()) } answers {
             firstArg<RoutesObserver>().onRoutesChanged(
                 mockk {
-                    every { navigationRoutes } returns routes
+                    every { navigationRoutes } returns this@RouteStateControllerTest.routes
                 }
             )
         }
 
         sut.onAttached(mapboxNavigation)
 
-        store.dispatch(RoutesAction.SetRoutes(routes, 1))
-
-        assertEquals(store.state.value.routes.size, routes.size)
+        assertEquals(store.state.value.routes, routes)
+        verify(exactly = 0) { mapboxNavigation.setNavigationRoutes(any(), any(), any()) }
     }
 }


### PR DESCRIPTION
### Description
In some cases (like reroute or route refresh) `MapboxNavigation` routes are updated, but `SharedApp` still references the old ones. With this change the routes are kept in sync. This lets us simplify `CameraComponent` by observing routes from `SharedApp` instead of `MapboxNavigation`, which also fixed a couple of camera issues. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
