### PR TITLE
Use `MapboxNavigationApp.lifecycleOwner` instead of `ProcessLifecycleOwner` to support AA

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -139,7 +139,6 @@ ext {
       androidXLifecycleRuntime  : "androidx.lifecycle:lifecycle-runtime-ktx:${version.androidXLifecycle}",
       androidXLifecycleLivedata : "androidx.lifecycle:lifecycle-livedata-ktx:${version.androidXLifecycle}",
       androidXLifecycleViewmodel: "androidx.lifecycle:lifecycle-viewmodel-ktx:${version.androidXLifecycle}",
-      androidXLifecycleProcess  : "androidx.lifecycle:lifecycle-process:${version.androidXLifecycle}",
       androidXLifecycleTesting  : "androidx.lifecycle:lifecycle-runtime-testing:${version.androidXLifecycle}",
 
       // square crew

--- a/libnavigation-copilot/build.gradle
+++ b/libnavigation-copilot/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation dependenciesList.coroutinesAndroid
 
     implementation dependenciesList.androidXWorkManager
-    implementation dependenciesList.androidXLifecycleProcess
 
     testImplementation project(':libtesting-navigation-util')
     testImplementation project(':libtesting-utils')

--- a/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilotImpl.kt
+++ b/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilotImpl.kt
@@ -3,7 +3,6 @@ package com.mapbox.navigation.copilot
 import android.content.pm.ApplicationInfo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.gson.Gson
 import com.mapbox.common.UploadOptions
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
@@ -31,6 +30,7 @@ import com.mapbox.navigation.core.internal.telemetry.UserFeedback
 import com.mapbox.navigation.core.internal.telemetry.UserFeedbackCallback
 import com.mapbox.navigation.core.internal.telemetry.registerUserFeedbackCallback
 import com.mapbox.navigation.core.internal.telemetry.unregisterUserFeedbackCallback
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import java.io.File
 import java.util.Locale
 
@@ -115,7 +115,9 @@ internal class MapboxCopilotImpl(
      */
     fun start() {
         registerUserFeedbackCallback(userFeedbackCallback)
-        ProcessLifecycleOwner.get().lifecycle.addObserver(foregroundBackgroundLifecycleObserver)
+        MapboxNavigationApp.lifecycleOwner.lifecycle.addObserver(
+            foregroundBackgroundLifecycleObserver
+        )
         mapboxNavigation.registerHistoryRecordingStateChangeObserver(
             historyRecordingStateChangeObserver
         )
@@ -126,7 +128,9 @@ internal class MapboxCopilotImpl(
      */
     fun stop() {
         unregisterUserFeedbackCallback(userFeedbackCallback)
-        ProcessLifecycleOwner.get().lifecycle.removeObserver(foregroundBackgroundLifecycleObserver)
+        MapboxNavigationApp.lifecycleOwner.lifecycle.removeObserver(
+            foregroundBackgroundLifecycleObserver
+        )
         mapboxNavigation.unregisterHistoryRecordingStateChangeObserver(
             historyRecordingStateChangeObserver
         )


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Use `MapboxNavigationApp.lifecycleOwner` instead of `ProcessLifecycleOwner` to support AA

Fixes https://github.com/mapbox/mapbox-navigation-android/pull/6572#discussion_r1021359205