### PR TITLE
[Android Auto] Add getStyleExtension to MapboxCarMapLoader

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Added `MapboxCarMapLoader.getStyleExtension` to get access to the values set. [#6571](https://github.com/mapbox/mapbox-navigation-android/pull/6571)
 
 ## androidauto-v0.16.0 - 04 November, 2022
 ### Changelog

--- a/libnavui-androidauto/api/current.txt
+++ b/libnavui-androidauto/api/current.txt
@@ -253,6 +253,7 @@ package com.mapbox.androidauto.map {
 
   public final class MapboxCarMapLoader implements com.mapbox.maps.extension.androidauto.MapboxCarMapObserver {
     ctor public MapboxCarMapLoader();
+    method public com.mapbox.maps.extension.style.StyleContract.StyleExtension getStyleExtension(boolean isDarkMode);
     method public com.mapbox.androidauto.map.MapboxCarMapLoader onCarConfigurationChanged(androidx.car.app.CarContext carContext);
     method public com.mapbox.androidauto.map.MapboxCarMapLoader setDarkStyleOverride(com.mapbox.maps.extension.style.StyleContract.StyleExtension? styleContract);
     method public com.mapbox.androidauto.map.MapboxCarMapLoader setLightStyleOverride(com.mapbox.maps.extension.style.StyleContract.StyleExtension? styleContract);

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/map/MapboxCarMapLoader.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/map/MapboxCarMapLoader.kt
@@ -46,7 +46,7 @@ class MapboxCarMapLoader : MapboxCarMapObserver {
         with(mapboxCarMapSurface) {
             logAndroidAuto("onAttached load style")
             mapSurface.getMapboxMap().loadStyle(
-                mapStyle(carContext.isDarkMode),
+                getStyleExtension(carContext.isDarkMode),
                 onStyleLoaded = { style ->
                     logAndroidAuto("onAttached style loaded")
                     style.addPersistentStyleCustomLayer(
@@ -63,6 +63,17 @@ class MapboxCarMapLoader : MapboxCarMapObserver {
     override fun onDetached(mapboxCarMapSurface: MapboxCarMapSurface) {
         mapboxCarMapSurface.getStyle()?.removeStyleLayer(EMPTY_LAYER_ID)
         mapboxMap = null
+    }
+
+    /**
+     * Returns the current style contract. If an override has not been set the default is returned.
+     */
+    fun getStyleExtension(isDarkMode: Boolean): StyleContract.StyleExtension {
+        return if (isDarkMode) {
+            darkStyleOverride ?: DEFAULT_NIGHT_STYLE
+        } else {
+            lightStyleOverride ?: DEFAULT_DAY_STYLE
+        }
     }
 
     /**
@@ -96,7 +107,7 @@ class MapboxCarMapLoader : MapboxCarMapObserver {
      */
     fun onCarConfigurationChanged(carContext: CarContext) = apply {
         mapboxMap?.loadStyle(
-            mapStyle(carContext.isDarkMode),
+            getStyleExtension(carContext.isDarkMode),
             onStyleLoaded = { style ->
                 logAndroidAuto("updateMapStyle styleAvailable ${style.styleURI}")
             },
@@ -104,14 +115,6 @@ class MapboxCarMapLoader : MapboxCarMapObserver {
         ) ?: logAndroidAuto(
             "onCarConfigurationChanged did not load the map because the map is not attached"
         )
-    }
-
-    private fun mapStyle(isDarkMode: Boolean): StyleContract.StyleExtension {
-        return if (isDarkMode) {
-            darkStyleOverride ?: DEFAULT_NIGHT_STYLE
-        } else {
-            lightStyleOverride ?: DEFAULT_DAY_STYLE
-        }
     }
 
     private companion object {

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/map/MapboxCarMapLoaderTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/map/MapboxCarMapLoaderTest.kt
@@ -87,6 +87,33 @@ class MapboxCarMapLoaderTest {
         assertEquals("test-dark-override", styleExtensionSlot.captured.styleUri)
     }
 
+    @Test
+    fun `getStyleExtension will return the default styles`() {
+        assertEquals(
+            NavigationStyles.NAVIGATION_DAY_STYLE,
+            sut.getStyleExtension(false).styleUri
+        )
+        assertEquals(
+            NavigationStyles.NAVIGATION_NIGHT_STYLE,
+            sut.getStyleExtension(true).styleUri
+        )
+    }
+
+    @Test
+    fun `getStyleExtension will return the overridden styles`() {
+        sut.setLightStyleOverride(mockk { every { styleUri } returns "test-light-override" })
+        sut.setDarkStyleOverride(mockk { every { styleUri } returns "test-dark-override" })
+
+        assertEquals(
+            "test-light-override",
+            sut.getStyleExtension(false).styleUri
+        )
+        assertEquals(
+            "test-dark-override",
+            sut.getStyleExtension(true).styleUri
+        )
+    }
+
     private fun mockMapboxCarMapSurface(
         styleExtensionSlot: CapturingSlot<StyleContract.StyleExtension>
     ): MapboxCarMapSurface {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

When calling `mapboxCarMap.setup(` the map will be loaded with a `mapStyleUri`. The `MapInitOptions` takes a default map styleUri that is [Style.MAPBOX_STREETS](https://github.com/mapbox/mapbox-maps-android/blob/c932cc06971e319715cc9a39857c2bd2d327ba24/sdk/src/main/java/com/mapbox/maps/MapInitOptions.kt#L33). This eager map loading can cause 2 map styles to load because navigation has a different default style.

Surfacing the `getCurrentStyle` so you can initialize transfer the style to `MapInitOptions`.