### PR TITLE
[Drop-In UI] Add binders and customization options for POINameComponent and ArrivalTextComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Mapbox welcomes participation and contributions from everyone.
   - `ViewOptionsCustomization.showRoutePreviewButton` can be used to show/hide info panel's show route preview button. The default is `true`. [#6506](https://github.com/mapbox/mapbox-navigation-android/pull/6506)
   - `ViewOptionsCustomization.showStartNavigationButton` can be used to show/hide info panel's start navigation button. The default is `true`. [#6506](https://github.com/mapbox/mapbox-navigation-android/pull/6506)
   - `ViewOptionsCustomization.showEndNavigationButton` can be used to show/hide info panel's end navigation button. The default is `true`. [#6506](https://github.com/mapbox/mapbox-navigation-android/pull/6506)
+- Introduced `ViewOptionsCustomization.showPoiName` and `ViewOptionsCustomization.showArrivalText` that allows showing/hiding of the POI and arrival text view. [#6515](https://github.com/mapbox/mapbox-navigation-android/pull/6515)
+- Introduced `ViewBinderCustomization.infoPanelPoiNameBinder` and `ViewBinderCustomization.infoPanelArrivalTextBinder` that allows injection of custom Info Panel POI and arrival text view into `NavigationView`. [#6515](https://github.com/mapbox/mapbox-navigation-android/pull/6515)
 #### Bug fixes and improvements
 - :warning: Removed `MapboxMapScalebarParams` and replaced `ViewStyleCustomization.mapScalebarParams` by `ViewOptionsCustomization.showMapScalebar` [#6523](https://github.com/mapbox/mapbox-navigation-android/pull/6523)
 - Refactored `ScalebarComponent` to use `ViewOptionsCustomization.distanceFormatterOptions` to change between imperial and metric based unit. [#6523](https://github.com/mapbox/mapbox-navigation-android/pull/6523)

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -68,6 +68,7 @@ package com.mapbox.navigation.dropin {
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getActionRecenterButtonBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getActionToggleAudioButtonBinder();
     method public java.util.List<com.mapbox.navigation.dropin.actionbutton.ActionButtonDescription>? getCustomActionButtons();
+    method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelArrivalTextBinder();
     method public com.mapbox.navigation.dropin.infopanel.InfoPanelBinder? getInfoPanelBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelContentBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelEndNavigationButtonBinder();
@@ -77,6 +78,7 @@ package com.mapbox.navigation.dropin {
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelHeaderDestinationPreviewBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelHeaderFreeDriveBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelHeaderRoutesPreviewBinder();
+    method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelPoiNameBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelRoutePreviewButtonBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelStartNavigationButtonBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getInfoPanelTripProgressBinder();
@@ -92,6 +94,7 @@ package com.mapbox.navigation.dropin {
     method public void setActionRecenterButtonBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setActionToggleAudioButtonBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setCustomActionButtons(java.util.List<com.mapbox.navigation.dropin.actionbutton.ActionButtonDescription>?);
+    method public void setInfoPanelArrivalTextBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setInfoPanelBinder(com.mapbox.navigation.dropin.infopanel.InfoPanelBinder?);
     method public void setInfoPanelContentBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setInfoPanelEndNavigationButtonBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
@@ -101,6 +104,7 @@ package com.mapbox.navigation.dropin {
     method public void setInfoPanelHeaderDestinationPreviewBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setInfoPanelHeaderFreeDriveBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setInfoPanelHeaderRoutesPreviewBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
+    method public void setInfoPanelPoiNameBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setInfoPanelRoutePreviewButtonBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setInfoPanelStartNavigationButtonBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setInfoPanelTripProgressBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
@@ -116,6 +120,7 @@ package com.mapbox.navigation.dropin {
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? actionRecenterButtonBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? actionToggleAudioButtonBinder;
     property public final java.util.List<com.mapbox.navigation.dropin.actionbutton.ActionButtonDescription>? customActionButtons;
+    property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelArrivalTextBinder;
     property public final com.mapbox.navigation.dropin.infopanel.InfoPanelBinder? infoPanelBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelContentBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelEndNavigationButtonBinder;
@@ -125,6 +130,7 @@ package com.mapbox.navigation.dropin {
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelHeaderDestinationPreviewBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelHeaderFreeDriveBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelHeaderRoutesPreviewBinder;
+    property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelPoiNameBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelRoutePreviewButtonBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelStartNavigationButtonBinder;
     property public final com.mapbox.navigation.ui.base.lifecycle.UIBinder? infoPanelTripProgressBinder;
@@ -146,6 +152,7 @@ package com.mapbox.navigation.dropin {
     method public com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions? getRouteArrowOptions();
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions? getRouteLineOptions();
     method public Boolean? getShowActionButtons();
+    method public Boolean? getShowArrivalText();
     method public Boolean? getShowCameraDebugInfo();
     method public Boolean? getShowCameraModeActionButton();
     method public Boolean? getShowCompassActionButton();
@@ -153,6 +160,7 @@ package com.mapbox.navigation.dropin {
     method public Boolean? getShowInfoPanelInFreeDrive();
     method public Boolean? getShowManeuver();
     method public Boolean? getShowMapScalebar();
+    method public Boolean? getShowPoiName();
     method public Boolean? getShowRecenterActionButton();
     method public Boolean? getShowRoadName();
     method public Boolean? getShowRoutePreviewButton();
@@ -170,6 +178,7 @@ package com.mapbox.navigation.dropin {
     method public void setRouteArrowOptions(com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions?);
     method public void setRouteLineOptions(com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions?);
     method public void setShowActionButtons(Boolean?);
+    method public void setShowArrivalText(Boolean?);
     method public void setShowCameraDebugInfo(Boolean?);
     method public void setShowCameraModeActionButton(Boolean?);
     method public void setShowCompassActionButton(Boolean?);
@@ -177,6 +186,7 @@ package com.mapbox.navigation.dropin {
     method public void setShowInfoPanelInFreeDrive(Boolean?);
     method public void setShowManeuver(Boolean?);
     method public void setShowMapScalebar(Boolean?);
+    method public void setShowPoiName(Boolean?);
     method public void setShowRecenterActionButton(Boolean?);
     method public void setShowRoadName(Boolean?);
     method public void setShowRoutePreviewButton(Boolean?);
@@ -193,6 +203,7 @@ package com.mapbox.navigation.dropin {
     property public final com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions? routeArrowOptions;
     property public final com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions? routeLineOptions;
     property public final Boolean? showActionButtons;
+    property public final Boolean? showArrivalText;
     property public final Boolean? showCameraDebugInfo;
     property public final Boolean? showCameraModeActionButton;
     property public final Boolean? showCompassActionButton;
@@ -200,6 +211,7 @@ package com.mapbox.navigation.dropin {
     property public final Boolean? showInfoPanelInFreeDrive;
     property public final Boolean? showManeuver;
     property public final Boolean? showMapScalebar;
+    property public final Boolean? showPoiName;
     property public final Boolean? showRecenterActionButton;
     property public final Boolean? showRoadName;
     property public final Boolean? showRoutePreviewButton;

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
@@ -47,6 +47,18 @@ class ViewBinderCustomization {
     var infoPanelTripProgressBinder: UIBinder? = null
 
     /**
+     * Customize the Info Panel Point Of Interest Name text view by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var infoPanelPoiNameBinder: UIBinder? = null
+
+    /**
+     * Customize the Info Panel Arrival text view by providing your own [UIBinder].
+     * Use [UIBinder.USE_DEFAULT] to reset to default.
+     */
+    var infoPanelArrivalTextBinder: UIBinder? = null
+
+    /**
      * Customize the Info Panel Header by providing your own [UIBinder].
      * Use [UIBinder.USE_DEFAULT] to reset to default.
      */

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewOptionsCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewOptionsCustomization.kt
@@ -163,6 +163,18 @@ class ViewOptionsCustomization {
      */
     var showStartNavigationButton: Boolean? = null
 
+    /**
+     * Sets whether the POI text view should be visible.
+     * Set to `true` for the default behavior.
+     */
+    var showPoiName: Boolean? = null
+
+    /**
+     * Sets whether the arrival text view should be visible.
+     * Set to `true` for the default behavior.
+     */
+    var showArrivalText: Boolean? = null
+
     companion object {
         /**
          * Default route line options.

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelArrivalTextBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelArrivalTextBinder.kt
@@ -4,34 +4,27 @@ import android.transition.Scene
 import android.transition.TransitionManager
 import android.view.ViewGroup
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
-import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.dropin.R
-import com.mapbox.navigation.dropin.databinding.MapboxInfoPanelHeaderArrivalLayoutBinding
-import com.mapbox.navigation.dropin.internal.extensions.arrivalTextComponent
-import com.mapbox.navigation.dropin.internal.extensions.endNavigationButtonComponent
+import com.mapbox.navigation.dropin.arrival.ArrivalTextComponent
+import com.mapbox.navigation.dropin.databinding.MapboxArrivalTextViewLayoutBinding
 import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal class InfoPanelHeaderArrivalBinder(
+internal class InfoPanelArrivalTextBinder(
     private val context: NavigationViewContext
 ) : UIBinder {
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
         val scene = Scene.getSceneForLayout(
             viewGroup,
-            R.layout.mapbox_info_panel_header_arrival_layout,
+            R.layout.mapbox_arrival_text_view_layout,
             viewGroup.context
         )
         TransitionManager.go(scene)
-        val binding = MapboxInfoPanelHeaderArrivalLayoutBinding.bind(viewGroup)
+        val binding = MapboxArrivalTextViewLayoutBinding.bind(viewGroup)
 
-        return context.run {
-            navigationListOf(
-                arrivalTextComponent(binding.arrivedTextContainer),
-                endNavigationButtonComponent(binding.endNavigationButtonLayout)
-            )
-        }
+        return ArrivalTextComponent(binding.arrivedText, context.styles.arrivalTextAppearance)
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderDestinationPreviewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderDestinationPreviewBinder.kt
@@ -30,7 +30,7 @@ internal class InfoPanelHeaderDestinationPreviewBinder(
 
         return context.run {
             navigationListOf(
-                poiNameComponent(binding.poiName),
+                poiNameComponent(binding.poiNameContainer),
                 routePreviewButtonComponent(binding.routePreviewContainer),
                 startNavigationButtonComponent(binding.startNavigationContainer)
             )

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelPoiNameBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelPoiNameBinder.kt
@@ -4,34 +4,31 @@ import android.transition.Scene
 import android.transition.TransitionManager
 import android.view.ViewGroup
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
-import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.dropin.R
-import com.mapbox.navigation.dropin.databinding.MapboxInfoPanelHeaderArrivalLayoutBinding
-import com.mapbox.navigation.dropin.internal.extensions.arrivalTextComponent
-import com.mapbox.navigation.dropin.internal.extensions.endNavigationButtonComponent
+import com.mapbox.navigation.dropin.databinding.MapboxPoiTextViewLayoutBinding
+import com.mapbox.navigation.dropin.map.geocoding.POINameComponent
 import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal class InfoPanelHeaderArrivalBinder(
+internal class InfoPanelPoiNameBinder(
     private val context: NavigationViewContext
 ) : UIBinder {
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
         val scene = Scene.getSceneForLayout(
             viewGroup,
-            R.layout.mapbox_info_panel_header_arrival_layout,
+            R.layout.mapbox_poi_text_view_layout,
             viewGroup.context
         )
         TransitionManager.go(scene)
-        val binding = MapboxInfoPanelHeaderArrivalLayoutBinding.bind(viewGroup)
+        val binding = MapboxPoiTextViewLayoutBinding.bind(viewGroup)
 
-        return context.run {
-            navigationListOf(
-                arrivalTextComponent(binding.arrivedTextContainer),
-                endNavigationButtonComponent(binding.endNavigationButtonLayout)
-            )
-        }
+        return POINameComponent(
+            context.store,
+            binding.poiName,
+            context.styles.poiNameTextAppearance
+        )
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/extensions/NavigationViewContextEx.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/extensions/NavigationViewContextEx.kt
@@ -4,7 +4,6 @@ package com.mapbox.navigation.dropin.internal.extensions
 
 import android.view.ViewGroup
 import androidx.annotation.Px
-import androidx.appcompat.widget.AppCompatTextView
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.dropin.EmptyBinder
@@ -12,18 +11,31 @@ import com.mapbox.navigation.dropin.actionbutton.AudioGuidanceButtonBinder
 import com.mapbox.navigation.dropin.actionbutton.CameraModeButtonBinder
 import com.mapbox.navigation.dropin.actionbutton.CompassButtonBinder
 import com.mapbox.navigation.dropin.actionbutton.RecenterButtonBinder
-import com.mapbox.navigation.dropin.arrival.ArrivalTextComponent
+import com.mapbox.navigation.dropin.infopanel.InfoPanelArrivalTextBinder
 import com.mapbox.navigation.dropin.infopanel.InfoPanelEndNavigationButtonBinder
+import com.mapbox.navigation.dropin.infopanel.InfoPanelPoiNameBinder
 import com.mapbox.navigation.dropin.infopanel.InfoPanelRoutePreviewButtonBinder
 import com.mapbox.navigation.dropin.infopanel.InfoPanelStartNavigationButtonBinder
-import com.mapbox.navigation.dropin.map.geocoding.POINameComponent
 import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
 import com.mapbox.navigation.dropin.tripprogress.TripProgressBinder
 import kotlinx.coroutines.flow.combine
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal fun NavigationViewContext.poiNameComponent(textView: AppCompatTextView) =
-    POINameComponent(store, textView, styles.poiNameTextAppearance)
+internal fun NavigationViewContext.poiNameComponent(
+    viewGroup: ViewGroup
+): MapboxNavigationObserver {
+    val binderFlow = combine(
+        options.showPoiName,
+        uiBinders.infoPanelPoiNameBinder
+    ) { show, binder ->
+        if (show) {
+            binder ?: InfoPanelPoiNameBinder(this)
+        } else {
+            EmptyBinder()
+        }
+    }
+    return reloadOnChange(binderFlow) { it.bind(viewGroup) }
+}
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal fun NavigationViewContext.routePreviewButtonComponent(
@@ -77,8 +89,21 @@ internal fun NavigationViewContext.endNavigationButtonComponent(
 }
 
 @ExperimentalPreviewMapboxNavigationAPI
-internal fun NavigationViewContext.arrivalTextComponent(textView: AppCompatTextView) =
-    ArrivalTextComponent(textView, styles.arrivalTextAppearance)
+internal fun NavigationViewContext.arrivalTextComponent(
+    viewGroup: ViewGroup
+): MapboxNavigationObserver {
+    val binderFlow = combine(
+        options.showArrivalText,
+        uiBinders.infoPanelArrivalTextBinder
+    ) { show, binder ->
+        if (show) {
+            binder ?: InfoPanelArrivalTextBinder(this)
+        } else {
+            EmptyBinder()
+        }
+    }
+    return reloadOnChange(binderFlow) { it.bind(viewGroup) }
+}
 
 @ExperimentalPreviewMapboxNavigationAPI
 internal fun NavigationViewContext.tripProgressComponent(

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/map/geocoding/POINameComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/map/geocoding/POINameComponent.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.StateFlow
 internal class POINameComponent(
     private val store: Store,
     private val textView: AppCompatTextView,
-    private val textAppearance: StateFlow<Int>
+    private val textAppearance: StateFlow<Int>,
 ) : UIComponent() {
     private val resources get() = textView.resources
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewBinder.kt
@@ -96,6 +96,16 @@ internal class NavigationViewBinder {
     val infoPanelTripProgressBinder: StateFlow<UIBinder?>
         get() = _infoPanelTripProgressBinder.asStateFlow()
 
+    private val _infoPanelPoiNameBinder: MutableStateFlow<UIBinder?> =
+        MutableStateFlow(null)
+    val infoPanelPoiNameBinder: StateFlow<UIBinder?>
+        get() = _infoPanelPoiNameBinder.asStateFlow()
+
+    private val _infoPanelArrivalTextBinder: MutableStateFlow<UIBinder?> =
+        MutableStateFlow(null)
+    val infoPanelArrivalTextBinder: StateFlow<UIBinder?>
+        get() = _infoPanelArrivalTextBinder.asStateFlow()
+
     private val _infoPanelRoutePreviewButtonBinder: MutableStateFlow<UIBinder?> =
         MutableStateFlow(null)
     val infoPanelRoutePreviewButtonBinder: StateFlow<UIBinder?> =
@@ -160,6 +170,11 @@ internal class NavigationViewBinder {
         customization.infoPanelTripProgressBinder?.also {
             _infoPanelTripProgressBinder.emitOrNull(it)
         }
+        customization.infoPanelPoiNameBinder?.also { _infoPanelPoiNameBinder.emitOrNull(it) }
+        customization.infoPanelArrivalTextBinder?.also {
+            _infoPanelArrivalTextBinder.emitOrNull(it)
+        }
+
         customization.infoPanelContentBinder?.also { _infoPanelContentBinder.emitOrNull(it) }
 
         customization.infoPanelRoutePreviewButtonBinder?.also {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewOptions.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewOptions.kt
@@ -80,6 +80,12 @@ internal class NavigationViewOptions(context: Context) {
     val showEndNavigationButton: StateFlow<Boolean> = _showEndNavigationButton.asStateFlow()
     val showStartNavigationButton: StateFlow<Boolean> = _showStartNavigationButton.asStateFlow()
 
+    private var _showPoiName: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val showPoiName: StateFlow<Boolean> = _showPoiName.asStateFlow()
+
+    private var _showArrivalText: MutableStateFlow<Boolean> = MutableStateFlow(true)
+    val showArrivalText: StateFlow<Boolean> = _showArrivalText.asStateFlow()
+
     fun applyCustomization(customization: ViewOptionsCustomization) {
         customization.mapStyleUriDay?.also { _mapStyleUriDay.value = it }
         customization.mapStyleUriNight?.also { _mapStyleUriNight.value = it }
@@ -106,5 +112,8 @@ internal class NavigationViewOptions(context: Context) {
         customization.showRoutePreviewButton?.also { _showRoutePreviewButton.value = it }
         customization.showEndNavigationButton?.also { _showEndNavigationButton.value = it }
         customization.showStartNavigationButton?.also { _showStartNavigationButton.value = it }
+
+        customization.showPoiName?.also { _showPoiName.value = it }
+        customization.showArrivalText?.also { _showArrivalText.value = it }
     }
 }

--- a/libnavui-dropin/src/main/res/layout/mapbox_arrival_text_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_arrival_text_view_layout.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:background="@drawable/mapbox_bg_info_panel"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        tools:style="@style/DropInInfoPanelHeadlineTextAppearance"
+        android:id="@+id/arrivedText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minHeight="@dimen/mapbox_infoPanel_buttonHeight"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:text="@string/mapbox_drop_in_arrived"
+        android:maxLines="2"
+        android:ellipsize="end" />
+
+</merge>

--- a/libnavui-dropin/src/main/res/layout/mapbox_info_panel_header_arrival_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_info_panel_header_arrival_layout.xml
@@ -8,20 +8,16 @@
     tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
     tools:layout_height="@dimen/mapbox_infoPanel_peekHeight">
 
-    <androidx.appcompat.widget.AppCompatTextView
-        tools:style="@style/DropInInfoPanelHeadlineTextAppearance"
-        android:id="@+id/arrivedText"
-        android:layout_width="wrap_content"
+    <FrameLayout
+        android:id="@+id/arrivedTextContainer"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingEnd="8dp"
-        android:text="@string/mapbox_drop_in_arrived"
-        android:maxLines="2"
-        android:ellipsize="end"
-        app:layout_constraintTop_toTopOf="@+id/endNavigationButtonLayout"
-        app:layout_constraintBottom_toBottomOf="@+id/endNavigationButtonLayout"
+        android:layout_marginTop="26dp"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5" />
+        tools:layout_height="@dimen/mapbox_infoPanel_buttonHeight"
+        tools:background="#00ccff" />
 
     <FrameLayout
         android:id="@+id/endNavigationButtonLayout"

--- a/libnavui-dropin/src/main/res/layout/mapbox_info_panel_header_destination_preview_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_info_panel_header_destination_preview_layout.xml
@@ -2,29 +2,24 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     tools:background="@drawable/mapbox_bg_info_panel"
-    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
     tools:layout_height="@dimen/mapbox_infoPanel_peekHeight">
 
-    <androidx.appcompat.widget.AppCompatTextView
-        tools:style="@style/DropInInfoPanelHeadlineTextAppearance"
-        android:id="@+id/poiName"
+    <FrameLayout
+        android:id="@+id/poiNameContainer"
         android:layout_width="0dp"
-        android:layout_height="70dp"
-        android:paddingEnd="8dp"
-        android:text=""
-        android:maxLines="2"
-        android:ellipsize="end"
-        android:gravity="center_vertical"
+        android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
         android:layout_marginEnd="10dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="@+id/routePreviewContainer"
         app:layout_constraintEnd_toStartOf="@+id/routePreviewContainer"
         app:layout_constraintTop_toTopOf="@+id/routePreviewContainer"
-        tools:text="POI Name" />
+        tools:layout_height="70dp"
+        tools:background="#ddd" />
 
     <FrameLayout
         android:id="@+id/routePreviewContainer"

--- a/libnavui-dropin/src/main/res/layout/mapbox_poi_text_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_poi_text_view_layout.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:background="@drawable/mapbox_bg_info_panel"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        tools:style="@style/DropInInfoPanelHeadlineTextAppearance"
+        android:id="@+id/poiName"
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:text=""
+        android:maxLines="2"
+        android:ellipsize="end"
+        android:gravity="center_vertical"
+        android:paddingEnd="8dp"
+        tools:text="POI Name" />
+
+</merge>

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelArrivalTextBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelArrivalTextBinderTest.kt
@@ -1,0 +1,63 @@
+package com.mapbox.navigation.dropin.infopanel
+
+import android.content.Context
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.arrival.ArrivalTextComponent
+import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
+import com.mapbox.navigation.dropin.navigationview.NavigationViewModel
+import com.mapbox.navigation.dropin.testutil.TestLifecycleOwner
+import com.mapbox.navigation.dropin.util.TestStore
+import com.mapbox.navigation.dropin.util.TestingUtil.findComponent
+import com.mapbox.navigation.testing.LoggingFrontendTestRule
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class InfoPanelArrivalTextBinderTest {
+
+    @get:Rule
+    val loggerRule = LoggingFrontendTestRule()
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private lateinit var ctx: Context
+    private lateinit var viewGroup: ViewGroup
+    private lateinit var mapboxNavigation: MapboxNavigation
+    private lateinit var navContext: NavigationViewContext
+    private lateinit var sut: InfoPanelArrivalTextBinder
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+        viewGroup = FrameLayout(ctx)
+        navContext = NavigationViewContext(
+            context = ctx,
+            lifecycleOwner = TestLifecycleOwner(),
+            viewModel = NavigationViewModel(),
+            storeProvider = { TestStore() }
+        )
+        mapboxNavigation = mockk(relaxed = true)
+        sut = InfoPanelArrivalTextBinder(navContext)
+    }
+
+    @Test
+    fun `bind should bind ArrivalTextComponent`() {
+        val components = sut.bind(viewGroup)
+        components.onAttached(mapboxNavigation)
+
+        assertNotNull(components.findComponent { it is ArrivalTextComponent })
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderArrivalBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderArrivalBinderTest.kt
@@ -1,13 +1,16 @@
 package com.mapbox.navigation.dropin.infopanel
 
 import android.content.Context
+import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.core.view.isEmpty
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.arrival.ArrivalTextComponent
 import com.mapbox.navigation.dropin.extendablebutton.EndNavigationButtonComponent
+import com.mapbox.navigation.dropin.map.geocoding.POINameComponent
 import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
 import com.mapbox.navigation.dropin.navigationview.NavigationViewModel
 import com.mapbox.navigation.dropin.testutil.TestLifecycleOwner
@@ -19,6 +22,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -60,7 +64,7 @@ class InfoPanelHeaderArrivalBinderTest {
 
         sut.bind(rootLayout)
 
-        assertNotNull(rootLayout.findViewById(R.id.arrivedText))
+        assertNotNull(rootLayout.findViewById(R.id.arrivedTextContainer))
         assertNotNull(rootLayout.findViewById(R.id.endNavigationButtonLayout))
     }
 
@@ -70,6 +74,20 @@ class InfoPanelHeaderArrivalBinderTest {
         components.onAttached(mapboxNavigation)
 
         assertNotNull(components.findComponent { it is ArrivalTextComponent })
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `should NOT bind ArrivalTextComponent when ViewOptionsCustomization showArrivalText is FALSE`() {
+        navContext.applyOptionsCustomization {
+            showArrivalText = false
+        }
+        val rootLayout = FrameLayout(ctx)
+        val components = sut.bind(rootLayout)
+        components.onAttached(mapboxNavigation)
+
+        assertNull(components.findComponent { it is POINameComponent })
+        assertTrue((rootLayout.findViewById(R.id.arrivedTextContainer) as ViewGroup).isEmpty())
     }
 
     @Test

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderDestinationPreviewBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderDestinationPreviewBinderTest.kt
@@ -1,7 +1,9 @@
 package com.mapbox.navigation.dropin.infopanel
 
 import android.content.Context
+import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.core.view.isEmpty
 import androidx.test.core.app.ApplicationProvider
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
@@ -22,6 +24,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -63,7 +66,7 @@ class InfoPanelHeaderDestinationPreviewBinderTest {
 
         sut.bind(rootLayout)
 
-        assertNotNull(rootLayout.findViewById(R.id.poiName))
+        assertNotNull(rootLayout.findViewById(R.id.poiNameContainer))
         assertNotNull(rootLayout.findViewById(R.id.routePreviewContainer))
         assertNotNull(rootLayout.findViewById(R.id.startNavigationContainer))
     }
@@ -74,6 +77,20 @@ class InfoPanelHeaderDestinationPreviewBinderTest {
         components.onAttached(mapboxNavigation)
 
         assertNotNull(components.findComponent { it is POINameComponent })
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `should NOT bind POINameComponent when ViewOptionsCustomization showPoiName is FALSE`() {
+        navContext.applyOptionsCustomization {
+            showPoiName = false
+        }
+        val rootLayout = FrameLayout(ctx)
+        val components = sut.bind(rootLayout)
+        components.onAttached(mapboxNavigation)
+
+        assertNull(components.findComponent { it is POINameComponent })
+        assertTrue((rootLayout.findViewById(R.id.poiNameContainer) as ViewGroup).isEmpty())
     }
 
     @Test

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelPoiNameBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelPoiNameBinderTest.kt
@@ -1,0 +1,63 @@
+package com.mapbox.navigation.dropin.infopanel
+
+import android.content.Context
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.map.geocoding.POINameComponent
+import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
+import com.mapbox.navigation.dropin.navigationview.NavigationViewModel
+import com.mapbox.navigation.dropin.testutil.TestLifecycleOwner
+import com.mapbox.navigation.dropin.util.TestStore
+import com.mapbox.navigation.dropin.util.TestingUtil.findComponent
+import com.mapbox.navigation.testing.LoggingFrontendTestRule
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class, ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class InfoPanelPoiNameBinderTest {
+
+    @get:Rule
+    val loggerRule = LoggingFrontendTestRule()
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private lateinit var ctx: Context
+    private lateinit var viewGroup: ViewGroup
+    private lateinit var mapboxNavigation: MapboxNavigation
+    private lateinit var navContext: NavigationViewContext
+    private lateinit var sut: InfoPanelPoiNameBinder
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+        viewGroup = FrameLayout(ctx)
+        navContext = NavigationViewContext(
+            context = ctx,
+            lifecycleOwner = TestLifecycleOwner(),
+            viewModel = NavigationViewModel(),
+            storeProvider = { TestStore() }
+        )
+        mapboxNavigation = mockk(relaxed = true)
+        sut = InfoPanelPoiNameBinder(navContext)
+    }
+
+    @Test
+    fun `bind should bind POINameComponent`() {
+        val components = sut.bind(viewGroup)
+        components.onAttached(mapboxNavigation)
+
+        assertNotNull(components.findComponent { it is POINameComponent })
+    }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewBinderTest.kt
@@ -78,6 +78,8 @@ internal class NavigationViewBinderTest {
             c.infoPanelEndNavigationButtonBinder,
             sut.infoPanelEndNavigationButtonBinder.value
         )
+        assertEquals(c.infoPanelPoiNameBinder, sut.infoPanelPoiNameBinder.value)
+        assertEquals(c.infoPanelArrivalTextBinder, sut.infoPanelArrivalTextBinder.value)
         assertEquals(c.mapViewBinder, sut.mapViewBinder.value)
     }
 
@@ -108,6 +110,8 @@ internal class NavigationViewBinderTest {
                 infoPanelHeaderRoutesPreviewBinder = UIBinder.USE_DEFAULT
                 infoPanelHeaderActiveGuidanceBinder = UIBinder.USE_DEFAULT
                 infoPanelHeaderArrivalBinder = UIBinder.USE_DEFAULT
+                infoPanelPoiNameBinder = UIBinder.USE_DEFAULT
+                infoPanelArrivalTextBinder = UIBinder.USE_DEFAULT
 
                 infoPanelTripProgressBinder = UIBinder.USE_DEFAULT
                 infoPanelContentBinder = UIBinder.USE_DEFAULT
@@ -143,6 +147,8 @@ internal class NavigationViewBinderTest {
         assertTrue(sut.infoPanelRoutePreviewButtonBinder.value == null)
         assertTrue(sut.infoPanelStartNavigationButtonBinder.value == null)
         assertTrue(sut.infoPanelEndNavigationButtonBinder.value == null)
+        assertTrue(sut.infoPanelPoiNameBinder.value == null)
+        assertTrue(sut.infoPanelArrivalTextBinder.value == null)
 
         assertTrue(sut.infoPanelTripProgressBinder.value == null)
         assertTrue(sut.infoPanelContentBinder.value == null)
@@ -175,6 +181,8 @@ internal class NavigationViewBinderTest {
         infoPanelHeaderRoutesPreviewBinder = EmptyBinder()
         infoPanelHeaderActiveGuidanceBinder = EmptyBinder()
         infoPanelHeaderArrivalBinder = EmptyBinder()
+        infoPanelPoiNameBinder = EmptyBinder()
+        infoPanelArrivalTextBinder = EmptyBinder()
 
         infoPanelTripProgressBinder = EmptyBinder()
         infoPanelContentBinder = EmptyBinder()

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewOptionsTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewOptionsTest.kt
@@ -60,6 +60,8 @@ internal class NavigationViewOptionsTest {
         assertEquals(c.showRoutePreviewButton, sut.showRoutePreviewButton.value)
         assertEquals(c.showStartNavigationButton, sut.showStartNavigationButton.value)
         assertEquals(c.showEndNavigationButton, sut.showEndNavigationButton.value)
+        assertEquals(c.showPoiName, sut.showPoiName.value)
+        assertEquals(c.showArrivalText, sut.showArrivalText.value)
     }
 
     private fun customization() =
@@ -84,6 +86,7 @@ internal class NavigationViewOptionsTest {
                 .Builder(ctx)
                 .unitType(UnitType.METRIC)
                 .build()
+
             showManeuver = false
             showSpeedLimit = false
             showRoadName = false
@@ -97,5 +100,7 @@ internal class NavigationViewOptionsTest {
             showRoutePreviewButton = false
             showStartNavigationButton = false
             showEndNavigationButton = false
+            showPoiName = false
+            showArrivalText = false
         }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -50,4 +50,6 @@ class CustomizedViewModel : ViewModel() {
     val enableDestinationPreview = MutableLiveData(true)
     val isInfoPanelHideable = MutableLiveData(false)
     val infoPanelStateOverride = MutableLiveData("--")
+    val infoPanelShowPoiName = MutableLiveData(true)
+    val infoPanelShowArrivalText = MutableLiveData(true)
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -696,6 +696,18 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
             viewModel.infoPanelStateOverride,
             ::toggleInfoPanelState
         )
+
+        bindSwitch(
+            menuBinding.toggleShowPoiName,
+            viewModel.infoPanelShowPoiName,
+            ::toggleShowPoiName
+        )
+
+        bindSwitch(
+            menuBinding.toggleShowArrivalText,
+            viewModel.infoPanelShowArrivalText,
+            ::toggleShowArrivalText
+        )
     }
 
     private fun toggleShowTripProgress(enabled: Boolean) {
@@ -838,6 +850,18 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
     private fun toggleInfoPanelHiding(isHideable: Boolean) {
         binding.navigationView.customizeViewOptions {
             isInfoPanelHideable = isHideable
+        }
+    }
+
+    private fun toggleShowPoiName(enabled: Boolean) {
+        binding.navigationView.customizeViewOptions {
+            showPoiName = enabled
+        }
+    }
+
+    private fun toggleShowArrivalText(enabled: Boolean) {
+        binding.navigationView.customizeViewOptions {
+            showArrivalText = enabled
         }
     }
 

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -377,6 +377,24 @@
                     android:text="Info Panel" />
 
                 <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/toggleShowPoiName"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingVertical="10dp"
+                    android:text="Show POI Name"
+                    android:textAllCaps="true" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/toggleShowArrivalText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingVertical="10dp"
+                    android:text="Show Arrival Text"
+                    android:textAllCaps="true" />
+
+                <androidx.appcompat.widget.SwitchCompat
                     android:id="@+id/toggleShowTripProgress"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
Closes NAVAND-803
Fixes https://github.com/mapbox/mapbox-navigation-android/issues/6514

### Description
Changes:

- Added `InfoPanelPoiNameBinder` and `InfoPanelArrivalTextBinder`.
  <img width="500" src="https://user-images.githubusercontent.com/2678039/198325002-f180c11f-fc55-43b2-aada-7421f2b80998.png"/>
- Updated `ViewBinderCustomization` to allow injection of a custom binder for POI Name and Arrival Text views.
- Updated `ViewOptionsCustomization` to allow showing and hiding of POI Name and Arrival Text views.
- Updated Info Panel Header layouts to allow injection of custom POI Name and Arrival Text Views.
- Regen **libnavui-dropin** Metalaval file.

### TODO
- [x] merge https://github.com/mapbox/mapbox-navigation-android/pull/6498
- [x] retarget this PR to `main` branch
- [x] add CHANGELOG entry