### PR TITLE
NAVAND-925: fix IllegalArgumentException in ConstantVelocityInterpolator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 #### Bug fixes and improvements
 - Fixed crash in `PermissionsLauncherFragment` occurring on device rotation. [#6635](https://github.com/mapbox/mapbox-navigation-android/pull/6635)
+- Fixed a rare `java.lang.IllegalArgumentException: The Path cannot loop back on itself.` exception when using `NavigationLocationProvider`. [#6641](https://github.com/mapbox/mapbox-navigation-android/pull/6641)
 
 ## Mapbox Navigation SDK 2.9.2 - 18 November, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolator.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolator.kt
@@ -45,15 +45,18 @@ class ConstantVelocityInterpolator(
 
     private fun timingPath(distances: List<Double>, total: Double): Path {
         val path = Path()
-        val step = 1.0f / distances.size
-        var pathTime = 0.0f
+        val step = 1.0 / distances.size
+        var pathTime = 0.0
         // NOTE: The Path must start at (0,0) and end at (1,1)
         // To avoid PathInterpolator IllegalArgException, we ignore last keypoint distance value
         // and manually add line to (1,1).
         for (i in 0..distances.size - 2) {
             val deltaTime = distances[i] / total
-            pathTime += deltaTime.toFloat()
-            path.lineTo(pathTime, (step * (i + 1)))
+            pathTime += deltaTime
+            if (pathTime > 1.0) {
+                pathTime = 1.0
+            }
+            path.lineTo(pathTime.toFloat(), (step * (i + 1)).toFloat())
         }
         path.lineTo(1f, 1f)
         return path

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolatorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/location/ConstantVelocityInterpolatorTest.kt
@@ -72,6 +72,29 @@ class ConstantVelocityInterpolatorTest {
         )
     }
 
+    @Test
+    fun `should not crash because of error accumulation`() { // caused by NAVAND-925
+        val startPoint = Point.fromLngLat(48.36654772857354, 11.13222120183356)
+        val keyPoints = arrayOf(
+            Point.fromLngLat(48.416596, 11.027287),
+            Point.fromLngLat(48.416520999999996, 11.027080999999999),
+            Point.fromLngLat(48.416281, 11.02683),
+            Point.fromLngLat(48.416156, 11.02656),
+            Point.fromLngLat(48.416146999999995, 11.026156),
+            Point.fromLngLat(48.416205999999995, 11.02605),
+            Point.fromLngLat(48.416253, 11.025912),
+            Point.fromLngLat(48.416194, 11.025749),
+            Point.fromLngLat(48.416028, 11.025495999999999),
+            Point.fromLngLat(48.415786, 11.025307),
+            Point.fromLngLat(48.415642999999996, 11.025171),
+            Point.fromLngLat(48.4156, 11.025034),
+            Point.fromLngLat(48.415535999999996, 11.024955),
+            Point.fromLngLat(48.415535999999996, 11.024955000000004),
+        )
+        // no crash
+        ConstantVelocityInterpolator(startPoint, keyPoints)
+    }
+
     private fun calculatePathValues(p0: Point, vararg points: Point): List<Pair<Float, Float>> {
         val distances = mutableListOf<Double>()
         var totalDistance = 0.0


### PR DESCRIPTION
Crash description and its root cause is in the ticket.

Solution.
There are 3 possible approaches here:
1) Compare pathTime with 1 and if it's > 1 just set it to 1;
2) Make calculations more precise: use double for calculations and only convert to float when invoking the system API that accepts float;
2) Make calculations more precise: use `BigDecimal` for calculations and only convert to float when invoking the system API that accepts float;

I decided to go with 1 and 2 simultaneously. Reasons:
Not 3 because 3 is drastically slower (hundreds of times);
Not just 2 because there is still a probability pathTime will be greater than 1, although a much smaller one. For the data that originally caused the crash option 1 is redundant.