### PR TITLE
Add `ReplayEventStream` for replaying events while using constant memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Added `MapboxReplayer#attachStream` and `ReplayEventStream` for replaying events while using constant memory. [#6582](https://github.com/mapbox/mapbox-navigation-android/pull/6582)
+- Added `ReplayHistoryEventStream` for replaying history files as a stream. [#6582](https://github.com/mapbox/mapbox-navigation-android/pull/6582)
 
 ## Mapbox Navigation SDK 2.9.1 - 11 November, 2022
 ### Changelog

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/ReplayHistoryActivity.kt
@@ -47,7 +47,7 @@ import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
 import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
-import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.maps.route.line.model.NavigationRouteLine
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
 import kotlinx.coroutines.CoroutineScope
@@ -272,10 +272,8 @@ class ReplayHistoryActivity : AppCompatActivity() {
         }
         viewportDataSource.evaluate()
 
-        val routeLines = result.routes.map { RouteLine(it, null) }
-        routeLineApi.setRoutes(
-            routeLines
-        ) { value ->
+        val routeLines = result.navigationRoutes.map { NavigationRouteLine(it, null) }
+        routeLineApi.setNavigationRouteLines(routeLines) { value ->
             binding.mapView.getMapboxMap().getStyle()?.apply {
                 routeLineView.renderRouteDrawData(this, value)
             }
@@ -336,13 +334,13 @@ class ReplayHistoryActivity : AppCompatActivity() {
     @SuppressLint("MissingPermission")
     private fun handleHistoryFileSelected() {
         loadNavigationJob = CoroutineScope(Dispatchers.Main).launch {
-            val events = historyFileLoader
-                .loadReplayHistory(this@ReplayHistoryActivity)
             mapboxReplayer.clearEvents()
-            mapboxReplayer.pushEvents(events)
+            val eventStream = historyFileLoader
+                .loadReplayHistory(this@ReplayHistoryActivity)
+            mapboxReplayer.attachStream(eventStream)
             binding.playReplay.visibility = View.VISIBLE
             mapboxNavigation.resetTripSession()
-            mapboxNavigation.setRoutes(emptyList())
+            mapboxNavigation.setNavigationRoutes(emptyList())
             isLocationInitialized = false
             mapboxReplayer.playFirstLocation()
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/replay/HistoryFileLoader.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/replay/HistoryFileLoader.kt
@@ -2,47 +2,29 @@ package com.mapbox.navigation.examples.core.replay
 
 import android.annotation.SuppressLint
 import android.content.Context
-import com.mapbox.navigation.core.history.MapboxHistoryReader
-import com.mapbox.navigation.core.replay.history.ReplayEventBase
-import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper
-import com.mapbox.navigation.core.replay.history.ReplaySetNavigationRoute
+import com.mapbox.navigation.core.replay.history.ReplayHistoryEventStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class HistoryFileLoader {
-    private val replayHistoryMapper = ReplayHistoryMapper.Builder().setRouteMapper {
-        ReplaySetNavigationRoute.Builder(eventTimestamp = it.eventTimestamp)
-            .route(it.navigationRoute)
-            .build()
-    }.build()
     private val historyFilesDirectory = HistoryFilesDirectory()
 
     @SuppressLint("MissingPermission")
     suspend fun loadReplayHistory(
         context: Context
-    ): List<ReplayEventBase> = withContext(Dispatchers.IO) {
-        loadSelectedHistory() ?: loadDefaultReplayHistory(context)
+    ): ReplayHistoryEventStream = withContext(Dispatchers.IO) {
+        HistoryFilesActivity.selectedHistory ?: loadDefaultReplayHistory(context)
     }
-
-    private suspend fun loadSelectedHistory(): List<ReplayEventBase>? =
-        withContext(Dispatchers.IO) {
-            HistoryFilesActivity.selectedHistory?.asSequence()?.mapNotNull { historyEvent ->
-                replayHistoryMapper.mapToReplayEvent(historyEvent)
-            }?.toList()
-        }
 
     private suspend fun loadDefaultReplayHistory(
         context: Context
-    ): List<ReplayEventBase> = withContext(Dispatchers.IO) {
+    ): ReplayHistoryEventStream = withContext(Dispatchers.IO) {
         val fileName = "replay-history-activity.json"
         val inputStream = context.assets.open(fileName)
         val outputFile = historyFilesDirectory.outputFile(context, fileName)
         outputFile.outputStream().use { fileOut ->
             inputStream.copyTo(fileOut)
         }
-        MapboxHistoryReader(outputFile.absolutePath)
-            .asSequence()
-            .mapNotNull { replayHistoryMapper.mapToReplayEvent(it) }
-            .toList()
+        ReplayHistoryEventStream(outputFile.absolutePath)
     }
 }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/replay/HistoryFilesActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/replay/HistoryFilesActivity.kt
@@ -11,7 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
-import com.mapbox.navigation.core.history.MapboxHistoryReader
+import com.mapbox.navigation.core.replay.history.ReplayHistoryEventStream
 import com.mapbox.navigation.examples.core.R
 
 @SuppressLint("HardwareIds")
@@ -20,7 +20,7 @@ class HistoryFilesActivity : AppCompatActivity() {
     companion object {
         const val REQUEST_CODE: Int = 123
         const val EXTRA_HISTORY_FILE_DIRECTORY = "EXTRA_HISTORY_FILE_DIRECTORY"
-        var selectedHistory: MapboxHistoryReader? = null
+        var selectedHistory: ReplayHistoryEventStream? = null
             private set
     }
 
@@ -53,8 +53,8 @@ class HistoryFilesActivity : AppCompatActivity() {
 
         val historyFileDirectory = intent.extras?.getString(EXTRA_HISTORY_FILE_DIRECTORY)
         filesViewController = HistoryFilesViewController(historyFileDirectory)
-        filesViewController.attach(this, viewAdapter) { historyDataResponse ->
-            if (historyDataResponse == null) {
+        filesViewController.attach(this, viewAdapter) { replayHistoryEventStream ->
+            if (replayHistoryEventStream == null) {
                 Snackbar.make(
                     recyclerView,
                     getString(R.string.history_failed_to_load_item),
@@ -64,7 +64,7 @@ class HistoryFilesActivity : AppCompatActivity() {
                     null
                 ).show()
             } else {
-                selectedHistory = historyDataResponse
+                selectedHistory = replayHistoryEventStream
                 finish()
             }
         }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/replay/HistoryFilesClient.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/replay/HistoryFilesClient.kt
@@ -2,7 +2,7 @@ package com.mapbox.navigation.examples.core.replay
 
 import android.util.Log
 import androidx.annotation.Keep
-import com.mapbox.navigation.core.history.MapboxHistoryReader
+import com.mapbox.navigation.core.replay.history.ReplayHistoryEventStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -55,14 +55,14 @@ class HistoryFilesClient {
             }
         }
 
-    suspend fun requestJsonFile(pathName: String, outputFile: File): MapboxHistoryReader? =
+    suspend fun requestJsonFile(pathName: String, outputFile: File): ReplayHistoryEventStream? =
         withContext(Dispatchers.IO) {
             try {
                 val inputStream = URL(HISTORY_FILE_URL + pathName).openStream()
                 outputFile.outputStream().use { fileOut ->
                     inputStream.copyTo(fileOut)
                 }
-                MapboxHistoryReader(outputFile.absolutePath)
+                ReplayHistoryEventStream(outputFile.absolutePath)
             } catch (exception: IOException) {
                 Log.e(TAG, "requestJsonFile onFailure: $exception")
                 null

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/replay/HistoryFilesViewController.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/replay/HistoryFilesViewController.kt
@@ -1,7 +1,7 @@
 package com.mapbox.navigation.examples.core.replay
 
 import android.content.Context
-import com.mapbox.navigation.core.history.MapboxHistoryReader
+import com.mapbox.navigation.core.replay.history.ReplayHistoryEventStream
 import com.mapbox.navigation.examples.core.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -14,7 +14,6 @@ import java.util.Collections
 class HistoryFilesViewController(
     private val historyFileDirectory: String?
 ) {
-
     private var viewAdapter: HistoryFileAdapter? = null
     private val historyFilesRepository = HistoryFilesDirectory()
     private val historyFilesApi = HistoryFilesClient()
@@ -22,7 +21,7 @@ class HistoryFilesViewController(
     fun attach(
         context: Context,
         viewAdapter: HistoryFileAdapter,
-        result: (MapboxHistoryReader?) -> Unit
+        result: (ReplayHistoryEventStream?) -> Unit
     ) {
         this.viewAdapter = viewAdapter
         viewAdapter.itemClicked = { historyFileItem ->
@@ -90,10 +89,10 @@ class HistoryFilesViewController(
 
     private fun requestFromFileCache(
         historyFileItem: ReplayPath,
-        result: (MapboxHistoryReader) -> Unit
+        result: (ReplayHistoryEventStream) -> Unit
     ) {
         CoroutineScope(Dispatchers.Main).launch {
-            val data = MapboxHistoryReader(historyFileItem.path)
+            val data = ReplayHistoryEventStream(historyFileItem.path)
             result(data)
         }
     }
@@ -101,7 +100,7 @@ class HistoryFilesViewController(
     private fun requestFromServer(
         context: Context,
         replayPath: ReplayPath,
-        result: (MapboxHistoryReader?) -> Unit
+        result: (ReplayHistoryEventStream?) -> Unit
     ): Job {
         return CoroutineScope(Dispatchers.Main).launch {
             val outputFile = historyFilesRepository.outputFile(context, replayPath.path)
@@ -113,7 +112,7 @@ class HistoryFilesViewController(
     private fun requestFromAssets(
         context: Context,
         replayPath: ReplayPath,
-        result: (MapboxHistoryReader?) -> Unit
+        result: (ReplayHistoryEventStream?) -> Unit
     ) {
         CoroutineScope(Dispatchers.IO).launch {
             val inputStream = context.assets.open(replayPath.path)
@@ -121,7 +120,7 @@ class HistoryFilesViewController(
             outputFile.outputStream().use { fileOut ->
                 inputStream.copyTo(fileOut)
             }
-            val reader = MapboxHistoryReader(outputFile.absolutePath)
+            val reader = ReplayHistoryEventStream(outputFile.absolutePath)
             withContext(Dispatchers.Main) {
                 result(reader)
             }

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -251,10 +251,8 @@ package com.mapbox.navigation.core.history {
 
   public final class MapboxHistoryReader implements java.util.Iterator<com.mapbox.navigation.core.history.model.HistoryEvent> kotlin.jvm.internal.markers.KMappedMarker {
     ctor public MapboxHistoryReader(String filePath);
-    method public String getFilePath();
     method public boolean hasNext();
-    method public com.mapbox.navigation.core.history.model.HistoryEvent next();
-    property public final String filePath;
+    method @kotlin.jvm.Throws(exceptionClasses=NullPointerException::class) public com.mapbox.navigation.core.history.model.HistoryEvent next() throws java.lang.NullPointerException;
   }
 
   public final class MapboxHistoryRecorder {
@@ -435,6 +433,7 @@ package com.mapbox.navigation.core.replay {
 
   @UiThread public final class MapboxReplayer {
     ctor public MapboxReplayer();
+    method public com.mapbox.navigation.core.replay.MapboxReplayer attachStream(com.mapbox.navigation.core.replay.ReplayEventStream eventStream);
     method public void clearEvents();
     method public double durationSeconds();
     method public double eventRealtimeOffset(double eventTimestamp);
@@ -451,6 +450,10 @@ package com.mapbox.navigation.core.replay {
     method public void stop();
     method public void unregisterObserver(com.mapbox.navigation.core.replay.history.ReplayEventsObserver observer);
     method public void unregisterObservers();
+  }
+
+  public interface ReplayEventStream extends java.io.Closeable java.util.Iterator<com.mapbox.navigation.core.replay.history.ReplayEventBase> {
+    method public default void close();
   }
 
   @UiThread public final class ReplayLocationEngine implements com.mapbox.android.core.location.LocationEngine com.mapbox.navigation.core.replay.history.ReplayEventsObserver {
@@ -537,6 +540,13 @@ package com.mapbox.navigation.core.replay.history {
 
   public fun interface ReplayHistoryEventMapper<Event extends com.mapbox.navigation.core.history.model.HistoryEvent> {
     method public com.mapbox.navigation.core.replay.history.ReplayEventBase? map(Event event);
+  }
+
+  public final class ReplayHistoryEventStream implements com.mapbox.navigation.core.replay.ReplayEventStream {
+    ctor public ReplayHistoryEventStream(String filePath);
+    ctor public ReplayHistoryEventStream(String filePath, com.mapbox.navigation.core.replay.history.ReplayHistoryMapper replayHistoryMapper);
+    method public boolean hasNext();
+    method @kotlin.jvm.Throws(exceptionClasses=NullPointerException::class) public com.mapbox.navigation.core.replay.history.ReplayEventBase next() throws java.lang.NullPointerException;
   }
 
   public final class ReplayHistoryMapper {

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -251,8 +251,10 @@ package com.mapbox.navigation.core.history {
 
   public final class MapboxHistoryReader implements java.util.Iterator<com.mapbox.navigation.core.history.model.HistoryEvent> kotlin.jvm.internal.markers.KMappedMarker {
     ctor public MapboxHistoryReader(String filePath);
+    method public String getFilePath();
     method public boolean hasNext();
     method @kotlin.jvm.Throws(exceptionClasses=NullPointerException::class) public com.mapbox.navigation.core.history.model.HistoryEvent next() throws java.lang.NullPointerException;
+    property public final String filePath;
   }
 
   public final class MapboxHistoryRecorder {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/history/MapboxHistoryReader.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/history/MapboxHistoryReader.kt
@@ -11,6 +11,7 @@ import com.mapbox.navigator.HistoryReaderInterface
  * All files in the [MapboxHistoryRecorder.fileDirectory] can be read with this reader.
  */
 class MapboxHistoryReader @VisibleForTesting internal constructor(
+    val filePath: String,
     private val nativeHistoryReader: HistoryReaderInterface,
     private val historyEventMapper: HistoryEventMapper
 ) : Iterator<HistoryEvent> {
@@ -19,6 +20,7 @@ class MapboxHistoryReader @VisibleForTesting internal constructor(
      * @param filePath absolute path to a file containing the native history file.
      */
     constructor(filePath: String) : this(
+        filePath,
         HistoryReader(filePath),
         HistoryEventMapper()
     )

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/history/MapboxHistoryReader.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/history/MapboxHistoryReader.kt
@@ -1,50 +1,55 @@
 package com.mapbox.navigation.core.history
 
+import androidx.annotation.VisibleForTesting
 import com.mapbox.navigation.core.history.model.HistoryEvent
 import com.mapbox.navigation.core.history.model.HistoryEventMapper
 import com.mapbox.navigator.HistoryReader
+import com.mapbox.navigator.HistoryReaderInterface
 
 /**
  * Allows you to read history files previously saved by [MapboxHistoryRecorder].
  * All files in the [MapboxHistoryRecorder.fileDirectory] can be read with this reader.
- *
- * @param filePath absolute path to a file containing the native history file.
  */
-class MapboxHistoryReader(
-    val filePath: String
+class MapboxHistoryReader @VisibleForTesting internal constructor(
+    private val nativeHistoryReader: HistoryReaderInterface,
+    private val historyEventMapper: HistoryEventMapper
 ) : Iterator<HistoryEvent> {
 
-    private val nativeHistoryReader = HistoryReader(filePath)
-    private val historyEventMapper = HistoryEventMapper()
+    /**
+     * @param filePath absolute path to a file containing the native history file.
+     */
+    constructor(filePath: String) : this(
+        HistoryReader(filePath),
+        HistoryEventMapper()
+    )
 
-    private var hasNext: Boolean = false
     private var next: HistoryEvent? = null
 
     init {
-        hasNext = loadNext()
+        loadNext()
     }
 
     /**
      * Returns `true` if the iteration has more elements.
      */
-    override fun hasNext(): Boolean = hasNext
+    override fun hasNext(): Boolean = next != null
 
     /**
      * Returns the next element in the iteration.
      *
      * @throws NullPointerException when [hasNext] is false
      */
+    @Throws(NullPointerException::class)
     override fun next(): HistoryEvent = next!!.also {
-        hasNext = loadNext()
+        loadNext()
     }
 
-    private fun loadNext(): Boolean {
+    private fun loadNext() {
         val historyRecord = nativeHistoryReader.next()
         next = if (historyRecord != null) {
             historyEventMapper.map(historyRecord)
         } else {
             null
         }
-        return next != null
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/history/model/HistoryEventMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/history/model/HistoryEventMapper.kt
@@ -24,7 +24,6 @@ import java.net.URL
 internal class HistoryEventMapper {
 
     private companion object {
-        private const val LOG_CATEGORY = "HistoryEventMapper"
         private const val NANOS_PER_SECOND = 1e-9
         private const val WAYPOINTS_JSON_KEY = "waypoints"
         private const val NAME_JSON_KEY = "name"

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/ReplayEventStream.java
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/ReplayEventStream.java
@@ -1,0 +1,32 @@
+package com.mapbox.navigation.core.replay;
+
+import com.mapbox.navigation.core.replay.history.ReplayEventBase;
+import com.mapbox.navigation.core.replay.history.ReplayHistoryEventStream;
+import com.mapbox.navigation.core.replay.route.ReplayRouteOptions;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+/**
+ * Interface used for memory efficient replay systems. This is needed for simulations that include
+ * many events, for example high frequencies {@link ReplayRouteOptions#getFrequency()}. This is
+ * also needed for large history files.
+ *
+ * @see ReplayHistoryEventStream
+ */
+public interface ReplayEventStream extends Closeable, Iterator<ReplayEventBase> {
+
+  /**
+   * Remove is not supported by default.
+   */
+  default void remove() {
+    throw new UnsupportedOperationException("remove");
+  }
+
+  /**
+   * Close will do nothing by default.
+   */
+  default void close() {
+    // No operation by default
+  }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventBuffer.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventBuffer.kt
@@ -1,0 +1,76 @@
+package com.mapbox.navigation.core.replay.history
+
+import com.mapbox.navigation.core.replay.ReplayEventStream
+
+/**
+ * This class is responsible for queuing events into the MapboxReplayer. It will take events
+ * out of a file and push them into replay.
+ *
+ * It may be needed to update the [bufferSize] and [batchSize] to support configurations with
+ * different requirements. If replay events are large at low frequencies, a small buffer is needed.
+ * If replay events are small but frequent, a large buffer is needed. Large events at high
+ * frequencies require devices with more memory.
+ */
+internal class ReplayEventBuffer {
+    private val replayEvents = mutableListOf<ReplayEventBase>()
+    private var eventStream: ReplayEventStream? = null
+
+    val events: List<ReplayEventBase>
+        get() = replayEvents
+
+    /**
+     * Threshold defines when there are less than this many events, add more events.
+     */
+    private var bufferSize: Int = DEFAULT_REPLAY_EVENT_BUFFER_SIZE
+
+    /**
+     * Threshold defines the number of events that will be pushed at a time.
+     */
+    private var batchSize: Int = DEFAULT_REPLAY_EVENT_BATCH_SIZE
+
+    /**
+     * Ignore buffer sizes and add a list of events.
+     */
+    fun pushEvents(events: List<ReplayEventBase>) {
+        this.replayEvents.addAll(events)
+    }
+
+    /**
+     * Close the previous stream, and start pushing new events from the stream.
+     *
+     * @param eventStream contains a stream of [ReplayEventBase]
+     */
+    fun attachStream(eventStream: ReplayEventStream?) {
+        this.eventStream?.close()
+        this.eventStream = eventStream
+        bufferEvents()
+    }
+
+    /**
+     * This needs to be periodically called in order to push new events.
+     */
+    fun bufferEvents() {
+        val queuedEvents = replayEvents.size
+        if (queuedEvents < bufferSize && eventStream?.hasNext() == true) {
+            eventStream?.asSequence()
+                ?.take(batchSize)
+                ?.toList()
+                ?.let { replayEvents ->
+                    pushEvents(replayEvents)
+                }
+        }
+    }
+
+    /**
+     * Clear all the events, and close the event stream.
+     */
+    fun clear() {
+        eventStream?.close()
+        replayEvents.clear()
+    }
+
+    private companion object {
+        private const val DEFAULT_REPLAY_EVENT_BUFFER_SIZE = 100
+        private const val DEFAULT_REPLAY_EVENT_BATCH_SIZE = 50
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayEventSimulator.kt
@@ -18,7 +18,7 @@ import kotlin.math.roundToLong
  * @param replayEvents events needed to be replayed by [MapboxReplayer]
  */
 internal class ReplayEventSimulator(
-    private val replayEvents: ReplayEvents
+    private val replayEvents: ReplayEventBuffer
 ) {
 
     private val jobControl = InternalJobControlFactory.createMainScopeJobControl()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryEventStream.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryEventStream.kt
@@ -1,0 +1,72 @@
+package com.mapbox.navigation.core.replay.history
+
+import androidx.annotation.VisibleForTesting
+import com.mapbox.navigation.core.history.MapboxHistoryReader
+import com.mapbox.navigation.core.replay.ReplayEventStream
+
+/**
+ * Lower memory option for reading replay events from a history file. Use the [ReplayHistoryMapper]
+ * to support replaying custom events with [ReplayHistoryMapper.pushEventMappers].
+ *
+ * TODO NN-268 MapboxHistoryReader loads the entire file so the memory optimization does not work.
+ *   The issue will be addressed without changes to this interface.
+ */
+class ReplayHistoryEventStream @VisibleForTesting internal constructor(
+    private val historyReader: MapboxHistoryReader,
+    private val replayHistoryMapper: ReplayHistoryMapper
+) : ReplayEventStream {
+
+    /**
+     * Construct an event stream from a file. A default event mapper, any unrecognized events will
+     * be dropped. Provide a [replayHistoryMapper] to customize how events are mapped.
+     *
+     * @param filePath absolute path to a file containing the native history file.
+     */
+    constructor(filePath: String) : this(
+        MapboxHistoryReader(filePath),
+        ReplayHistoryMapper.Builder().build()
+    )
+
+    /**
+     * Construct an event stream from a file with a custom event mapper.
+     *
+     * @param filePath absolute path to a file containing the native history file.
+     * @param replayHistoryMapper for customizing how the events are mapped.
+     */
+    constructor(filePath: String, replayHistoryMapper: ReplayHistoryMapper) : this(
+        MapboxHistoryReader(filePath),
+        replayHistoryMapper
+    )
+
+    private var next: ReplayEventBase? = null
+
+    init {
+        loadNext()
+    }
+
+    /**
+     * Returns `true` if the iteration has more elements.
+     */
+    override fun hasNext(): Boolean = next != null
+
+    /**
+     * Returns the next element in the iteration.
+     *
+     * @throws NullPointerException when [hasNext] is false.
+     */
+    @Throws(NullPointerException::class)
+    override fun next(): ReplayEventBase = next!!.also {
+        loadNext()
+    }
+
+    private fun loadNext() {
+        do {
+            if (historyReader.hasNext()) {
+                next = replayHistoryMapper.mapToReplayEvent(historyReader.next())
+            } else {
+                next = null
+                return
+            }
+        } while (next == null)
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapper.kt
@@ -193,10 +193,9 @@ class ReplayHistoryMapper private constructor(
 
             private val DefaultSetRouteMapper =
                 ReplayHistoryEventMapper<HistoryEventSetRoute> {
-                    ReplaySetRoute(
-                        eventTimestamp = it.eventTimestamp,
-                        route = it.directionsRoute
-                    )
+                    ReplaySetNavigationRoute.Builder(eventTimestamp = it.eventTimestamp)
+                        .route(it.navigationRoute)
+                        .build()
                 }
 
             private val DefaultStatusMapper =

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/history/MapboxHistoryReaderTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/history/MapboxHistoryReaderTest.kt
@@ -1,0 +1,51 @@
+package com.mapbox.navigation.core.history
+
+import com.mapbox.navigation.core.history.model.HistoryEventMapper
+import com.mapbox.navigator.HistoryReaderInterface
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class MapboxHistoryReaderTest {
+
+    private val historyEventMapper: HistoryEventMapper = mockk {
+        every { map(any()) } returns mockk()
+    }
+
+    @Test
+    fun `next is loaded when object is constructed`() {
+        val nativeHistoryReader: HistoryReaderInterface = mockk {
+            every { next() } returns mockk()
+        }
+        val sut = MapboxHistoryReader(nativeHistoryReader, historyEventMapper)
+
+        val next = sut.next()
+
+        assertNotNull(next)
+    }
+
+    @Test
+    fun `hasNext is false when next returns null`() {
+        val nativeHistoryReader: HistoryReaderInterface = mockk {
+            every { next() } returns null
+        }
+        val sut = MapboxHistoryReader(nativeHistoryReader, historyEventMapper)
+
+        val hasNext = sut.hasNext()
+
+        assertFalse(hasNext)
+    }
+
+    @Test(expected = NullPointerException::class)
+    fun `next is false when next returns null`() {
+        val nativeHistoryReader: HistoryReaderInterface = mockk {
+            every { next() } returns null
+        }
+        val sut = MapboxHistoryReader(nativeHistoryReader, historyEventMapper)
+
+        // Should crash
+        sut.next()
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/history/MapboxHistoryReaderTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/history/MapboxHistoryReaderTest.kt
@@ -19,7 +19,7 @@ class MapboxHistoryReaderTest {
         val nativeHistoryReader: HistoryReaderInterface = mockk {
             every { next() } returns mockk()
         }
-        val sut = MapboxHistoryReader(nativeHistoryReader, historyEventMapper)
+        val sut = MapboxHistoryReader(mockk(), nativeHistoryReader, historyEventMapper)
 
         val next = sut.next()
 
@@ -31,7 +31,7 @@ class MapboxHistoryReaderTest {
         val nativeHistoryReader: HistoryReaderInterface = mockk {
             every { next() } returns null
         }
-        val sut = MapboxHistoryReader(nativeHistoryReader, historyEventMapper)
+        val sut = MapboxHistoryReader(mockk(), nativeHistoryReader, historyEventMapper)
 
         val hasNext = sut.hasNext()
 
@@ -43,7 +43,7 @@ class MapboxHistoryReaderTest {
         val nativeHistoryReader: HistoryReaderInterface = mockk {
             every { next() } returns null
         }
-        val sut = MapboxHistoryReader(nativeHistoryReader, historyEventMapper)
+        val sut = MapboxHistoryReader(mockk(), nativeHistoryReader, historyEventMapper)
 
         // Should crash
         sut.next()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryEventStreamTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryEventStreamTest.kt
@@ -1,0 +1,103 @@
+package com.mapbox.navigation.core.replay.history
+
+import com.mapbox.navigation.core.history.MapboxHistoryReader
+import com.mapbox.navigation.core.history.model.HistoryEvent
+import com.mapbox.navigation.core.history.model.HistoryEventGetStatus
+import com.mapbox.navigation.core.history.model.HistoryEventPushHistoryRecord
+import com.mapbox.navigation.core.history.model.HistoryEventSetRoute
+import com.mapbox.navigation.core.history.model.HistoryEventUpdateLocation
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReplayHistoryEventStreamTest {
+
+    private val mapboxHistoryReader: MapboxHistoryReader = mockk()
+
+    @Test
+    fun `next will return mapped event when mapboxHistoryReader#hasNext is true`() {
+        every { mapboxHistoryReader.hasNext() } returns true
+        every { mapboxHistoryReader.next() } returns mockk()
+        val sut = ReplayHistoryEventStream(mapboxHistoryReader, mockHistoryEventMapper())
+
+        val next = sut.next()
+
+        assertNotNull(next)
+    }
+
+    @Test
+    fun `hasNext is false when mapboxHistoryReader#hasNext returns false`() {
+        every { mapboxHistoryReader.hasNext() } returns false
+        val sut = ReplayHistoryEventStream(mapboxHistoryReader, mockHistoryEventMapper())
+
+        val hasNext = sut.hasNext()
+
+        assertFalse(hasNext)
+    }
+
+    @Test(expected = NullPointerException::class)
+    fun `next will crash when mapboxHistoryReader#hasNext is false`() {
+        every { mapboxHistoryReader.hasNext() } returns false
+        val sut = ReplayHistoryEventStream(mapboxHistoryReader, mockHistoryEventMapper())
+
+        // Should crash
+        sut.next()
+    }
+
+    @Test
+    fun `will emit events in the same order as the mapboxHistoryReader`() {
+        every { mapboxHistoryReader.hasNext() } returns true
+        every { mapboxHistoryReader.next() } returnsMany listOf(
+            mockk<HistoryEventGetStatus>(),
+            mockk<HistoryEventUpdateLocation>(),
+            mockk<HistoryEventSetRoute>(),
+            mockk<HistoryEventPushHistoryRecord>(),
+        )
+        val sut = ReplayHistoryEventStream(mapboxHistoryReader, mockHistoryEventMapper())
+
+        assertTrue(sut.next() is ReplayEventGetStatus)
+        assertTrue(sut.next() is ReplayEventUpdateLocation)
+        assertTrue(sut.next() is ReplaySetNavigationRoute)
+        assertNotNull(sut.next())
+    }
+
+    @Test
+    fun `customized mapper can be used to ignore or change events`() {
+        class CustomPushHistoryEvent(override val eventTimestamp: Double) : ReplayEventBase
+        val customizedMapper: ReplayHistoryMapper = mockk {
+            every { mapToReplayEvent(any()) } answers {
+                when (firstArg<HistoryEvent>()) {
+                    is HistoryEventGetStatus -> null
+                    is HistoryEventUpdateLocation -> mockk<ReplayEventUpdateLocation>()
+                    is HistoryEventSetRoute -> null
+                    else -> mockk<CustomPushHistoryEvent>()
+                }
+            }
+        }
+        every { mapboxHistoryReader.hasNext() } returns true
+        every { mapboxHistoryReader.next() } returnsMany listOf(
+            mockk<HistoryEventGetStatus>(),
+            mockk<HistoryEventUpdateLocation>(),
+            mockk<HistoryEventSetRoute>(),
+            mockk<HistoryEventPushHistoryRecord>(),
+        )
+        val sut = ReplayHistoryEventStream(mapboxHistoryReader, customizedMapper)
+
+        assertTrue(sut.next() is ReplayEventUpdateLocation)
+        assertTrue(sut.next() is CustomPushHistoryEvent)
+    }
+
+    private fun mockHistoryEventMapper(): ReplayHistoryMapper = mockk {
+        every { mapToReplayEvent(any()) } answers {
+            when (firstArg<HistoryEvent>()) {
+                is HistoryEventGetStatus -> mockk<ReplayEventGetStatus>()
+                is HistoryEventUpdateLocation -> mockk<ReplayEventUpdateLocation>()
+                is HistoryEventSetRoute -> mockk<ReplaySetNavigationRoute>()
+                else -> mockk()
+            }
+        }
+    }
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/history/ReplayHistoryMapperTest.kt
@@ -77,13 +77,13 @@ class ReplayHistoryMapperTest : BuilderTest<ReplayHistoryMapper, ReplayHistoryMa
     fun `should map HistoryEventSetRoute`() {
         val event: HistoryEventSetRoute = mockk {
             every { eventTimestamp } returns 1580744198.879556
-            every { directionsRoute } returns mockk(relaxed = true)
+            every { navigationRoute } returns mockk(relaxed = true)
         }
 
         val replayHistoryMapper = ReplayHistoryMapper.Builder().build()
         val replayEvent = replayHistoryMapper.mapToReplayEvent(event)!!
 
-        assertTrue(replayEvent is ReplaySetRoute)
+        assertTrue(replayEvent is ReplaySetNavigationRoute)
         assertEquals(1580744198.879556, replayEvent.eventTimestamp, 0.0001)
     }
 

--- a/libtesting-utils/src/main/java/com/mapbox/navigation/testing/MemoryTestRule.kt
+++ b/libtesting-utils/src/main/java/com/mapbox/navigation/testing/MemoryTestRule.kt
@@ -1,0 +1,30 @@
+package com.mapbox.navigation.testing
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * This test rule will help you understand memory usage for tests.
+ */
+class MemoryTestRule : TestRule {
+
+    private var startMemoryBytes: Long? = null
+
+    override fun apply(base: Statement, description: Description) = object : Statement() {
+        @Throws(Throwable::class)
+        override fun evaluate() {
+            val runtime = Runtime.getRuntime()
+            runtime.gc()
+            startMemoryBytes = runtime.totalMemory() - runtime.freeMemory()
+            base.evaluate()
+        }
+    }
+
+    val memoryUsedMB: Double
+        get() {
+            val runtime = Runtime.getRuntime()
+            val memoryAfter = runtime.totalMemory() - runtime.freeMemory()
+            return (memoryAfter - startMemoryBytes!!) * 1e-6
+        }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/testing/JavaInterfaceChecker.java
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/testing/JavaInterfaceChecker.java
@@ -2,13 +2,23 @@ package com.mapbox.navigation.qa_test_app.testing;
 
 import android.app.Application;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.LifecycleOwner;
 
 import com.mapbox.navigation.base.options.NavigationOptions;
 import com.mapbox.navigation.core.MapboxNavigation;
+import com.mapbox.navigation.core.history.model.HistoryEventPushHistoryRecord;
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp;
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver;
+import com.mapbox.navigation.core.replay.history.ReplayEventBase;
+import com.mapbox.navigation.core.replay.history.ReplayEventGetStatus;
+import com.mapbox.navigation.core.replay.history.ReplayHistoryEventMapper;
+import com.mapbox.navigation.core.replay.history.ReplayHistoryEventStream;
+import com.mapbox.navigation.core.replay.history.ReplayHistoryMapper;
 import com.mapbox.navigation.ui.voice.api.MapboxAudioGuidance;
+
+import java.util.Collections;
 
 import kotlinx.coroutines.CoroutineScope;
 
@@ -53,5 +63,30 @@ class JavaInterfaceChecker {
     JavaFlow.collect(sut.stateFlow(), coroutineScope, (enabled) -> {
       // observe state
     });
+  }
+
+  ReplayHistoryMapper replayHistoryMapper() {
+    return new ReplayHistoryMapper.Builder()
+        .locationMapper(event -> () -> 0)
+        .setRouteMapper(event -> (ReplayEventBase) () -> 0)
+        .statusMapper(event -> new ReplayEventGetStatus(0.0))
+        .pushEventMappers(Collections.singletonList(
+          new ReplayHistoryEventMapper<HistoryEventPushHistoryRecord>() {
+            @Nullable
+            @Override
+            public ReplayEventBase map(@NonNull HistoryEventPushHistoryRecord event) {
+              return null;
+            }
+          }
+        ))
+        .build();
+  }
+
+  void ReplayHistoryEventStream(String filename) {
+    ReplayHistoryEventStream withMapper = new ReplayHistoryEventStream(
+            filename,
+            replayHistoryMapper()
+    );
+    ReplayHistoryEventStream withoutMapper = new ReplayHistoryEventStream(filename);
   }
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

There has been a known issue with replaying history and routes, which is that it loads all the events into memory before starting the simulation and that will cause memory issues when there is a lot of data. Years ago I started solving this https://github.com/mapbox/mapbox-navigation-android/pull/3806. The reason I did not merge that, was because nav-native was adding protobuf history files and that was changing the details. I didn't pick it up again because we are not replaying sensor data. High frequency sensor data was the reason for large history files.

Now with the introduction of simulating routes with high frequency location updates https://github.com/mapbox/mapbox-navigation-android/pull/5748. There is a new need to handle large data for the simulations. Simulating a large route at high frequency requires a lot of memory and can cause OutOfMemory exceptions.

So this effort will be a 2 part series. 1 optimize history replay. 2 optimize route replay. This pull request is part 1 because it is simpler than optimizing the simulation algorithm.

Opening as draft because the `ReplayHistoryActivity` is all working as expected. But I'm still writing tests.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

Introducing the new `ReplayEventStream`. This allows you to keep a low memory footprint while simulating events.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
