### PR TITLE
[Android Auto] Prepare androidauto-v0.15.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
       mapboxCore                : '5.0.2',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '23.1.0-rc.2',
-      mapboxSearchSdk           : '1.0.0-beta.37',
+      mapboxSearchSdk           : '1.0.0-beta.38.1',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.8.0',

--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -4,6 +4,13 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+#### Bug fixes and improvements
+
+## androidauto-v0.15.0 - October 21, 2022
+### Changelog
+[Changes between 0.14.0 and 0.15.0](https://github.com/mapbox/mapbox-navigation-android/compare/androidauto-v0.14.0...androidauto-v0.15.0)
+
+#### Features
 - Added a new `MapboxCarOptions` that contains mutable options for `MapboxCarContext`. [#6478](https://github.com/mapbox/mapbox-navigation-android/pull/6478)
 - Added a new `MapboxCarOptionsCustomization` that allows you to change the `MapboxCarOptions`. [#6478](https://github.com/mapbox/mapbox-navigation-android/pull/6478)
 
@@ -14,6 +21,12 @@ Mapbox welcomes participation and contributions from everyone.
 - Deleted `ActionProvider` and `ScreenActionProvider` in favor of `MapboxActionProvider`. [#6494](https://github.com/mapbox/mapbox-navigation-android/pull/6494)
 - Renamed `CarAppLocation` to `CarLocationProvider` with a `getRegisteredInstance` accessor. [#6492](https://github.com/mapbox/mapbox-navigation-android/pull/6492)
 - Removed `MapboxCarApp` as it is no longer needed. Use `CarLocationProvider.getRegisteredInstance()` if needed. [#6492](https://github.com/mapbox/mapbox-navigation-android/pull/6492)
+
+### Mapbox dependencies
+This release defines minimum versions for the Mapbox dependencies.
+- Mapbox Maps Android Auto Extension `v0.3.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/extension-androidauto-v0.3.0))
+- Mapbox Navigation `v2.9.0-beta.3` ([release notes](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.9.0-beta.3))
+- Mapbox Search `v1.0.0-beta.38.1` ([release notes](https://github.com/mapbox/mapbox-search-android/releases/tag/v1.0.0-beta.38.1))
 
 ## androidauto-v0.14.0 - October 13, 2022
 ### Changelog

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     // This defines the minimum version of Navigation which is included in this SDK. To upgrade the
     // Navigation versions, you can specify a newer version in your downstream build.gradle.
-    releaseApi("com.mapbox.navigation:android:2.9.0-beta.1")
+    releaseApi("com.mapbox.navigation:android:2.9.0-beta.3")
     debugApi project(":libnavigation-android")
 
     // Search is currently in beta so it is not included in this SDK. The functionality of search


### PR DESCRIPTION
Updating the dependencies and the changelog. Mapbox Search is not on the exact same common sdk version (23.1.0-rc.1 vs 23.1.0-rc.2). But I didn't find an issue with this.

## androidauto-v0.15.0 - October 21, 2022
### Changelog
[Changes between 0.14.0 and 0.15.0](https://github.com/mapbox/mapbox-navigation-android/compare/androidauto-v0.14.0...androidauto-v0.15.0)

#### Features
- Added a new `MapboxCarOptions` that contains mutable options for `MapboxCarContext`. [#6478](https://github.com/mapbox/mapbox-navigation-android/pull/6478)
- Added a new `MapboxCarOptionsCustomization` that allows you to change the `MapboxCarOptions`. [#6478](https://github.com/mapbox/mapbox-navigation-android/pull/6478)

#### Bug fixes and improvements
- Removed options from the `MapboxCarContext` constructor so that it can be compatible with future changes. [#6478](https://github.com/mapbox/mapbox-navigation-android/pull/6478)
- Deleted `RoutePreviewCarContext` in favor of `MapboxCarContext`. [#6478](https://github.com/mapbox/mapbox-navigation-android/pull/6478)
- Renamed `CarSettingsStorage` to `MapboxCarStorage`. [#6478](https://github.com/mapbox/mapbox-navigation-android/pull/6478)
- Deleted `ActionProvider` and `ScreenActionProvider` in favor of `MapboxActionProvider`. [#6494](https://github.com/mapbox/mapbox-navigation-android/pull/6494)
- Renamed `CarAppLocation` to `CarLocationProvider` with a `getRegisteredInstance` accessor. [#6492](https://github.com/mapbox/mapbox-navigation-android/pull/6492)
- Removed `MapboxCarApp` as it is no longer needed. Use `CarLocationProvider.getRegisteredInstance()` if needed. [#6492](https://github.com/mapbox/mapbox-navigation-android/pull/6492)

### Mapbox dependencies
This release defines minimum versions for the Mapbox dependencies.
- Mapbox Maps Android Auto Extension `v0.3.0` ([release notes](https://github.com/mapbox/mapbox-maps-android/releases/tag/extension-androidauto-v0.3.0))
- Mapbox Navigation `v2.9.0-beta.3` ([release notes](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.9.0-beta.3))
- Mapbox Search `v1.0.0-beta.38.1` ([release notes](https://github.com/mapbox/mapbox-search-android/releases/tag/v1.0.0-beta.38.1))
