### PR TITLE
Refactor the usage of default puck

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptions.kt
@@ -11,8 +11,10 @@ import com.mapbox.navigation.ui.maps.R
  * Gives options to specify either [LocationPuck2D] or [LocationPuck3D] references to the location
  * puck to be displayed on top of map view in each of different navigation states.
  *
+ * If you want to use the same puck for all different navigation states you can invoke
+ * `defaultPuck()` on the [Builder] and that would be used for pucks in all navigation states.
+ *
  * @param context from which to reference puck drawables
- * @param defaultPuck stores the puck appearance to be displayed in all navigation states
  * @param freeDrivePuck stores the puck appearance to be displayed in free drive state
  * @param destinationPreviewPuck stores the puck appearance to be displayed in destination preview state
  * @param routePreviewPuck stores the puck appearance to be displayed in route preview state
@@ -21,7 +23,6 @@ import com.mapbox.navigation.ui.maps.R
  */
 class LocationPuckOptions private constructor(
     val context: Context,
-    val defaultPuck: LocationPuck,
     val freeDrivePuck: LocationPuck,
     val destinationPreviewPuck: LocationPuck,
     val routePreviewPuck: LocationPuck,
@@ -33,7 +34,6 @@ class LocationPuckOptions private constructor(
      * @return the [Builder] that created the [LocationPuckOptions]
      */
     fun toBuilder(): Builder = Builder(context).apply {
-        defaultPuck(defaultPuck)
         freeDrivePuck(freeDrivePuck)
         destinationPreviewPuck(destinationPreviewPuck)
         routePreviewPuck(routePreviewPuck)
@@ -51,7 +51,6 @@ class LocationPuckOptions private constructor(
         other as LocationPuckOptions
 
         if (context != other.context) return false
-        if (defaultPuck != other.defaultPuck) return false
         if (freeDrivePuck != other.freeDrivePuck) return false
         if (destinationPreviewPuck != other.destinationPreviewPuck) return false
         if (routePreviewPuck != other.routePreviewPuck) return false
@@ -66,7 +65,6 @@ class LocationPuckOptions private constructor(
      */
     override fun hashCode(): Int {
         var result = context.hashCode()
-        result = 31 * result + defaultPuck.hashCode()
         result = 31 * result + freeDrivePuck.hashCode()
         result = 31 * result + destinationPreviewPuck.hashCode()
         result = 31 * result + routePreviewPuck.hashCode()
@@ -81,7 +79,6 @@ class LocationPuckOptions private constructor(
     override fun toString(): String {
         return "LocationPuckOptions(" +
             "context=$context, " +
-            "defaultPuck=$defaultPuck, " +
             "freeDrivePuck=$freeDrivePuck, " +
             "destinationPreviewPuck=$destinationPreviewPuck, " +
             "routePreviewPuck=$routePreviewPuck, " +
@@ -95,12 +92,11 @@ class LocationPuckOptions private constructor(
      */
     class Builder(private val context: Context) {
 
-        private var freeDrivePuck: LocationPuck? = null
-        private var destinationPreviewPuck: LocationPuck? = null
-        private var routePreviewPuck: LocationPuck? = null
-        private var activeNavigationPuck: LocationPuck? = null
-        private var arrivalPuck: LocationPuck? = null
-        private var defaultPuck: LocationPuck? = null
+        private var freeDrivePuck: LocationPuck = regularPuck(context)
+        private var destinationPreviewPuck: LocationPuck = regularPuck(context)
+        private var routePreviewPuck: LocationPuck = regularPuck(context)
+        private var activeNavigationPuck: LocationPuck = navigationPuck(context)
+        private var arrivalPuck: LocationPuck = navigationPuck(context)
 
         /**
          * Apply the same [LocationPuck2D] or [LocationPuck3D] to location puck in all different
@@ -108,7 +104,11 @@ class LocationPuckOptions private constructor(
          * @param defaultPuck [LocationPuck] to be used in all navigation states
          */
         fun defaultPuck(defaultPuck: LocationPuck): Builder = apply {
-            this.defaultPuck = defaultPuck
+            this.freeDrivePuck = defaultPuck
+            this.destinationPreviewPuck = defaultPuck
+            this.routePreviewPuck = defaultPuck
+            this.activeNavigationPuck = defaultPuck
+            this.arrivalPuck = defaultPuck
         }
 
         /**
@@ -157,16 +157,13 @@ class LocationPuckOptions private constructor(
          * @return [LocationPuckOptions]
          */
         fun build(): LocationPuckOptions {
-            val regularPuck by lazy { regularPuck(context) }
-            val navigationPuck by lazy { navigationPuck(context) }
             return LocationPuckOptions(
                 context,
-                defaultPuck ?: regularPuck,
-                freeDrivePuck ?: defaultPuck ?: regularPuck,
-                destinationPreviewPuck ?: defaultPuck ?: regularPuck,
-                routePreviewPuck ?: defaultPuck ?: regularPuck,
-                activeNavigationPuck ?: defaultPuck ?: navigationPuck,
-                arrivalPuck ?: defaultPuck ?: regularPuck
+                freeDrivePuck,
+                destinationPreviewPuck,
+                routePreviewPuck,
+                activeNavigationPuck,
+                arrivalPuck
             )
         }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Follow up from https://github.com/mapbox/mapbox-navigation-android/pull/6574#discussion_r1018362917. While the suggestion was implemented, thinking it over again, we are introducing `defaultPuck` so that the end users don't have to do the following to use the same puck for all navigation states.

```
LocationPuckOptions
    .Builder(context)
    .freeDrivePuck(myPuck)
    .destinationPreviewPuck(myPuck)
    .routePreviewPuck(myPuck)
    .activeNavigationPuck(myPuck)
    .arrivalPuck(myPuck)
    .build()
```
instead they can now call

```
LocationPuckOptions
    .Builder(context)
    .defaultPuck(myPuck)
    .build()
```
and `myPuck` will be used in all navigation states.

Hence we technically don't need to fulfill the use case 
```
val opt1 = LocationPuckOptions.Builder(context)
   .freeDrivePuck(myFDPuck)
   .defaultPuck(myPuck)
   .build()

val opt2 = LocationPuckOptions.Builder(context)
   .defaultPuck(myPuck)
   .freeDrivePuck(myFDPuck)
   .build()

assertEquals(opt1, opt2)
```
as `defaultPuck` is to be used when you want to assign the same puck to all navigation states. In that case it is not recommended to pass in a freeDrive puck. However, if the idea is to use one puck for freeDrive and other for all other states, users can perform 
```
val opt2 = LocationPuckOptions.Builder(context)
   .defaultPuck(myPuck)
   .freeDrivePuck(myFDPuck)
   .build()
```
Introducing `defaultPuck` as a property enforces us to add the property to the private constructor, toString, hashCode etc functions. This creates confusion as the usage of `defaultPuck` is now misleading.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
