### PR TITLE
fixed an issue where DirectionsResponse#waypoints list was cleared after a successful non-EV route refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed an issue where "silent waypoints" (not regular waypoints that define legs) had markers added on the map when route line was drawn with `MapboxRouteLineApi` and `MapboxRouteLineView`. [#6526](https://github.com/mapbox/mapbox-navigation-android/pull/6526)
 - Slightly improved performance of updates to the traveled portion of the route in MapboxRouteLineView. [#6528](https://github.com/mapbox/mapbox-navigation-android/pull/6528)
 - Fixed an issue with `NavigationView` that caused road label position to not update in some cases. [#6531](https://github.com/mapbox/mapbox-navigation-android/pull/6531)
+- Fixed an issue where `DirectionsResponse#waypoints` list was cleared after a successful non-EV route refresh. [#6539](https://github.com/mapbox/mapbox-navigation-android/pull/6539)
 
 ## Mapbox Navigation SDK 2.10.0-alpha.1 - 28 October, 2022
 ### Changelog

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/RouteRefreshTest.kt
@@ -265,6 +265,14 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                 refreshedRoutes[1].directionsRoute.legs()!!.first().duration()!!,
                 0.0001
             )
+            assertEquals(
+                requestedRoutes[0].directionsResponse.waypoints(),
+                refreshedRoutes[0].directionsResponse.waypoints()
+            )
+            assertEquals(
+                requestedRoutes[1].directionsResponse.waypoints(),
+                refreshedRoutes[1].directionsResponse.waypoints()
+            )
         }
 
     @Test
@@ -508,6 +516,16 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                 ),
                 refreshedRoutes[0].directionsRoute.legs()!![1].closures()
             )
+
+            // waypoints
+            assertEquals(
+                requestedRoutes[0].directionsResponse.waypoints(),
+                refreshedRoutes[0].directionsResponse.waypoints()
+            )
+            assertEquals(
+                requestedRoutes[1].directionsResponse.waypoints(),
+                refreshedRoutes[1].directionsResponse.waypoints()
+            )
         }
 
     @Test
@@ -583,6 +601,12 @@ class RouteRefreshTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.ja
                         .build()
                 ),
                 refreshedRoutes[0].directionsRoute.legs()!![1].closures()
+            )
+
+            // waypoints
+            assertEquals(
+                requestedRoutes[0].directionsResponse.waypoints(),
+                refreshedRoutes[0].directionsResponse.waypoints()
             )
         }
 

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/route/NavigationRouteEx.kt
@@ -198,21 +198,11 @@ private fun DirectionsResponse.Builder.updateWaypoints(
     oldWaypoints: List<DirectionsWaypoint>?,
     updatedWaypoints: List<DirectionsWaypoint?>?,
 ): DirectionsResponse.Builder {
-    if (oldWaypoints == null) {
+    if (oldWaypoints == null || updatedWaypoints == null) {
         return this
     }
-    val newWaypoints = mutableListOf<DirectionsWaypoint>()
-    if (updatedWaypoints != null) {
-        oldWaypoints.forEachIndexed { index, oldWaypoint ->
-            if (index < updatedWaypoints.size) {
-                val updatedWaypoint = updatedWaypoints[index]
-                if (updatedWaypoint == null) {
-                    newWaypoints.add(oldWaypoint)
-                } else {
-                    newWaypoints.add(updatedWaypoint)
-                }
-            }
-        }
+    val newWaypoints = oldWaypoints.mapIndexed { index, oldWaypoint ->
+        updatedWaypoints.getOrNull(index) ?: oldWaypoint
     }
     return waypoints(newWaypoints)
 }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/route/NavigationRouteExTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/route/NavigationRouteExTest.kt
@@ -350,7 +350,7 @@ class NavigationRouteExTest {
                         listOf(provideDefaultLegAnnotation(), null),
                         listOf(provideDefaultIncidents(), null),
                         listOf(provideDefaultClosures(), null),
-                        emptyList(),
+                        waypoints,
                         0
                     ),
                 )
@@ -375,7 +375,7 @@ class NavigationRouteExTest {
                         listOf(provideDefaultLegAnnotation(), null),
                         listOf(provideDefaultIncidents(), null),
                         listOf(provideDefaultClosures(), null),
-                        emptyList(),
+                        waypoints,
                         0
                     ),
                 )
@@ -404,7 +404,7 @@ class NavigationRouteExTest {
                         listOf(provideDefaultLegAnnotation(), null),
                         listOf(provideDefaultIncidents(), null),
                         listOf(provideDefaultClosures(), null),
-                        listOf(createWaypoint("name3")),
+                        listOf(createWaypoint("name3"), createWaypoint("name2")),
                         0
                     ),
                 )
@@ -500,7 +500,6 @@ class NavigationRouteExTest {
                     ),
                 )
             },
-
             run {
                 val refreshedWaypoints = listOf(
                     createWaypoint("name11"),
@@ -750,6 +749,11 @@ class NavigationRouteExTest {
                     description,
                     result.newWaypoints,
                     updatedNavRoute.directionsResponse.waypoints()
+                )
+                assertEquals(
+                    description,
+                    navRoute.directionsResponse.waypoints()?.size,
+                    updatedNavRoute.directionsResponse.waypoints()?.size
                 )
 
                 val capturedOldAnnotations = mutableListOf<LegAnnotation?>()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
The PR fixes an issue with cleared waypoints list in the route response object after a successful non-EV refresh procedure because the code assumed that all refresh responses would contain valid waypoints structure while that's only true for EV refresh responses.

I'm also adding additional checks to tests to ensure that the waypoints size remains consistent at all times after a refresh procedure. A refresh should never change the waypoints size (as the route path and number of legs does not change), only update the metadata.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
