### PR TITLE
NAVSDK-757: cache turf distances to improve routeProgressUpdate performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Optimized `MapboxRouteLineApi#updateWithRouteProgress` by enabling cache optimization be default. Added `MapboxRouteLineApi#updateWithRouteProgress(RouteProgress, Boolean, MapboxNavigationConsumer)` to use in order to disable cach optimization.
 
 ## Mapbox Navigation SDK 2.9.2 - 18 November, 2022
 ### Changelog

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '10.10.0-beta.1',
-      mapboxSdkServices         : '6.10.0-beta.2',
+      mapboxSdkServices         : '6.10.0-beta.3', // TODO release beta3
       mapboxCore                : '5.0.2',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '23.2.0-beta.1',

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -980,6 +980,7 @@ package com.mapbox.navigation.ui.maps.route.line.api {
     method public void showRouteWithLegIndexHighlighted(int legIndexToHighlight, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue>> consumer);
     method public com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue> updateTraveledRouteLine(com.mapbox.geojson.Point point);
     method public void updateWithRouteProgress(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue>> consumer);
+    method public void updateWithRouteProgress(com.mapbox.navigation.base.trip.model.RouteProgress routeProgress, boolean useCacheOptimization, com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer<com.mapbox.bindgen.Expected<com.mapbox.navigation.ui.maps.route.line.model.RouteLineError,com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue>> consumer);
     field public static final com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi.Companion Companion;
   }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/StepDistanceCache.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/StepDistanceCache.kt
@@ -1,0 +1,41 @@
+package com.mapbox.navigation.ui.maps.route.line.api
+
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.turf.TurfConstants
+import com.mapbox.turf.TurfMeasurement
+
+private data class CurrentData(
+    val routeId: String,
+    val legIndex: Int,
+    val stepIndex: Int,
+    val distances: List<Double>
+)
+
+internal class StepDistanceCache {
+
+    private var currentData: CurrentData? = null
+
+    fun onRouteProgressUpdate(routeProgress: RouteProgress) {
+        if (routeProgress.navigationRoute.id != currentData?.routeId) {
+            currentData = null
+        }
+        val legIndex = routeProgress.currentLegProgress?.legIndex
+        val stepIndex = routeProgress.currentLegProgress?.currentStepProgress?.stepIndex
+        if (
+            legIndex != null && stepIndex != null &&
+            (legIndex != currentData?.legIndex || stepIndex != currentData?.stepIndex)
+        ) {
+            currentData = CurrentData(
+                routeProgress.navigationRoute.id,
+                legIndex,
+                stepIndex,
+                routeProgress.currentLegProgress!!.currentStepProgress!!.stepPoints
+                    ?.zipWithNext { a, b ->
+                        TurfMeasurement.distance(a, b, TurfConstants.UNIT_METERS)
+                    } ?: emptyList()
+            )
+        }
+    }
+
+    fun currentDistances(): List<Double>? = currentData?.distances
+}

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiRoboTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiRoboTest.kt
@@ -323,7 +323,7 @@ class MapboxRouteLineApiRoboTest {
 
         api.updateVanishingPointState(RouteProgressState.TRACKING)
         api.setNavigationRoutes(listOf(route))
-        api.updateUpcomingRoutePointIndex(routeProgress)
+        api.updateUpcomingRoutePointIndex(routeProgress, false)
 
         val result = api.updateTraveledRouteLine(lineString.coordinates()[1])
 
@@ -369,14 +369,14 @@ class MapboxRouteLineApiRoboTest {
 
             api.updateVanishingPointState(RouteProgressState.TRACKING)
             api.setNavigationRoutes(listOf(route))
-            api.updateUpcomingRoutePointIndex(routeProgress)
+            api.updateUpcomingRoutePointIndex(routeProgress, false)
 
             pauseDispatcher {
                 val result1 = api.updateTraveledRouteLine(lineString.coordinates()[1])
                 assertTrue(result1.isValue)
 
                 Thread.sleep(1000L)
-                api.updateUpcomingRoutePointIndex(routeProgress) // only update the progress
+                api.updateUpcomingRoutePointIndex(routeProgress, false) // only update the progress
                 Thread.sleep(300L) // in summary we've waited for 1.3s since last point update
                 val result2 = api.updateTraveledRouteLine(lineString.coordinates()[1])
                 assertTrue(result2.isValue) // should succeed because threshold was 1.2s
@@ -406,7 +406,7 @@ class MapboxRouteLineApiRoboTest {
 
             api.updateVanishingPointState(RouteProgressState.TRACKING)
             api.setNavigationRoutes(listOf(route))
-            api.updateUpcomingRoutePointIndex(routeProgress)
+            api.updateUpcomingRoutePointIndex(routeProgress, false)
 
             mockkObject(MapboxRouteLineUtils)
             val result = api.updateTraveledRouteLine(lineString.coordinates()[1])
@@ -447,7 +447,7 @@ class MapboxRouteLineApiRoboTest {
 
             api.updateVanishingPointState(RouteProgressState.TRACKING)
             api.setNavigationRoutes(listOf(route))
-            api.updateUpcomingRoutePointIndex(routeProgress)
+            api.updateUpcomingRoutePointIndex(routeProgress, false)
 
             val result = api.updateTraveledRouteLine(lineString.coordinates()[1])
 

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiTest.kt
@@ -427,7 +427,7 @@ class MapboxRouteLineApiTest {
         api.updateVanishingPointState(RouteProgressState.TRACKING)
         api.setNavigationRoutes(listOf(route))
 
-        api.updateUpcomingRoutePointIndex(routeProgress)
+        api.updateUpcomingRoutePointIndex(routeProgress, false)
 
         verify { mockVanishingRouteLine.primaryRouteRemainingDistancesIndex = 6 }
     }
@@ -454,7 +454,7 @@ class MapboxRouteLineApiTest {
             api.updateVanishingPointState(RouteProgressState.TRACKING)
             api.setNavigationRoutes(listOf(route))
 
-            api.updateUpcomingRoutePointIndex(routeProgress)
+            api.updateUpcomingRoutePointIndex(routeProgress, false)
 
             verify { mockVanishingRouteLine.primaryRouteRemainingDistancesIndex = 6 }
 
@@ -479,7 +479,7 @@ class MapboxRouteLineApiTest {
             api.updateVanishingPointState(RouteProgressState.TRACKING)
             api.setNavigationRoutes(listOf(route))
 
-            api.updateUpcomingRoutePointIndex(routeProgress)
+            api.updateUpcomingRoutePointIndex(routeProgress, false)
 
             verify { mockVanishingRouteLine.primaryRouteRemainingDistancesIndex = null }
         }
@@ -499,7 +499,7 @@ class MapboxRouteLineApiTest {
             api.updateVanishingPointState(RouteProgressState.TRACKING)
             api.setNavigationRoutes(listOf(route))
 
-            api.updateUpcomingRoutePointIndex(routeProgress)
+            api.updateUpcomingRoutePointIndex(routeProgress, false)
 
             verify { mockVanishingRouteLine.primaryRouteRemainingDistancesIndex = null }
         }
@@ -518,6 +518,27 @@ class MapboxRouteLineApiTest {
         api.setNavigationRoutes(listOf(route))
 
         api.updateWithRouteProgress(routeProgress) {}
+
+        verify { mockVanishingRouteLine.primaryRouteRemainingDistancesIndex = 6 }
+        verify {
+            mockVanishingRouteLine.updateVanishingPointState(RouteProgressState.TRACKING)
+        }
+    }
+
+    @Test
+    fun updateWithRouteProgressNoCache() = coroutineRule.runBlockingTest {
+        val route = loadNavigationRoute("short_route.json")
+        val mockVanishingRouteLine = mockk<VanishingRouteLine>(relaxUnitFun = true) {
+            every { vanishPointOffset } returns 0.0
+        }
+        val options = mockRouteOptions()
+        every { options.vanishingRouteLine } returns mockVanishingRouteLine
+        val api = MapboxRouteLineApi(options)
+        val routeProgress = mockRouteProgress(route, stepIndexValue = 2)
+        api.updateVanishingPointState(RouteProgressState.TRACKING)
+        api.setNavigationRoutes(listOf(route))
+
+        api.updateWithRouteProgress(routeProgress, false) {}
 
         verify { mockVanishingRouteLine.primaryRouteRemainingDistancesIndex = 6 }
         verify {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/StepDistanceCacheTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/StepDistanceCacheTest.kt
@@ -1,0 +1,162 @@
+package com.mapbox.navigation.ui.maps.route.line.api
+
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteStepProgress
+import com.mapbox.turf.TurfConstants
+import com.mapbox.turf.TurfMeasurement
+import io.mockk.clearStaticMockk
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class StepDistanceCacheTest {
+
+    private val route = mockk<NavigationRoute>(relaxed = true) {
+        every { id } returns "id#0"
+    }
+    private val p1 = mockk<Point>(relaxed = true)
+    private val p2 = mockk<Point>(relaxed = true)
+    private val p3 = mockk<Point>(relaxed = true)
+    private val stepProgress = mockk<RouteStepProgress>(relaxed = true) {
+        every { stepIndex } returns 2
+        every { stepPoints } returns listOf(p1, p2, p3)
+    }
+    private val legProgress = mockk<RouteLegProgress>(relaxed = true) {
+        every { currentStepProgress } returns this@StepDistanceCacheTest.stepProgress
+        every { legIndex } returns 1
+    }
+    private val routeProgress = mockk<RouteProgress>(relaxed = true) {
+        every { navigationRoute } returns this@StepDistanceCacheTest.route
+        every { currentLegProgress } returns this@StepDistanceCacheTest.legProgress
+    }
+    private val sut = StepDistanceCache()
+
+    @Before
+    fun setUp() {
+        mockkStatic(TurfMeasurement::class)
+        every { TurfMeasurement.distance(p1, p2, TurfConstants.UNIT_METERS) } returns 1.2
+        every { TurfMeasurement.distance(p2, p3, TurfConstants.UNIT_METERS) } returns 3.4
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(TurfMeasurement::class)
+    }
+
+    @Test
+    fun initialCurrentDistances() {
+        assertNull(sut.currentDistances())
+    }
+
+    @Test
+    fun firstValidOnRouteProgressUpdate() {
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertEquals(listOf(1.2, 3.4), sut.currentDistances())
+    }
+
+    @Test
+    fun firstValidOnRouteProgressUpdateNullStepPoints() {
+        every { stepProgress.stepPoints } returns null
+
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertEquals(emptyList<Double>(), sut.currentDistances())
+    }
+
+    @Test
+    fun firstValidOnRouteProgressUpdateEmptyStepPoints() {
+        every { stepProgress.stepPoints } returns emptyList()
+
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertEquals(emptyList<Double>(), sut.currentDistances())
+    }
+
+    @Test
+    fun firstValidOnRouteProgressUpdateOneStepPoint() {
+        every { stepProgress.stepPoints } returns listOf(p1)
+
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertEquals(emptyList<Double>(), sut.currentDistances())
+    }
+
+    @Test
+    fun secondValidOnRouteProgressUpdateSameRouteLegIndexChanged() {
+        sut.onRouteProgressUpdate(routeProgress)
+
+        every { legProgress.legIndex } returns 2
+        every { TurfMeasurement.distance(p1, p2, TurfConstants.UNIT_METERS) } returns 5.6
+        every { TurfMeasurement.distance(p2, p3, TurfConstants.UNIT_METERS) } returns 7.8
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertEquals(listOf(5.6, 7.8), sut.currentDistances())
+    }
+
+    @Test
+    fun secondValidOnRouteProgressUpdateSameRouteStepIndexChanged() {
+        sut.onRouteProgressUpdate(routeProgress)
+
+        every { stepProgress.stepIndex } returns 3
+        every { TurfMeasurement.distance(p1, p2, TurfConstants.UNIT_METERS) } returns 5.6
+        every { TurfMeasurement.distance(p2, p3, TurfConstants.UNIT_METERS) } returns 7.8
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertEquals(listOf(5.6, 7.8), sut.currentDistances())
+    }
+
+    @Test
+    fun secondValidOnRouteProgressUpdateSameRouteNothingChanged() {
+        sut.onRouteProgressUpdate(routeProgress)
+        clearStaticMockk(TurfMeasurement::class, answers = false)
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertEquals(listOf(1.2, 3.4), sut.currentDistances())
+        verify(exactly = 0) { TurfMeasurement.distance(any(), any(), any()) }
+    }
+
+    @Test
+    fun secondValidOnRouteProgressUpdateNewRoute() {
+        sut.onRouteProgressUpdate(routeProgress)
+
+        every { route.id } returns "id#1"
+        every { TurfMeasurement.distance(p1, p2, TurfConstants.UNIT_METERS) } returns 5.6
+        every { TurfMeasurement.distance(p2, p3, TurfConstants.UNIT_METERS) } returns 7.8
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertEquals(listOf(5.6, 7.8), sut.currentDistances())
+    }
+
+    @Test
+    fun secondInvalidOnRouteProgressUpdateNewRoute_nullLegProgress() {
+        sut.onRouteProgressUpdate(routeProgress)
+
+        every { route.id } returns "id#1"
+        every { routeProgress.currentLegProgress } returns null
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertNull(sut.currentDistances())
+    }
+
+    @Test
+    fun secondInvalidOnRouteProgressUpdateNewRoute_nullStepProgress() {
+        sut.onRouteProgressUpdate(routeProgress)
+
+        every { route.id } returns "id#1"
+        every { legProgress.currentStepProgress } returns null
+        sut.onRouteProgressUpdate(routeProgress)
+
+        assertNull(sut.currentDistances())
+    }
+}


### PR DESCRIPTION
Should be used together with https://github.com/mapbox/mapbox-java/pull/1519.
See the performance testing results in the ticket.