### PR TITLE
[Drop-In UI] fix road label position not updating in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Mapbox welcomes participation and contributions from everyone.
   - The `MapboxExtendableButtonParams` class has been removed. Any action button placement adjustments must be done via custom `ActionButtonsBinder` implementation. [#6498](https://github.com/mapbox/mapbox-navigation-android/pull/6498)
 - Fixed an issue where "silent waypoints" (not regular waypoints that define legs) had markers added on the map when route line was drawn with `MapboxRouteLineApi` and `MapboxRouteLineView`. [#6526](https://github.com/mapbox/mapbox-navigation-android/pull/6526)
 - Slightly improved performance of updates to the traveled portion of the route in MapboxRouteLineView. [#6528](https://github.com/mapbox/mapbox-navigation-android/pull/6528)
+- Fixed an issue with `NavigationView` that caused road label position to not update in some cases. [#6531](https://github.com/mapbox/mapbox-navigation-android/pull/6531)
 
 ## Mapbox Navigation SDK 2.10.0-alpha.1 - 28 October, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelCoordinator.kt
@@ -81,7 +81,7 @@ internal class InfoPanelCoordinator(
             }
         }
         coroutineScope.launch {
-            context.systemBarsInsets.collect(this@InfoPanelCoordinator::updateGuidelinePosition)
+            context.systemBarsInsets.collect { updateGuidelinePosition(systemBarsInsets = it) }
         }
         coroutineScope.launch {
             context.options.isInfoPanelHideable.collect { hideable ->
@@ -98,7 +98,7 @@ internal class InfoPanelCoordinator(
             bottomSheetPeekHeight().collect { behavior.peekHeight = it }
         }
         coroutineScope.launch {
-            infoPanelTop.collect { updateGuidelinePosition() }
+            infoPanelTop.collect { updateGuidelinePosition(infoPanelTop = it) }
         }
     }
 
@@ -157,10 +157,13 @@ internal class InfoPanelCoordinator(
         state = BottomSheetBehavior.STATE_HIDDEN
     }
 
-    private fun updateGuidelinePosition(systemBarsInsets: Insets = context.systemBarsInsets.value) {
+    private fun updateGuidelinePosition(
+        systemBarsInsets: Insets = context.systemBarsInsets.value,
+        infoPanelTop: Int = infoPanel.top,
+    ) {
         val parentHeight = (infoPanel.parent as ViewGroup).height
         val maxPos = (parentHeight * GUIDELINE_MAX_POSITION_PERCENT).toInt()
-        val pos = parentHeight - infoPanel.top - systemBarsInsets.bottom
+        val pos = parentHeight - infoPanelTop - systemBarsInsets.bottom
         guidelineBottom.setGuidelineEnd(pos.coerceIn(0, maxPos))
     }
 


### PR DESCRIPTION
### Description
Another week, another fix for road label position update. I was able to reproduce it only in 1TAP. For some reason, sometimes we get outdated values when we access `infoPanel.top` in `updateGuidelinePosition`, therefore we should pass the value that we collected from the flow, like it is implemented with `systemBarsInsets`. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
