### PR TITLE
[Android Auto] Fix example issues

### DIFF
--- a/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
+++ b/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.launch
  * The libraries are defining public apis so that there can be options to determine the experience
  * while both the car and phone are displayed.
  */
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class CarAppSyncComponent private constructor() : MapboxNavigationObserver {
 
     private var navigationView: NavigationView? = null
@@ -74,8 +73,15 @@ class CarAppSyncComponent private constructor() : MapboxNavigationObserver {
     private val appListener = object : NavigationViewListener() {
         override fun onFreeDrive() {
             if (PermissionsManager.areLocationPermissionsGranted(navigationView!!.context)) {
-                logI(LOG_TAG, "updateCarAppState onFreeDrive")
-                MapboxScreenManager.replaceTop(MapboxScreen.FREE_DRIVE)
+                // TODO use the RoutesPreview feature introduced in 2.10. Until then, the route
+                //   preview state requires a custom implementation.
+                //   https://github.com/mapbox/mapbox-navigation-android/blob/main/CHANGELOG.md
+                val currentCarScreen = MapboxScreenManager.current()?.key
+                val isInRoutePreview = currentCarScreen == MapboxScreen.ROUTE_PREVIEW
+                if (!isInRoutePreview) {
+                    logI(LOG_TAG, "updateCarAppState onFreeDrive")
+                    MapboxScreenManager.replaceTop(MapboxScreen.FREE_DRIVE)
+                }
             }
         }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

BitmapWidgetRenderer can create an issue with terrain map styles https://github.com/mapbox/mapbox-maps-android/pull/1834. The work around is to use `ContextMode.SHARED` as you can see in the changes. 

Another issue discussed has to do with the route preview state. There is a new route review feature coming in [v2.10.0](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.10.0-alpha.3), but until then we need a work around in the examples. For the example, the route preview state is not kept in sync between dropin ui and android auto.
