### PR TITLE
Cherry-pick #6574: Ability to assign different location pucks based on navigation state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Mapbox welcomes participation and contributions from everyone.
 
 ## Unreleased
 #### Features
+-:warning: Introduced `ViewStyleCustomization.locationPuckOptions` in favor of `ViewStyleCustomization.locationPuck` that can be used to leverage `LocationPuckOptions` to change the location puck at runtime for each navigation state. [#6574](https://github.com/mapbox/mapbox-navigation-android/pull/6574)
 #### Bug fixes and improvements
 - Slightly decreased the memory consumption of the online router. [#6562](https://github.com/mapbox/mapbox-navigation-android/pull/6562)
 - Improved positioning and location signal simulation in tunnels. [#6562](https://github.com/mapbox/mapbox-navigation-android/pull/6562)

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -239,7 +239,7 @@ package com.mapbox.navigation.dropin {
     method public Integer? getInfoPanelMarginEnd();
     method public Integer? getInfoPanelMarginStart();
     method public Integer? getInfoPanelPeekHeight();
-    method public com.mapbox.maps.plugin.LocationPuck? getLocationPuck();
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions? getLocationPuckOptions();
     method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions? getManeuverViewOptions();
     method public Integer? getPoiNameTextAppearance();
     method public Integer? getRecenterButtonStyle();
@@ -260,7 +260,7 @@ package com.mapbox.navigation.dropin {
     method public void setInfoPanelMarginEnd(Integer?);
     method public void setInfoPanelMarginStart(Integer?);
     method public void setInfoPanelPeekHeight(Integer?);
-    method public void setLocationPuck(com.mapbox.maps.plugin.LocationPuck?);
+    method public void setLocationPuckOptions(com.mapbox.navigation.ui.maps.puck.LocationPuckOptions?);
     method public void setManeuverViewOptions(com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions?);
     method public void setPoiNameTextAppearance(Integer?);
     method public void setRecenterButtonStyle(Integer?);
@@ -281,7 +281,7 @@ package com.mapbox.navigation.dropin {
     property public final Integer? infoPanelMarginEnd;
     property public final Integer? infoPanelMarginStart;
     property public final Integer? infoPanelPeekHeight;
-    property public final com.mapbox.maps.plugin.LocationPuck? locationPuck;
+    property public final com.mapbox.navigation.ui.maps.puck.LocationPuckOptions? locationPuckOptions;
     property public final com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions? maneuverViewOptions;
     property public final Integer? poiNameTextAppearance;
     property public final Integer? recenterButtonStyle;
@@ -306,7 +306,7 @@ package com.mapbox.navigation.dropin {
     method @Px public int defaultInfoPanelMarginEnd();
     method @Px public int defaultInfoPanelMarginStart();
     method @Px public int defaultInfoPanelPeekHeight(android.content.Context context);
-    method public com.mapbox.maps.plugin.LocationPuck defaultLocationPuck(android.content.Context context);
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions defaultLocationPuckOptions(android.content.Context context);
     method public com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions defaultManeuverViewOptions();
     method @StyleRes public int defaultPoiNameTextAppearance();
     method @StyleRes public int defaultRecenterButtonStyle();

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
@@ -11,6 +11,7 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.mapbox.maps.plugin.LocationPuck
 import com.mapbox.maps.plugin.LocationPuck2D
+import com.mapbox.maps.plugin.LocationPuck3D
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.arrival.ArrivalTextComponent
@@ -23,6 +24,7 @@ import com.mapbox.navigation.ui.maneuver.model.ManeuverSubOptions
 import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
 import com.mapbox.navigation.ui.maneuver.model.MapboxExitProperties
 import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverView
+import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
 import com.mapbox.navigation.ui.maps.roadname.view.MapboxRoadNameView
 import com.mapbox.navigation.ui.maps.view.MapboxCameraModeButton
 import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView
@@ -175,10 +177,12 @@ class ViewStyleCustomization {
     var arrivalTextAppearance: Int? = null
 
     /**
-     * Provide custom [LocationPuck] for [MapView].
-     * Use [defaultLocationPuck] to reset to default.
+     * Provide [LocationPuckOptions] containing references to either [LocationPuck2D] or
+     * [LocationPuck3D] for location puck in each of the different navigation states to be
+     * displayed on top of the [MapView].
+     * Use [defaultLocationPuckOptions] to reset to default.
      */
-    var locationPuck: LocationPuck? = null
+    var locationPuckOptions: LocationPuckOptions? = null
 
     companion object {
         /**
@@ -362,12 +366,8 @@ class ViewStyleCustomization {
         /**
          * Default [LocationPuck] for [MapView].
          */
-        fun defaultLocationPuck(context: Context): LocationPuck = LocationPuck2D(
-            bearingImage = ContextCompat.getDrawable(
-                context,
-                R.drawable.mapbox_navigation_puck_icon,
-            )
-        )
+        fun defaultLocationPuckOptions(context: Context): LocationPuckOptions =
+            LocationPuckOptions.Builder(context).build()
 
         private fun defaultMutcdProperties() = MapboxExitProperties.PropertiesMutcd(
             exitBackground = R.drawable.mapbox_dropin_exit_board_background,

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/map/MapViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/map/MapViewBinder.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.dropin.map
 import android.content.Context
 import android.view.ViewGroup
 import com.mapbox.maps.MapView
+import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
 import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
@@ -24,6 +25,8 @@ import com.mapbox.navigation.ui.maps.internal.ui.LocationComponent
 import com.mapbox.navigation.ui.maps.internal.ui.LocationPuckComponent
 import com.mapbox.navigation.ui.maps.internal.ui.RouteArrowComponent
 import com.mapbox.navigation.ui.maps.internal.ui.RouteLineComponent
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 
@@ -71,8 +74,16 @@ abstract class MapViewBinder : UIBinder {
         return navigationListOf(
             CameraLayoutObserver(store, mapView, navigationViewBinding),
             LocationComponent(context.locationProvider),
-            reloadOnChange(context.styles.locationPuck) { locationPuck ->
-                LocationPuckComponent(mapView.location, locationPuck, context.locationProvider)
+            reloadOnChange(
+                navigationState,
+                context.styles.locationPuckOptions
+            ) { navState, _ ->
+                locationPuckComponent(
+                    navState,
+                    mapView.location,
+                    context.locationProvider,
+                    context.styles.locationPuckOptions.value
+                )
             },
             LogoAttributionComponent(mapView, context.systemBarsInsets),
             reloadOnChange(
@@ -113,6 +124,51 @@ abstract class MapViewBinder : UIBinder {
         RouteLineComponent(mapView.getMapboxMap(), mapView, lineOptions, contractProvider = {
             RouteLineComponentContractImpl(context.store, context.mapClickBehavior)
         })
+
+    private fun locationPuckComponent(
+        navigationState: NavigationState,
+        location: LocationComponentPlugin,
+        provider: NavigationLocationProvider,
+        options: LocationPuckOptions
+    ): LocationPuckComponent {
+        return when (navigationState) {
+            NavigationState.FreeDrive -> {
+                LocationPuckComponent(
+                    location,
+                    options.freeDrivePuck,
+                    provider,
+                )
+            }
+            NavigationState.DestinationPreview -> {
+                LocationPuckComponent(
+                    location,
+                    options.destinationPreviewPuck,
+                    provider,
+                )
+            }
+            NavigationState.RoutePreview -> {
+                LocationPuckComponent(
+                    location,
+                    options.routePreviewPuck,
+                    provider,
+                )
+            }
+            NavigationState.ActiveNavigation -> {
+                LocationPuckComponent(
+                    location,
+                    options.activeNavigationPuck,
+                    provider,
+                )
+            }
+            NavigationState.Arrival -> {
+                LocationPuckComponent(
+                    location,
+                    options.arrivalPuck,
+                    provider,
+                )
+            }
+        }
+    }
 
     private fun longPressMapComponent(navigationState: NavigationState, mapView: MapView) =
         when (navigationState) {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewStyles.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewStyles.kt
@@ -1,11 +1,11 @@
 package com.mapbox.navigation.dropin.navigationview
 
 import android.content.Context
-import com.mapbox.maps.plugin.LocationPuck
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.ViewStyleCustomization
 import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
+import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -55,8 +55,8 @@ internal class NavigationViewStyles(context: Context) {
         MutableStateFlow(ViewStyleCustomization.defaultDestinationMarkerAnnotationOptions(context))
     private val _arrivalTextAppearance: MutableStateFlow<Int> =
         MutableStateFlow(ViewStyleCustomization.defaultArrivalTextAppearance())
-    private val _locationPuck: MutableStateFlow<LocationPuck> =
-        MutableStateFlow(ViewStyleCustomization.defaultLocationPuck(context))
+    private val _locationPuckOptions: MutableStateFlow<LocationPuckOptions> =
+        MutableStateFlow(ViewStyleCustomization.defaultLocationPuckOptions(context))
 
     val infoPanelPeekHeight: StateFlow<Int> = _infoPanelPeekHeight.asStateFlow()
     val infoPanelMarginStart: StateFlow<Int> = _infoPanelMarginStart.asStateFlow()
@@ -81,7 +81,7 @@ internal class NavigationViewStyles(context: Context) {
     val roadNameTextAppearance: StateFlow<Int> = _roadNameTextAppearance.asStateFlow()
     val maneuverViewOptions: StateFlow<ManeuverViewOptions> = _maneuverViewOptions.asStateFlow()
     val arrivalTextAppearance: StateFlow<Int> = _arrivalTextAppearance.asStateFlow()
-    val locationPuck: StateFlow<LocationPuck> = _locationPuck.asStateFlow()
+    val locationPuckOptions: StateFlow<LocationPuckOptions> = _locationPuckOptions.asStateFlow()
 
     fun applyCustomization(customization: ViewStyleCustomization) {
         customization.infoPanelPeekHeight?.also { _infoPanelPeekHeight.value = it }
@@ -108,6 +108,6 @@ internal class NavigationViewStyles(context: Context) {
         customization.roadNameBackground?.also { _roadNameBackground.value = it }
         customization.roadNameTextAppearance?.also { _roadNameTextAppearance.value = it }
         customization.arrivalTextAppearance?.also { _arrivalTextAppearance.value = it }
-        customization.locationPuck?.also { _locationPuck.value = it }
+        customization.locationPuckOptions?.also { _locationPuckOptions.value = it }
     }
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/map/MapViewBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/map/MapViewBinderTest.kt
@@ -42,6 +42,7 @@ import com.mapbox.navigation.ui.maps.internal.ui.LocationComponent
 import com.mapbox.navigation.ui.maps.internal.ui.LocationPuckComponent
 import com.mapbox.navigation.ui.maps.internal.ui.RouteArrowComponent
 import com.mapbox.navigation.ui.maps.internal.ui.RouteLineComponent
+import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import io.mockk.Runs
@@ -164,9 +165,29 @@ class MapViewBinderTest {
 
         val firstComponent = components.findComponent { it is LocationPuckComponent }
         navContext.applyStyleCustomization {
-            locationPuck =
-                LocationPuck2D(bearingImage = ctx.getDrawable(android.R.drawable.arrow_down_float))
+            locationPuckOptions = LocationPuckOptions
+                .Builder(ctx)
+                .freeDrivePuck(
+                    LocationPuck2D(
+                        bearingImage = ctx.getDrawable(android.R.drawable.arrow_down_float)
+                    )
+                )
+                .build()
         }
+        val secondComponent = components.findComponent { it is LocationPuckComponent }
+
+        assertNotNull(firstComponent)
+        assertNotNull(secondComponent)
+        assertNotEquals(secondComponent, firstComponent)
+    }
+
+    @Test
+    fun `bind should reload LocationPuckComponent on navigation state change`() {
+        val components = sut.bind(FrameLayout(ctx))
+        components.onAttached(mapboxNavigation)
+
+        val firstComponent = components.findComponent { it is LocationPuckComponent }
+        store.updateState { it.copy(navigation = NavigationState.RoutePreview) }
         val secondComponent = components.findComponent { it is LocationPuckComponent }
 
         assertNotNull(firstComponent)

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewStylesTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewStylesTest.kt
@@ -9,6 +9,7 @@ import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.ViewStyleCustomization
 import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
+import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -57,7 +58,7 @@ class NavigationViewStylesTest {
         assertEquals(c.roadNameBackground, sut.roadNameBackground.value)
         assertEquals(c.roadNameTextAppearance, sut.roadNameTextAppearance.value)
         assertEquals(c.arrivalTextAppearance, sut.arrivalTextAppearance.value)
-        assertEquals(c.locationPuck, sut.locationPuck.value)
+        assertEquals(c.locationPuckOptions, sut.locationPuckOptions.value)
     }
 
     private fun customization() = ViewStyleCustomization().apply {
@@ -81,11 +82,16 @@ class NavigationViewStylesTest {
         roadNameBackground = android.R.drawable.spinner_background
         roadNameTextAppearance = android.R.style.TextAppearance_DeviceDefault_Large
         arrivalTextAppearance = android.R.style.TextAppearance_DeviceDefault_Large
-        locationPuck = LocationPuck2D(
-            bearingImage = ContextCompat.getDrawable(
-                ctx,
-                android.R.drawable.ic_media_play
+        locationPuckOptions = LocationPuckOptions
+            .Builder(ctx)
+            .freeDrivePuck(
+                LocationPuck2D(
+                    bearingImage = ContextCompat.getDrawable(
+                        ctx,
+                        android.R.drawable.ic_media_play
+                    )
+                )
             )
-        )
+            .build()
     }
 }

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -730,6 +730,43 @@ package com.mapbox.navigation.ui.maps.location {
 
 }
 
+package com.mapbox.navigation.ui.maps.puck {
+
+  public final class LocationPuckOptions {
+    method public com.mapbox.maps.plugin.LocationPuck getActiveNavigationPuck();
+    method public com.mapbox.maps.plugin.LocationPuck getArrivalPuck();
+    method public android.content.Context getContext();
+    method public com.mapbox.maps.plugin.LocationPuck getDestinationPreviewPuck();
+    method public com.mapbox.maps.plugin.LocationPuck getFreeDrivePuck();
+    method public com.mapbox.maps.plugin.LocationPuck getRoutePreviewPuck();
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder toBuilder();
+    property public final com.mapbox.maps.plugin.LocationPuck activeNavigationPuck;
+    property public final com.mapbox.maps.plugin.LocationPuck arrivalPuck;
+    property public final android.content.Context context;
+    property public final com.mapbox.maps.plugin.LocationPuck destinationPreviewPuck;
+    property public final com.mapbox.maps.plugin.LocationPuck freeDrivePuck;
+    property public final com.mapbox.maps.plugin.LocationPuck routePreviewPuck;
+  }
+
+  public static final class LocationPuckOptions.Builder {
+    ctor public LocationPuckOptions.Builder(android.content.Context context);
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder activeNavigationPuck(com.mapbox.maps.plugin.LocationPuck activeNavigationPuck);
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder arrivalPuck(com.mapbox.maps.plugin.LocationPuck arrivalPuck);
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions build();
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder defaultPuck(com.mapbox.maps.plugin.LocationPuck defaultPuck);
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder destinationPreviewPuck(com.mapbox.maps.plugin.LocationPuck destinationPreviewPuck);
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder freeDrivePuck(com.mapbox.maps.plugin.LocationPuck freeDrivePuck);
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder routePreviewPuck(com.mapbox.maps.plugin.LocationPuck routePreviewPuck);
+    field public static final com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder.Companion Companion;
+  }
+
+  public static final class LocationPuckOptions.Builder.Companion {
+    method public com.mapbox.maps.plugin.LocationPuck navigationPuck(android.content.Context context);
+    method public com.mapbox.maps.plugin.LocationPuck regularPuck(android.content.Context context);
+  }
+
+}
+
 package com.mapbox.navigation.ui.maps.roadname.api {
 
   @Deprecated public final class MapboxRoadNameLabelApi {

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptions.kt
@@ -11,8 +11,10 @@ import com.mapbox.navigation.ui.maps.R
  * Gives options to specify either [LocationPuck2D] or [LocationPuck3D] references to the location
  * puck to be displayed on top of map view in each of different navigation states.
  *
+ * If you want to use the same puck for all different navigation states you can invoke
+ * `defaultPuck()` on the [Builder] and that would be used for pucks in all navigation states.
+ *
  * @param context from which to reference puck drawables
- * @param defaultPuck stores the puck appearance to be displayed in all navigation states
  * @param freeDrivePuck stores the puck appearance to be displayed in free drive state
  * @param destinationPreviewPuck stores the puck appearance to be displayed in destination preview state
  * @param routePreviewPuck stores the puck appearance to be displayed in route preview state
@@ -21,7 +23,6 @@ import com.mapbox.navigation.ui.maps.R
  */
 class LocationPuckOptions private constructor(
     val context: Context,
-    val defaultPuck: LocationPuck,
     val freeDrivePuck: LocationPuck,
     val destinationPreviewPuck: LocationPuck,
     val routePreviewPuck: LocationPuck,
@@ -33,7 +34,6 @@ class LocationPuckOptions private constructor(
      * @return the [Builder] that created the [LocationPuckOptions]
      */
     fun toBuilder(): Builder = Builder(context).apply {
-        defaultPuck(defaultPuck)
         freeDrivePuck(freeDrivePuck)
         destinationPreviewPuck(destinationPreviewPuck)
         routePreviewPuck(routePreviewPuck)
@@ -51,7 +51,6 @@ class LocationPuckOptions private constructor(
         other as LocationPuckOptions
 
         if (context != other.context) return false
-        if (defaultPuck != other.defaultPuck) return false
         if (freeDrivePuck != other.freeDrivePuck) return false
         if (destinationPreviewPuck != other.destinationPreviewPuck) return false
         if (routePreviewPuck != other.routePreviewPuck) return false
@@ -66,7 +65,6 @@ class LocationPuckOptions private constructor(
      */
     override fun hashCode(): Int {
         var result = context.hashCode()
-        result = 31 * result + defaultPuck.hashCode()
         result = 31 * result + freeDrivePuck.hashCode()
         result = 31 * result + destinationPreviewPuck.hashCode()
         result = 31 * result + routePreviewPuck.hashCode()
@@ -81,7 +79,6 @@ class LocationPuckOptions private constructor(
     override fun toString(): String {
         return "LocationPuckOptions(" +
             "context=$context, " +
-            "defaultPuck=$defaultPuck, " +
             "freeDrivePuck=$freeDrivePuck, " +
             "destinationPreviewPuck=$destinationPreviewPuck, " +
             "routePreviewPuck=$routePreviewPuck, " +
@@ -95,12 +92,11 @@ class LocationPuckOptions private constructor(
      */
     class Builder(private val context: Context) {
 
-        private var freeDrivePuck: LocationPuck? = null
-        private var destinationPreviewPuck: LocationPuck? = null
-        private var routePreviewPuck: LocationPuck? = null
-        private var activeNavigationPuck: LocationPuck? = null
-        private var arrivalPuck: LocationPuck? = null
-        private var defaultPuck: LocationPuck? = null
+        private var freeDrivePuck: LocationPuck = regularPuck(context)
+        private var destinationPreviewPuck: LocationPuck = regularPuck(context)
+        private var routePreviewPuck: LocationPuck = regularPuck(context)
+        private var activeNavigationPuck: LocationPuck = navigationPuck(context)
+        private var arrivalPuck: LocationPuck = navigationPuck(context)
 
         /**
          * Apply the same [LocationPuck2D] or [LocationPuck3D] to location puck in all different
@@ -108,7 +104,11 @@ class LocationPuckOptions private constructor(
          * @param defaultPuck [LocationPuck] to be used in all navigation states
          */
         fun defaultPuck(defaultPuck: LocationPuck): Builder = apply {
-            this.defaultPuck = defaultPuck
+            this.freeDrivePuck = defaultPuck
+            this.destinationPreviewPuck = defaultPuck
+            this.routePreviewPuck = defaultPuck
+            this.activeNavigationPuck = defaultPuck
+            this.arrivalPuck = defaultPuck
         }
 
         /**
@@ -157,16 +157,13 @@ class LocationPuckOptions private constructor(
          * @return [LocationPuckOptions]
          */
         fun build(): LocationPuckOptions {
-            val regularPuck by lazy { regularPuck(context) }
-            val navigationPuck by lazy { navigationPuck(context) }
             return LocationPuckOptions(
                 context,
-                defaultPuck ?: regularPuck,
-                freeDrivePuck ?: defaultPuck ?: regularPuck,
-                destinationPreviewPuck ?: defaultPuck ?: regularPuck,
-                routePreviewPuck ?: defaultPuck ?: regularPuck,
-                activeNavigationPuck ?: defaultPuck ?: navigationPuck,
-                arrivalPuck ?: defaultPuck ?: regularPuck
+                freeDrivePuck,
+                destinationPreviewPuck,
+                routePreviewPuck,
+                activeNavigationPuck,
+                arrivalPuck
             )
         }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptions.kt
@@ -1,0 +1,205 @@
+package com.mapbox.navigation.ui.maps.puck
+
+import android.content.Context
+import androidx.core.content.ContextCompat
+import com.mapbox.maps.plugin.LocationPuck
+import com.mapbox.maps.plugin.LocationPuck2D
+import com.mapbox.maps.plugin.LocationPuck3D
+import com.mapbox.navigation.ui.maps.R
+
+/**
+ * Gives options to specify either [LocationPuck2D] or [LocationPuck3D] references to the location
+ * puck to be displayed on top of map view in each of different navigation states.
+ *
+ * @param context from which to reference puck drawables
+ * @param defaultPuck stores the puck appearance to be displayed in all navigation states
+ * @param freeDrivePuck stores the puck appearance to be displayed in free drive state
+ * @param destinationPreviewPuck stores the puck appearance to be displayed in destination preview state
+ * @param routePreviewPuck stores the puck appearance to be displayed in route preview state
+ * @param activeNavigationPuck stores the puck appearance to be displayed in active navigation state
+ * @param arrivalPuck stores the puck appearance to be displayed in arrival state
+ */
+class LocationPuckOptions private constructor(
+    val context: Context,
+    val defaultPuck: LocationPuck,
+    val freeDrivePuck: LocationPuck,
+    val destinationPreviewPuck: LocationPuck,
+    val routePreviewPuck: LocationPuck,
+    val activeNavigationPuck: LocationPuck,
+    val arrivalPuck: LocationPuck,
+) {
+
+    /**
+     * @return the [Builder] that created the [LocationPuckOptions]
+     */
+    fun toBuilder(): Builder = Builder(context).apply {
+        defaultPuck(defaultPuck)
+        freeDrivePuck(freeDrivePuck)
+        destinationPreviewPuck(destinationPreviewPuck)
+        routePreviewPuck(routePreviewPuck)
+        activeNavigationPuck(activeNavigationPuck)
+        arrivalPuck(arrivalPuck)
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as LocationPuckOptions
+
+        if (context != other.context) return false
+        if (defaultPuck != other.defaultPuck) return false
+        if (freeDrivePuck != other.freeDrivePuck) return false
+        if (destinationPreviewPuck != other.destinationPreviewPuck) return false
+        if (routePreviewPuck != other.routePreviewPuck) return false
+        if (activeNavigationPuck != other.activeNavigationPuck) return false
+        if (arrivalPuck != other.arrivalPuck) return false
+
+        return true
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun hashCode(): Int {
+        var result = context.hashCode()
+        result = 31 * result + defaultPuck.hashCode()
+        result = 31 * result + freeDrivePuck.hashCode()
+        result = 31 * result + destinationPreviewPuck.hashCode()
+        result = 31 * result + routePreviewPuck.hashCode()
+        result = 31 * result + activeNavigationPuck.hashCode()
+        result = 31 * result + arrivalPuck.hashCode()
+        return result
+    }
+
+    /**
+     * Regenerate whenever a change is made
+     */
+    override fun toString(): String {
+        return "LocationPuckOptions(" +
+            "context=$context, " +
+            "defaultPuck=$defaultPuck, " +
+            "freeDrivePuck=$freeDrivePuck, " +
+            "destinationPreviewPuck=$destinationPreviewPuck, " +
+            "routePreviewPuck=$routePreviewPuck, " +
+            "activeNavigationPuck=$activeNavigationPuck, " +
+            "arrivalPuck=$arrivalPuck" +
+            ")"
+    }
+
+    /**
+     * Builder of [LocationPuckOptions]
+     */
+    class Builder(private val context: Context) {
+
+        private var freeDrivePuck: LocationPuck? = null
+        private var destinationPreviewPuck: LocationPuck? = null
+        private var routePreviewPuck: LocationPuck? = null
+        private var activeNavigationPuck: LocationPuck? = null
+        private var arrivalPuck: LocationPuck? = null
+        private var defaultPuck: LocationPuck? = null
+
+        /**
+         * Apply the same [LocationPuck2D] or [LocationPuck3D] to location puck in all different
+         * navigation states
+         * @param defaultPuck [LocationPuck] to be used in all navigation states
+         */
+        fun defaultPuck(defaultPuck: LocationPuck): Builder = apply {
+            this.defaultPuck = defaultPuck
+        }
+
+        /**
+         * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in free drive state
+         * @param freeDrivePuck [LocationPuck] to be used in free drive state
+         */
+        fun freeDrivePuck(freeDrivePuck: LocationPuck): Builder = apply {
+            this.freeDrivePuck = freeDrivePuck
+        }
+
+        /**
+         * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in destination preview state
+         * @param destinationPreviewPuck [LocationPuck] to be used in destination preview state
+         */
+        fun destinationPreviewPuck(destinationPreviewPuck: LocationPuck): Builder = apply {
+            this.destinationPreviewPuck = destinationPreviewPuck
+        }
+
+        /**
+         * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in route preview state
+         * @param routePreviewPuck [LocationPuck] to be used in route preview state
+         */
+        fun routePreviewPuck(routePreviewPuck: LocationPuck): Builder = apply {
+            this.routePreviewPuck = routePreviewPuck
+        }
+
+        /**
+         * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in active navigation state
+         * @param activeNavigationPuck [LocationPuck] to be used in active navigation state
+         */
+        fun activeNavigationPuck(activeNavigationPuck: LocationPuck): Builder = apply {
+            this.activeNavigationPuck = activeNavigationPuck
+        }
+
+        /**
+         * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in arrival state
+         * @param arrivalPuck [LocationPuck] to be used in arrival state
+         */
+        fun arrivalPuck(arrivalPuck: LocationPuck): Builder = apply {
+            this.arrivalPuck = arrivalPuck
+        }
+
+        /**
+         * Build a new instance of [LocationPuckOptions]
+         *
+         * @return [LocationPuckOptions]
+         */
+        fun build(): LocationPuckOptions {
+            val regularPuck by lazy { regularPuck(context) }
+            val navigationPuck by lazy { navigationPuck(context) }
+            return LocationPuckOptions(
+                context,
+                defaultPuck ?: regularPuck,
+                freeDrivePuck ?: defaultPuck ?: regularPuck,
+                destinationPreviewPuck ?: defaultPuck ?: regularPuck,
+                routePreviewPuck ?: defaultPuck ?: regularPuck,
+                activeNavigationPuck ?: defaultPuck ?: navigationPuck,
+                arrivalPuck ?: defaultPuck ?: regularPuck
+            )
+        }
+
+        companion object {
+            /**
+             * Provides access to [LocationPuck2D] more suited for active navigation and arrival
+             * use cases.
+             */
+            fun navigationPuck(context: Context): LocationPuck = LocationPuck2D(
+                bearingImage = ContextCompat.getDrawable(
+                    context,
+                    R.drawable.mapbox_navigation_puck_icon,
+                )
+            )
+
+            /**
+             * Provides access to [LocationPuck2D] more suited for free drive,
+             * destination preview and route preview use cases.
+             */
+            fun regularPuck(context: Context): LocationPuck = LocationPuck2D(
+                topImage = ContextCompat.getDrawable(
+                    context,
+                    com.mapbox.maps.plugin.locationcomponent.R.drawable.mapbox_user_icon
+                ),
+                bearingImage = ContextCompat.getDrawable(
+                    context,
+                    com.mapbox.maps.plugin.locationcomponent.R.drawable.mapbox_user_bearing_icon
+                ),
+                shadowImage = ContextCompat.getDrawable(
+                    context,
+                    com.mapbox.maps.plugin.locationcomponent.R.drawable.mapbox_user_stroke_icon
+                )
+            )
+        }
+    }
+}

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptionsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptionsTest.kt
@@ -1,0 +1,29 @@
+package com.mapbox.navigation.ui.maps.puck
+
+import android.content.Context
+import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
+import kotlin.reflect.KClass
+
+class LocationPuckOptionsTest :
+    BuilderTest<LocationPuckOptions, LocationPuckOptions.Builder>() {
+
+    private val context: Context = mockk(relaxed = true)
+
+    override fun getImplementationClass(): KClass<LocationPuckOptions> = LocationPuckOptions::class
+
+    override fun getFilledUpBuilder(): LocationPuckOptions.Builder {
+        return LocationPuckOptions
+            .Builder(context)
+            .defaultPuck(mockk())
+            .freeDrivePuck(mockk())
+            .destinationPreviewPuck(mockk())
+            .routePreviewPuck(mockk())
+            .activeNavigationPuck(mockk())
+            .arrivalPuck(mockk())
+    }
+
+    override fun trigger() {
+        // only used to trigger JUnit4 to run this class if all test cases come from the parent
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -55,7 +55,7 @@ import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultEndN
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelBackground
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelMarginEnd
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultInfoPanelMarginStart
-import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultLocationPuck
+import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultLocationPuckOptions
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultManeuverViewOptions
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRecenterButtonStyle
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRoadNameBackground
@@ -83,6 +83,7 @@ import com.mapbox.navigation.qa_test_app.view.base.DrawerActivity
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import com.mapbox.navigation.ui.maps.NavigationStyles
+import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
 import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
 import com.mapbox.navigation.utils.internal.toPoint
 
@@ -352,12 +353,17 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
                 mapStyleUriNight = Style.DARK
             }
             binding.navigationView.customizeViewStyles {
-                locationPuck = LocationPuck2D(
-                    bearingImage = ContextCompat.getDrawable(
-                        this@MapboxNavigationViewCustomizedActivity,
-                        R.drawable.ic_sv_puck
+                locationPuckOptions = LocationPuckOptions
+                    .Builder(applicationContext)
+                    .freeDrivePuck(
+                        LocationPuck2D(
+                            bearingImage = ContextCompat.getDrawable(
+                                this@MapboxNavigationViewCustomizedActivity,
+                                R.drawable.ic_sv_puck
+                            )
+                        )
                     )
-                )
+                    .build()
             }
         } else {
             // Reset defaults
@@ -371,7 +377,7 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
                 mapStyleUriNight = NavigationStyles.NAVIGATION_NIGHT_STYLE
             }
             binding.navigationView.customizeViewStyles {
-                locationPuck = defaultLocationPuck(applicationContext)
+                locationPuckOptions = defaultLocationPuckOptions(applicationContext)
             }
         }
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Cherry-pick #6574: Ability to assign different location pucks based on navigation state

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
