### PR TITLE
[Drop-In UI] Fixed crash in MapboxInfoPanelHeaderArrivalLayoutBinding.java 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Updated `MapboxAudioGuidance`, used by `NavigationView`, to avoid playback of duplicate voice instructions when un-muting. [#6608](https://github.com/mapbox/mapbox-navigation-android/pull/6608)
 - Optimized rerouting: now the reroute request is interrupted if the puck returns to the route. [#6614](https://github.com/mapbox/mapbox-navigation-android/pull/6614)
+- Fixed crash in `MapboxInfoPanelHeaderArrivalLayoutBinding.java` by disabling layout transitions in `InfoPanelHeaderActiveGuidanceBinder`, `InfoPanelHeaderArrivalBinder`, `InfoPanelHeaderDestinationPreviewBinder` and `InfoPanelHeaderRoutesPreviewBinder`. [#6616](https://github.com/mapbox/mapbox-navigation-android/pull/6616)
 
 ## Mapbox Navigation SDK 2.9.1 - 11 November, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderActiveGuidanceBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderActiveGuidanceBinder.kt
@@ -1,11 +1,9 @@
 package com.mapbox.navigation.dropin.infopanel
 
-import android.transition.Scene
-import android.transition.TransitionManager
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
-import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxInfoPanelHeaderActiveGuidanceLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.endNavigationButtonComponent
 import com.mapbox.navigation.dropin.internal.extensions.tripProgressComponent
@@ -17,13 +15,11 @@ internal class InfoPanelHeaderActiveGuidanceBinder(
 ) : UIBinder {
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
-        val scene = Scene.getSceneForLayout(
-            viewGroup,
-            R.layout.mapbox_info_panel_header_active_guidance_layout,
-            viewGroup.context
+        viewGroup.removeAllViews()
+        val binding = MapboxInfoPanelHeaderActiveGuidanceLayoutBinding.inflate(
+            LayoutInflater.from(viewGroup.context),
+            viewGroup
         )
-        TransitionManager.go(scene)
-        val binding = MapboxInfoPanelHeaderActiveGuidanceLayoutBinding.bind(viewGroup)
 
         return context.run {
             navigationListOf(

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderArrivalBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderArrivalBinder.kt
@@ -1,11 +1,9 @@
 package com.mapbox.navigation.dropin.infopanel
 
-import android.transition.Scene
-import android.transition.TransitionManager
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
-import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxInfoPanelHeaderArrivalLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.arrivalTextComponent
 import com.mapbox.navigation.dropin.internal.extensions.endNavigationButtonComponent
@@ -17,13 +15,11 @@ internal class InfoPanelHeaderArrivalBinder(
 ) : UIBinder {
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
-        val scene = Scene.getSceneForLayout(
-            viewGroup,
-            R.layout.mapbox_info_panel_header_arrival_layout,
-            viewGroup.context
+        viewGroup.removeAllViews()
+        val binding = MapboxInfoPanelHeaderArrivalLayoutBinding.inflate(
+            LayoutInflater.from(viewGroup.context),
+            viewGroup
         )
-        TransitionManager.go(scene)
-        val binding = MapboxInfoPanelHeaderArrivalLayoutBinding.bind(viewGroup)
 
         return context.run {
             navigationListOf(

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderDestinationPreviewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderDestinationPreviewBinder.kt
@@ -1,11 +1,9 @@
 package com.mapbox.navigation.dropin.infopanel
 
-import android.transition.Scene
-import android.transition.TransitionManager
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
-import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxInfoPanelHeaderDestinationPreviewLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.poiNameComponent
 import com.mapbox.navigation.dropin.internal.extensions.routePreviewButtonComponent
@@ -18,13 +16,11 @@ internal class InfoPanelHeaderDestinationPreviewBinder(
 ) : UIBinder {
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
-        val scene = Scene.getSceneForLayout(
-            viewGroup,
-            R.layout.mapbox_info_panel_header_destination_preview_layout,
-            viewGroup.context
+        viewGroup.removeAllViews()
+        val binding = MapboxInfoPanelHeaderDestinationPreviewLayoutBinding.inflate(
+            LayoutInflater.from(viewGroup.context),
+            viewGroup
         )
-        TransitionManager.go(scene)
-        val binding = MapboxInfoPanelHeaderDestinationPreviewLayoutBinding.bind(viewGroup)
 
         return context.run {
             navigationListOf(

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderRoutesPreviewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelHeaderRoutesPreviewBinder.kt
@@ -1,11 +1,9 @@
 package com.mapbox.navigation.dropin.infopanel
 
-import android.transition.Scene
-import android.transition.TransitionManager
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
-import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxInfoPanelHeaderRoutePreviewLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.startNavigationButtonComponent
 import com.mapbox.navigation.dropin.internal.extensions.tripProgressComponent
@@ -17,13 +15,11 @@ internal class InfoPanelHeaderRoutesPreviewBinder(
 ) : UIBinder {
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
-        val scene = Scene.getSceneForLayout(
-            viewGroup,
-            R.layout.mapbox_info_panel_header_route_preview_layout,
-            viewGroup.context
+        viewGroup.removeAllViews()
+        val binding = MapboxInfoPanelHeaderRoutePreviewLayoutBinding.inflate(
+            LayoutInflater.from(viewGroup.context),
+            viewGroup
         )
-        TransitionManager.go(scene)
-        val binding = MapboxInfoPanelHeaderRoutePreviewLayoutBinding.bind(viewGroup)
 
         return context.run {
             navigationListOf(

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/Constants.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/Constants.kt
@@ -1,3 +1,7 @@
 package com.mapbox.navigation.qa_test_app.domain
 
 const val CATEGORY_BUNDLE_KEY = "testActivitiesCategory"
+
+const val CATEGORY_NONE = "none"
+const val CATEGORY_DROP_IN = "Drop-In UI"
+const val CATEGORY_COMPONENTS = "Component Installer"

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivityDescription.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivityDescription.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.qa_test_app.domain
 data class TestActivityDescription(
     val label: String,
     val fullDescriptionResource: Int,
+    val category: String = "none",
     /**
      *  When true, request permissions before launching the activity.
      *  When false, launch the activity without requesting permissions.

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -1,7 +1,7 @@
 package com.mapbox.navigation.qa_test_app.domain
 
-import android.app.Activity
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import androidx.appcompat.app.AppCompatActivity
+import com.mapbox.geojson.Point
 import com.mapbox.navigation.qa_test_app.R
 import com.mapbox.navigation.qa_test_app.utils.startActivity
 import com.mapbox.navigation.qa_test_app.view.AlternativeRouteActivity
@@ -30,23 +30,36 @@ import com.mapbox.navigation.qa_test_app.view.UpcomingRoadObjectsActivity
 import com.mapbox.navigation.qa_test_app.view.componentinstaller.ComponentsActivity
 import com.mapbox.navigation.qa_test_app.view.componentinstaller.ComponentsAltActivity
 import com.mapbox.navigation.qa_test_app.view.customnavview.MapboxNavigationViewCustomizedActivity
+import com.mapbox.navigation.qa_test_app.view.main.SelectDestinationDialogFragment
 import com.mapbox.navigation.qa_test_app.view.util.RouteDrawingActivity
 
-typealias LaunchActivityFun = (Activity) -> Unit
+typealias LaunchActivityFun = (AppCompatActivity) -> Unit
+
+data class Destination(val name: String, val point: Point)
 
 object TestActivitySuite {
 
-    @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+    const val CATEGORY_NONE = "none"
+    const val CATEGORY_DROP_IN = "Drop-In UI"
+    const val CATEGORY_COMPONENTS = "Component Installer"
+
+    private val testDestinations = listOf(
+        Destination("Newmarket: A&B office", Point.fromLngLat(-79.4443, 44.0620)),
+        Destination("Toronto: Lume Kitchen and Lounge", Point.fromLngLat(-79.4843, 43.6244))
+    )
+
     val testActivities = listOf(
         TestActivityDescription(
             "Components install via MapboxNavigationApp",
             R.string.experimental_components_install,
+            category = CATEGORY_COMPONENTS
         ) { activity ->
             activity.startActivity<ComponentsActivity>()
         },
         TestActivityDescription(
             "Components install via MapboxNavigation",
             R.string.experimental_alt_components_install,
+            category = CATEGORY_COMPONENTS
         ) { activity ->
             activity.startActivity<ComponentsAltActivity>()
         },
@@ -174,26 +187,41 @@ object TestActivitySuite {
         TestActivityDescription(
             "Default NavigationView",
             R.string.navigation_view_description,
+            category = CATEGORY_DROP_IN,
             launchAfterPermissionResult = false
         ) { activity -> activity.startActivity<MapboxNavigationViewActivity>() },
         TestActivityDescription(
             "Customized NavigationView",
             R.string.navigation_view_customized_description,
+            category = CATEGORY_DROP_IN,
             launchAfterPermissionResult = false
         ) { activity -> activity.startActivity<MapboxNavigationViewCustomizedActivity>() },
         TestActivityDescription(
+            "Navigate to point with NavigationView",
+            R.string.navigation_view_description,
+            category = CATEGORY_DROP_IN,
+            launchAfterPermissionResult = false
+        ) { activity ->
+            SelectDestinationDialogFragment(testDestinations) { dest, startReplay ->
+                MapboxNavigationViewActivity.startActivity(activity, dest.point, startReplay)
+            }.show(activity.supportFragmentManager, SelectDestinationDialogFragment.TAG)
+        },
+        TestActivityDescription(
             "Fullscreen NavigationView in a Fragment",
             R.string.navigation_view_fragment_description,
-            launchAfterPermissionResult = false
+            launchAfterPermissionResult = false,
+            category = CATEGORY_DROP_IN,
         ) { activity -> activity.startActivity<MapboxNavigationViewFragmentActivity>() },
         TestActivityDescription(
             "NavigationView lifecycle test with Fragments",
             R.string.navigation_view_fragment_lifecycle_description,
-            launchAfterPermissionResult = false
+            launchAfterPermissionResult = false,
+            category = CATEGORY_DROP_IN,
         ) { activity -> activity.startActivity<NavigationViewFragmentLifecycleActivity>() },
         TestActivityDescription(
             "Drop In Buttons",
-            R.string.drop_in_buttons_activity_description
+            R.string.drop_in_buttons_activity_description,
+            category = CATEGORY_DROP_IN
         ) { activity ->
             activity.startActivity<DropInButtonsActivity>()
         },
@@ -204,4 +232,12 @@ object TestActivitySuite {
             activity.startActivity<RoutesPreviewActivity>()
         },
     )
+
+    fun getTestActivities(category: String): List<TestActivityDescription> {
+        return if (category == CATEGORY_NONE) {
+            testActivities
+        } else {
+            testActivities.filter { it.category == category }
+        }
+    }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -39,10 +39,6 @@ data class Destination(val name: String, val point: Point)
 
 object TestActivitySuite {
 
-    const val CATEGORY_NONE = "none"
-    const val CATEGORY_DROP_IN = "Drop-In UI"
-    const val CATEGORY_COMPONENTS = "Component Installer"
-
     private val testDestinations = listOf(
         Destination("Newmarket: A&B office", Point.fromLngLat(-79.4443, 44.0620)),
         Destination("Toronto: Lume Kitchen and Lounge", Point.fromLngLat(-79.4843, 43.6244))

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/MapboxNavigationViewActivity.kt
@@ -1,13 +1,19 @@
 package com.mapbox.navigation.qa_test_app.view
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import androidx.lifecycle.lifecycleScope
+import com.mapbox.geojson.Point
 import com.mapbox.navigation.qa_test_app.databinding.LayoutActivityNavigationViewBinding
 import com.mapbox.navigation.qa_test_app.databinding.LayoutDrawerMenuNavViewBinding
+import com.mapbox.navigation.qa_test_app.utils.startActivity
 import com.mapbox.navigation.qa_test_app.view.base.DrawerActivity
+import com.mapbox.navigation.qa_test_app.view.customnavview.NavigationViewController
+import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class MapboxNavigationViewActivity : DrawerActivity() {
 
     private lateinit var binding: LayoutActivityNavigationViewBinding
@@ -23,12 +29,50 @@ class MapboxNavigationViewActivity : DrawerActivity() {
         return menuBinding.root
     }
 
+    private lateinit var controller: NavigationViewController
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        controller = NavigationViewController(this, binding.navigationView)
+        processIntentExtras()
 
         menuBinding.toggleReplay.isChecked = binding.navigationView.api.isReplayEnabled()
         menuBinding.toggleReplay.setOnCheckedChangeListener { _, isChecked ->
             binding.navigationView.api.routeReplayEnabled(isChecked)
+        }
+    }
+
+    private fun processIntentExtras() {
+        if (intent.getBooleanExtra(ARG_REPLAY_ENABLED, false)) {
+            binding.navigationView.api.routeReplayEnabled(true)
+        }
+        intent.getDestinationPointExtra()?.also { destination ->
+            lifecycleScope.launch {
+                Log.d("MapboxNavigationViewActivity", "navigating to $destination")
+                controller.startActiveGuidance(destination)
+            }
+        }
+    }
+
+    private fun Intent.getDestinationPointExtra(): Point? =
+        getStringExtra(ARG_DESTINATION_POINT)?.let {
+            runCatching { Point.fromJson(it) }.getOrNull()
+        }
+
+    companion object {
+        const val ARG_DESTINATION_POINT = "destination"
+        const val ARG_REPLAY_ENABLED = "replay_enabled"
+
+        fun startActivity(
+            parent: Activity,
+            destinationPoint: Point,
+            replayEnabled: Boolean = false
+        ) {
+            val bundle = Bundle().apply {
+                putString(ARG_DESTINATION_POINT, destinationPoint.toJson())
+                putBoolean(ARG_REPLAY_ENABLED, replayEnabled)
+            }
+            parent.startActivity<MapboxNavigationViewActivity>(bundle)
         }
     }
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/NavigationViewController.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/NavigationViewController.kt
@@ -1,0 +1,111 @@
+package com.mapbox.navigation.qa_test_app.view.customnavview
+
+import android.location.Location
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.NavigationRouterCallback
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.extensions.flowNewRawLocation
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.dropin.NavigationView
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import com.mapbox.navigation.utils.internal.toPoint
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal class NavigationViewController(
+    lifecycleOwner: LifecycleOwner,
+    private val navigationView: NavigationView
+) : DefaultLifecycleObserver, UIComponent() {
+    init {
+        lifecycleOwner.lifecycle.addObserver(this)
+    }
+
+    val location = MutableStateFlow<Location?>(null)
+    private val mapboxNavigation = MutableStateFlow<MapboxNavigation?>(null)
+
+    override fun onCreate(owner: LifecycleOwner) {
+        MapboxNavigationApp.registerObserver(this)
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        MapboxNavigationApp.unregisterObserver(this)
+    }
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+        this.mapboxNavigation.value = mapboxNavigation
+        mapboxNavigation.flowNewRawLocation().observe {
+            location.value = it
+        }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        super.onDetached(mapboxNavigation)
+        this.mapboxNavigation.value = null
+    }
+
+    suspend fun startActiveGuidance(destination: Point) {
+        val routes = fetchRoute(destination)
+        navigationView.api.startActiveGuidance(routes)
+    }
+
+    suspend fun fetchRoute(destination: Point): List<NavigationRoute> {
+        val origin = location.filterNotNull().first().toPoint()
+        val mapboxNavigation = this.mapboxNavigation.filterNotNull().first()
+        return mapboxNavigation.fetchRoute(origin, destination)
+    }
+
+    private suspend fun MapboxNavigation.fetchRoute(
+        origin: Point,
+        destination: Point
+    ): List<NavigationRoute> = suspendCancellableCoroutine { cont ->
+        val routeOptions = RouteOptions.builder()
+            .applyDefaultNavigationOptions()
+            .applyLanguageAndVoiceUnitOptions(navigationOptions.applicationContext)
+            .layersList(listOf(getZLevel(), null))
+            .coordinatesList(listOf(origin, destination))
+            .alternatives(true)
+            .build()
+        val requestId = requestRoutes(
+            routeOptions,
+            object : NavigationRouterCallback {
+                override fun onRoutesReady(
+                    routes: List<NavigationRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
+                    cont.resume(routes)
+                }
+
+                override fun onFailure(
+                    reasons: List<RouterFailure>,
+                    routeOptions: RouteOptions
+                ) {
+                    cont.resumeWithException(FetchRouteError(reasons, routeOptions))
+                }
+
+                override fun onCanceled(
+                    routeOptions: RouteOptions,
+                    routerOrigin: RouterOrigin
+                ) = Unit
+            }
+        )
+        cont.invokeOnCancellation { cancelRouteRequest(requestId) }
+    }
+
+    private class FetchRouteError(
+        val reasons: List<RouterFailure>,
+        val routeOptions: RouteOptions
+    ) : Error()
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/main/ActivitiesListFragment.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/main/ActivitiesListFragment.kt
@@ -1,0 +1,73 @@
+package com.mapbox.navigation.qa_test_app.view.main
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.mapbox.navigation.qa_test_app.R
+import com.mapbox.navigation.qa_test_app.databinding.LayoutFragmentActivitiesListBinding
+import com.mapbox.navigation.qa_test_app.domain.TestActivityDescription
+import com.mapbox.navigation.qa_test_app.view.adapters.ActivitiesListAdaptersSupport
+import com.mapbox.navigation.qa_test_app.view.adapters.GenericListAdapter
+
+class ActivitiesListFragment : Fragment() {
+
+    private val viewModel: MainViewModel by activityViewModels()
+
+    private lateinit var binding: LayoutFragmentActivitiesListBinding
+
+    private val listAdapter by lazy {
+        GenericListAdapter(
+            ActivitiesListAdaptersSupport.activitiesListOnBindViewHolderFun,
+            ActivitiesListAdaptersSupport.viewHolderFactory,
+            this::onItemSelected,
+            auxViewClickMap = mapOf(Pair(R.id.infoLabel, this::onAuxViewClicked))
+        )
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = LayoutFragmentActivitiesListBinding.inflate(inflater, container, false)
+
+        val layoutManager = LinearLayoutManager(context)
+        binding.activitiesList.layoutManager = LinearLayoutManager(context)
+        binding.activitiesList.adapter = listAdapter
+        binding.activitiesList.addItemDecoration(
+            DividerItemDecoration(context, layoutManager.orientation)
+        )
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val category = arguments?.getString(ARG_CATEGORY) ?: "none"
+
+        listAdapter.swap(viewModel.getActivitiesList(category))
+    }
+
+    private fun onItemSelected(index: Int, element: TestActivityDescription) {
+        viewModel.onSelectItem(element)
+    }
+
+    private fun onAuxViewClicked(index: Int, element: TestActivityDescription) {
+        viewModel.onSelectInfoIcon(element)
+    }
+
+    companion object {
+        const val ARG_CATEGORY = "category"
+
+        fun create(category: String) = ActivitiesListFragment().apply {
+            arguments = Bundle().apply {
+                putString(ARG_CATEGORY, category)
+            }
+        }
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/main/MainViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/main/MainViewModel.kt
@@ -1,0 +1,44 @@
+package com.mapbox.navigation.qa_test_app.view.main
+
+import androidx.lifecycle.ViewModel
+import com.mapbox.navigation.qa_test_app.domain.TestActivityDescription
+import com.mapbox.navigation.qa_test_app.domain.TestActivitySuite
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+data class PageInfo(val title: String, val category: String)
+
+class MainViewModel : ViewModel() {
+
+    private val _didSelectItemEvent = eventFlow<TestActivityDescription>()
+    val didSelectItemEvent: Flow<TestActivityDescription> = _didSelectItemEvent.asSharedFlow()
+
+    private val _didSelectInfoEvent = eventFlow<TestActivityDescription>()
+    val didSelectInfoEvent: Flow<TestActivityDescription> = _didSelectInfoEvent.asSharedFlow()
+
+    val pages: List<PageInfo> = listOf(
+        PageInfo("All", TestActivitySuite.CATEGORY_NONE),
+        PageInfo("Drop-In UI", TestActivitySuite.CATEGORY_DROP_IN),
+        PageInfo("Component Installer", TestActivitySuite.CATEGORY_COMPONENTS)
+    )
+
+    fun getActivitiesList(category: String): List<TestActivityDescription> {
+        return TestActivitySuite.getTestActivities(category)
+    }
+
+    fun onSelectItem(item: TestActivityDescription) {
+        _didSelectItemEvent.tryEmit(item)
+    }
+
+    fun onSelectInfoIcon(item: TestActivityDescription) {
+        _didSelectInfoEvent.tryEmit(item)
+    }
+}
+
+internal fun <T> eventFlow(): MutableSharedFlow<T> =
+    MutableSharedFlow(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/main/MainViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/main/MainViewModel.kt
@@ -1,6 +1,9 @@
 package com.mapbox.navigation.qa_test_app.view.main
 
 import androidx.lifecycle.ViewModel
+import com.mapbox.navigation.qa_test_app.domain.CATEGORY_COMPONENTS
+import com.mapbox.navigation.qa_test_app.domain.CATEGORY_DROP_IN
+import com.mapbox.navigation.qa_test_app.domain.CATEGORY_NONE
 import com.mapbox.navigation.qa_test_app.domain.TestActivityDescription
 import com.mapbox.navigation.qa_test_app.domain.TestActivitySuite
 import kotlinx.coroutines.channels.BufferOverflow
@@ -19,9 +22,9 @@ class MainViewModel : ViewModel() {
     val didSelectInfoEvent: Flow<TestActivityDescription> = _didSelectInfoEvent.asSharedFlow()
 
     val pages: List<PageInfo> = listOf(
-        PageInfo("All", TestActivitySuite.CATEGORY_NONE),
-        PageInfo("Drop-In UI", TestActivitySuite.CATEGORY_DROP_IN),
-        PageInfo("Component Installer", TestActivitySuite.CATEGORY_COMPONENTS)
+        PageInfo("All", CATEGORY_NONE),
+        PageInfo("Drop-In UI", CATEGORY_DROP_IN),
+        PageInfo("Component Installer", CATEGORY_COMPONENTS)
     )
 
     fun getActivitiesList(category: String): List<TestActivityDescription> {

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/main/SelectDestinationDialogFragment.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/main/SelectDestinationDialogFragment.kt
@@ -1,0 +1,40 @@
+package com.mapbox.navigation.qa_test_app.view.main
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.mapbox.navigation.qa_test_app.R
+import com.mapbox.navigation.qa_test_app.databinding.DialogDestinationSelectBinding
+import com.mapbox.navigation.qa_test_app.domain.Destination
+
+class SelectDestinationDialogFragment(
+    private val destinations: List<Destination>,
+    private val onSelectItem: ((dest: Destination, startReplay: Boolean) -> Unit)? = null
+) : BottomSheetDialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val binding = DialogDestinationSelectBinding.inflate(layoutInflater, container, false)
+        destinations.forEach { dest ->
+            val textView = TextView(context, null, 0, R.style.DestinationSelectItem).apply {
+                text = dest.name
+                setOnClickListener {
+                    this@SelectDestinationDialogFragment.dismiss()
+                    onSelectItem?.invoke(dest, binding.startReplaySwitch.isChecked)
+                }
+            }
+            binding.root.addView(textView)
+        }
+        return binding.root
+    }
+
+    companion object {
+        const val TAG = "SelectDestinationDialogFragment"
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/Utils.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/Utils.kt
@@ -1,6 +1,13 @@
 package com.mapbox.navigation.qa_test_app.view.util
 
 import android.content.Context
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 
 object Utils {
     /**
@@ -13,5 +20,16 @@ object Utils {
         val tokenResId = context.resources
             .getIdentifier("mapbox_access_token", "string", context.packageName)
         return if (tokenResId != 0) context.getString(tokenResId) else ""
+    }
+}
+
+internal inline fun <T> Flow<T>.observe(
+    lifecycleOwner: LifecycleOwner,
+    crossinline action: suspend (value: T) -> Unit
+) {
+    lifecycleOwner.lifecycleScope.launch {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            collect(action)
+        }
     }
 }

--- a/qa-test-app/src/main/res/layout/activity_main.xml
+++ b/qa-test-app/src/main/res/layout/activity_main.xml
@@ -7,17 +7,21 @@
     tools:context=".view.MainActivity"
     android:background="@color/primaryVariant">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/activitiesList"
+    <androidx.viewpager.widget.ViewPager
+        android:id="@+id/pager"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="8dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_height="match_parent">
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </androidx.viewpager.widget.ViewPager>
+
+<!--    <androidx.fragment.app.FragmentContainerView-->
+<!--        android:id="@+id/fragment_container"-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="match_parent"/>-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/qa-test-app/src/main/res/layout/dialog_destination_select.xml
+++ b/qa-test-app/src/main/res/layout/dialog_destination_select.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/colorSurface"
+    android:orientation="vertical">
+
+  <androidx.appcompat.widget.LinearLayoutCompat
+      style="@style/ActionBar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:padding="10dp">
+
+    <TextView
+        style="@style/TextAppearance.AppCompat.Subhead"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:text="Select destination"
+        android:textColor="#fff"
+        android:textStyle="bold" />
+
+    <TextView
+        style="@style/TextAppearance.AppCompat.Caption"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Start replay"
+        android:textColor="#fff"
+        android:textStyle="italic" />
+
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/startReplaySwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="30dp"
+        android:layout_marginStart="5dp"/>
+
+  </androidx.appcompat.widget.LinearLayoutCompat>
+
+</androidx.appcompat.widget.LinearLayoutCompat>

--- a/qa-test-app/src/main/res/layout/layout_fragment_activities_list.xml
+++ b/qa-test-app/src/main/res/layout/layout_fragment_activities_list.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/activitiesList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/qa-test-app/src/main/res/layout/test_activity_item_layout.xml
+++ b/qa-test-app/src/main/res/layout/test_activity_item_layout.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="80dp"
-    android:background="@color/secondaryVariant">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@drawable/surface_ripple"
+    >
 
     <TextView
         android:id="@+id/activityLabel"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
-        android:textColor="@color/onSecondary"
+        android:textColor="@color/colorOnSurface"
         android:textSize="18sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        tools:text="Some demo activity"
         />
 
     <TextView

--- a/qa-test-app/src/main/res/values/styles.xml
+++ b/qa-test-app/src/main/res/values/styles.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <style name="DestinationSelectItem" parent="TextAppearance.AppCompat.Medium">
+        <item name="android:paddingStart">10dp</item>
+        <item name="android:paddingEnd">10dp</item>
+        <item name="android:paddingTop">20dp</item>
+        <item name="android:paddingBottom">20dp</item>
+        <item name="android:background">@drawable/surface_ripple</item>
+    </style>
+
     <!-- StatusActivity -->
 
     <style name="CustomStatusView">


### PR DESCRIPTION
Fixes NAVAND-827

### Findings
It looks like the Store NavigationState change (`ActiveNavigation` -> `Arrival`) can happen during layout transition, making `****LayoutBinding.bind(viewGroup)` attempt to bind to an empty layout, resulting in a crash.

### Description

-  Disabled layout transitions in `InfoPanelHeaderActiveGuidanceBinder`, `InfoPanelHeaderArrivalBinder`, `InfoPanelHeaderDestinationPreviewBinder` and `InfoPanelHeaderRoutesPreviewBinder`
   - Using LayoutInflater instead of Scene API to manually swap Info Panel header content.
- Updated QA-Test-App.  
   - Using PageView and TabLayout to filter test activities.
  
### Screenshots or Gifs

_Screen recording of QA-Test-App captured on Google Pixel 6_

https://user-images.githubusercontent.com/2678039/202216654-d5113df6-c401-4126-bea7-5b9d471d704b.mp4

