### PR TITLE
[Drop-In UI] Fixed location permissions request when hosting NavigationView in a Fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Updated `MapboxAudioGuidance`, used by `NavigationView`, to avoid playback of duplicate voice instructions when un-muting. [#6608](https://github.com/mapbox/mapbox-navigation-android/pull/6608)
 - Optimized rerouting: now the reroute request is interrupted if the puck returns to the route. [#6614](https://github.com/mapbox/mapbox-navigation-android/pull/6614)
 - Fixed crash in `MapboxInfoPanelHeaderArrivalLayoutBinding.java` by disabling layout transitions in `InfoPanelHeaderActiveGuidanceBinder`, `InfoPanelHeaderArrivalBinder`, `InfoPanelHeaderDestinationPreviewBinder` and `InfoPanelHeaderRoutesPreviewBinder`. [#6616](https://github.com/mapbox/mapbox-navigation-android/pull/6616)
+- Fixed location permissions request when hosting `NavigationView` in a Fragment. [#6618](https://github.com/mapbox/mapbox-navigation-android/pull/6618) 
 
 ## Mapbox Navigation SDK 2.9.1 - 11 November, 2022
 ### Changelog

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/LocationPermissionComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/LocationPermissionComponent.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import com.mapbox.android.core.permissions.PermissionsManager
@@ -63,8 +64,12 @@ internal class LocationPermissionComponent(
                 store.dispatch(TripSessionStarterAction.OnLocationPermission(true))
             }
         } else {
-            launcher?.launch(LOCATION_PERMISSIONS)
-
+            val fragActivity = componentActivityRef.get() as? FragmentActivity
+            if (fragActivity != null) {
+                PermissionsLauncherFragment.create(fragActivity, LOCATION_PERMISSIONS, callback)
+            } else {
+                launcher?.launch(LOCATION_PERMISSIONS)
+            }
             notifyGrantedOnForegrounded(mapboxNavigation.navigationOptions.applicationContext)
         }
     }
@@ -93,6 +98,9 @@ internal class LocationPermissionComponent(
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
         super.onDetached(mapboxNavigation)
 
+        (componentActivityRef.get() as? FragmentActivity)?.also {
+            PermissionsLauncherFragment.destroy(it)
+        }
         launcher?.unregister()
     }
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/LocationPermissionComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/LocationPermissionComponent.kt
@@ -66,7 +66,7 @@ internal class LocationPermissionComponent(
         } else {
             val fragActivity = componentActivityRef.get() as? FragmentActivity
             if (fragActivity != null) {
-                PermissionsLauncherFragment.create(fragActivity, LOCATION_PERMISSIONS, callback)
+                PermissionsLauncherFragment.install(fragActivity, LOCATION_PERMISSIONS, callback)
             } else {
                 launcher?.launch(LOCATION_PERMISSIONS)
             }
@@ -99,7 +99,7 @@ internal class LocationPermissionComponent(
         super.onDetached(mapboxNavigation)
 
         (componentActivityRef.get() as? FragmentActivity)?.also {
-            PermissionsLauncherFragment.destroy(it)
+            PermissionsLauncherFragment.uninstall(it)
         }
         launcher?.unregister()
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/PermissionsLauncherFragment.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/PermissionsLauncherFragment.kt
@@ -1,0 +1,65 @@
+package com.mapbox.navigation.dropin.permission
+
+import android.content.Context
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions
+import androidx.core.content.ContextCompat.checkSelfPermission
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+
+/**
+ * A view-less fragment that requests permissions using [ActivityResultCaller] interface.
+ */
+internal class PermissionsLauncherFragment(
+    private val permissions: Array<String>,
+    private val onResult: ActivityResultCallback<Map<String, Boolean>>
+) : Fragment() {
+
+    private var launcher: ActivityResultLauncher<Array<String>>? = null
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        val areGranted = permissions.fold(false) { acc, permission ->
+            acc && checkSelfPermission(context, permission) == PERMISSION_GRANTED
+        }
+        if (!areGranted) {
+            launcher = registerForActivityResult(RequestMultiplePermissions(), onResult)
+            launcher?.launch(permissions)
+        }
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        launcher?.unregister()
+    }
+
+    companion object {
+        const val TAG = "MapboxPermissionsLauncherFragment"
+
+        fun create(
+            fragActivity: FragmentActivity,
+            permissions: Array<String>,
+            onResult: ActivityResultCallback<Map<String, Boolean>>
+        ) {
+            fragActivity.supportFragmentManager.apply {
+                val t = beginTransaction()
+                findFragmentByTag(TAG)?.also { t.remove(it) }
+                t.add(PermissionsLauncherFragment(permissions, onResult), TAG)
+                t.commit()
+            }
+        }
+
+        fun destroy(fragActivity: FragmentActivity) {
+            if (!fragActivity.isFinishing) {
+                fragActivity.supportFragmentManager.apply {
+                    findFragmentByTag(TAG)?.also {
+                        beginTransaction().remove(it).commit()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/PermissionsLauncherFragment.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/permission/PermissionsLauncherFragment.kt
@@ -22,12 +22,12 @@ internal class PermissionsLauncherFragment(
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        val areGranted = permissions.fold(false) { acc, permission ->
-            acc && checkSelfPermission(context, permission) == PERMISSION_GRANTED
+        val missingPermissions = permissions.filter { permission ->
+            checkSelfPermission(context, permission) != PERMISSION_GRANTED
         }
-        if (!areGranted) {
+        if (missingPermissions.isNotEmpty()) {
             launcher = registerForActivityResult(RequestMultiplePermissions(), onResult)
-            launcher?.launch(permissions)
+            launcher?.launch(missingPermissions.toTypedArray())
         }
     }
 
@@ -39,7 +39,7 @@ internal class PermissionsLauncherFragment(
     companion object {
         const val TAG = "MapboxPermissionsLauncherFragment"
 
-        fun create(
+        fun install(
             fragActivity: FragmentActivity,
             permissions: Array<String>,
             onResult: ActivityResultCallback<Map<String, Boolean>>
@@ -52,7 +52,7 @@ internal class PermissionsLauncherFragment(
             }
         }
 
-        fun destroy(fragActivity: FragmentActivity) {
+        fun uninstall(fragActivity: FragmentActivity) {
             if (!fragActivity.isFinishing) {
                 fragActivity.supportFragmentManager.apply {
                     findFragmentByTag(TAG)?.also {


### PR DESCRIPTION
Fixed NAVAND-791

### Description
- Updated `LocationPermissionComponent` to use view-less Fragment to request location permissions when hosted in FragmentActivity.
- Introduced PermissionsLauncherFragment, a view-less Fragment that uses the `ActivityResultCaller` interface to request missing permissions `onAttached`.
 
### Screenshots or Gifs

_Screen recordings of QA-Test-App captured on Emulator running Android 10_

<details><summary>Before</summary>

Notice that location permissions are requested once when the first Fragment with NavigationView is installed.

https://user-images.githubusercontent.com/2678039/202336993-34e45630-d1c1-45f4-98b5-a49a839a61c7.mp4 

> NOTE: The video artifacts are a side effect of FFMPEG webm -> mp4 transcoding

</details>

<details><summary>After</summary>

Notice that location permissions are requested every time the Fragment with NavigationView is installed.

https://user-images.githubusercontent.com/2678039/202337011-570d17ba-3623-47f9-b582-5b6cdf68ce98.mp4 

> NOTE: The video artifacts are a side effect of FFMPEG webm -> mp4 transcoding

</details>



