### PR TITLE
[Drop-In] Fix crash by removing fragment constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Fixed crash in `PermissionsLauncherFragment` occurring on device rotation. [#6635](https://github.com/mapbox/mapbox-navigation-android/pull/6635)
 
 ## Mapbox Navigation SDK 2.9.2 - 18 November, 2022
 ### Changelog

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/NavigationViewFragmentLifecycleActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/NavigationViewFragmentLifecycleActivity.kt
@@ -34,7 +34,7 @@ class NavigationViewFragmentLifecycleActivity : AppCompatActivity() {
         supportFragmentManager.commit {
             add(
                 R.id.navigationViewFragment,
-                PageNavigationFragment(FIRST_FRAGMENT_TAG),
+                PageNavigationFragment().apply { this.logTag = FIRST_FRAGMENT_TAG },
                 FIRST_FRAGMENT_TAG
             )
         }
@@ -57,9 +57,15 @@ class NavigationViewFragmentLifecycleActivity : AppCompatActivity() {
     private fun swapFragments() {
         val fragment = supportFragmentManager.findFragmentById(R.id.navigationViewFragment)
         val newFragmentPair = if (fragment?.tag == FIRST_FRAGMENT_TAG) {
-            Pair(PageNavigationFragment(SECOND_FRAGMENT_TAG), SECOND_FRAGMENT_TAG)
+            Pair(
+                PageNavigationFragment().apply { this.logTag = SECOND_FRAGMENT_TAG },
+                SECOND_FRAGMENT_TAG
+            )
         } else {
-            Pair(PageNavigationFragment(FIRST_FRAGMENT_TAG), FIRST_FRAGMENT_TAG)
+            Pair(
+                PageNavigationFragment().apply { this.logTag = FIRST_FRAGMENT_TAG },
+                FIRST_FRAGMENT_TAG
+            )
         }
         supportFragmentManager.commit {
             replace(R.id.navigationViewFragment, newFragmentPair.first, newFragmentPair.second)
@@ -69,8 +75,9 @@ class NavigationViewFragmentLifecycleActivity : AppCompatActivity() {
 }
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
-class PageNavigationFragment(private val logTag: String) : Fragment() {
+class PageNavigationFragment : Fragment() {
 
+    var logTag: String = ""
     var navigationView: NavigationView? = null
         private set
     private var frame: FrameLayout? = null


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fix crash as reported [here](https://github.com/mapbox/mapbox-navigation-android/pull/6618#discussion_r1026645961).

- Removed constructor arguments
- Added them as properties that are applied at runtime.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
