### PR TITLE
[Drop-In UI] check if location permissions are granted on inResume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Made `MapViewBinder#shouldLoadMapStyle` false by default. [#6485](https://github.com/mapbox/mapbox-navigation-android/pull/6485)
 - Fixed an issue that prevented any registered `OnBackPressedCallback`s to fire when `NavigationView` is attached. [#6483](https://github.com/mapbox/mapbox-navigation-android/pull/6483)
 - Removed `NavigationViewListener.onBackPressed()`. You can register your own [OnBackPressedCallback](https://developer.android.com/reference/androidx/activity/OnBackPressedCallback) to intercept any `NavigationView` BACK press events. [#6483](https://github.com/mapbox/mapbox-navigation-android/pull/6483)
+- Fixed an issue with `NavigationView` that caused trip session not to start after granting location permissions that were requested outside of Drop-In UI by an application. [#6489](https://github.com/mapbox/mapbox-navigation-android/pull/6489)
 
 ## Mapbox Navigation SDK 2.9.0-beta.2 - 14 October, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/LocationPermissionComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/LocationPermissionComponent.kt
@@ -80,11 +80,12 @@ internal class LocationPermissionComponent(
     /**
      * When the app is launched without location permissions. Run a check to see if location
      * permissions have been accepted yet. This will catch the case where a user will enable
-     * location permissions through the app settings.
+     * location permissions through the app settings or
+     * when developers request location permissions themselves.
      */
     private fun notifyGrantedOnForegrounded(applicationContext: Context) {
         coroutineScope.launch {
-            componentActivityRef.get()?.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            componentActivityRef.get()?.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 if (!store.state.value.tripSession.isLocationPermissionGranted) {
                     val isGranted = PermissionsManager.areLocationPermissionsGranted(
                         applicationContext

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/permission/LocationPermissionComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/permission/LocationPermissionComponentTest.kt
@@ -188,7 +188,7 @@ class LocationPermissionComponentTest {
 
             locationPermissionComponent.onAttached(mockMapboxNavigation())
             every { PermissionsManager.areLocationPermissionsGranted(any()) } returns true
-            testLifecycle.lifecycleRegistry.currentState = Lifecycle.State.STARTED
+            testLifecycle.lifecycleRegistry.currentState = Lifecycle.State.RESUMED
 
             verify {
                 testStore.dispatch(


### PR DESCRIPTION
### Description
If developer requests location permissions themselves and user grants them, then `LocationPermissionComponent` is not aware of that and therefore trip session is not started, because permission status is checked in `onStart`, while permission dialog only causes the app to become paused.  

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
