### PR TITLE
[Drop-In UI] fix road label position not updating in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 #### Bug fixes and improvements
 - Improved experience in tunnels and reduced the likelihood of losing road edge matching candidates. [#6510](https://github.com/mapbox/mapbox-navigation-android/pull/6510)
+- Fixed an issue with `NavigationView` that caused road label position to not update in some cases. [#6508](https://github.com/mapbox/mapbox-navigation-android/pull/6508)
 
 ## Mapbox Navigation SDK 2.9.0-beta.3 - 21 October, 2022
 ### Changelog


### PR DESCRIPTION
### Description
I was able to reproduce the issue only in 1TAP. In some cases `OnLayoutChangeListener` is not invoked, unlike `OnGlobalLayoutChangeListener`. Also I disabled peek height change animations, because they don't work if you update info panel content at the same time (which I believe is a common case) and they cause issues if developer uses transitions for updating info panel content (in which case peek height change is animated already). This is how transitions look in 1TAP:

https://user-images.githubusercontent.com/2395284/197788078-df1b858f-ded0-4608-8091-372bf037f314.mp4

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
