### PR TITLE
[Android Auto] Bump nav-sdk version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ ext {
       mapboxCore                : '5.0.2',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '23.1.1',
-      mapboxSearchSdk           : '1.0.0-beta.38.1',
+      mapboxSearchSdk           : '1.0.0-beta.39',
       mapboxCrashMonitor        : '2.0.0',
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.8.0',

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     // This defines the minimum version of Navigation which is included in this SDK. To upgrade the
     // Navigation versions, you can specify a newer version in your downstream build.gradle.
-    releaseApi("com.mapbox.navigation:android:2.9.0-beta.3")
+    releaseApi("com.mapbox.navigation:android:2.9.0-rc.2")
     debugApi project(":libnavigation-android")
 
     // Search is currently in beta so it is not included in this SDK. The functionality of search


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

This release we're using an automated release tool. Going to test it on 0.16.0, but also want to bump the sdk version to the latest rc. The common version is slightly different but hopefully that doesn't matter. Search sdk is using 23.1.0, but nav-sdk is on 23.1.1.
