### PR TITLE
ci config: shift android-lint check to the latest step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,13 +609,13 @@ jobs:
           steps:
             - read-workspace
             - verify-codestyle
-            - run-android-lint
             - verify-license
             - verify-common-sdk-version
             - check-api-core
             - check-api-ui
             - check-api-androidauto
             - check-public-documentation
+            - run-android-lint
       - run: exit 0
 
   publish-documentation:


### PR DESCRIPTION
### Description
ci config: shift `android-lint` check to the latest step

`android-lint` check is the rare failed step of all `static-analysis`. So moving it to the last step to catch more frequent issues earlier. 


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
