### PR TITLE
Removed layer initialization for vanishing route line updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Started clearing route geometry cache when no routes (neither routes used for Active Guidance nor previewed ones) are available. [#6617](https://github.com/mapbox/mapbox-navigation-android/pull/6617)
 - Added convenience `MapboxNavigation#moveRoutesFromPreviewToNavigator` method to simplify transition from Routes Preview state to Active Guidance state. [#6617](https://github.com/mapbox/mapbox-navigation-android/pull/6617)
 - Minor performance improvements for `MapboxNavigationViewportDataSource#evaluate`. [#6645](https://github.com/mapbox/mapbox-navigation-android/pull/6645)
+- Minor optimization when updating the vanishing route line by removing check for route line related layers. [#6642](https://github.com/mapbox/mapbox-navigation-android/pull/6642)
 
 ## Mapbox Navigation SDK 2.9.2 - 18 November, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -288,7 +288,6 @@ class MapboxRouteLineView(var options: MapboxRouteLineOptions) {
         style: Style,
         update: Expected<RouteLineError, RouteLineUpdateValue>
     ) {
-        MapboxRouteLineUtils.initializeLayers(style, options)
         jobControl.scope.launch(Dispatchers.Main) {
             mutex.withLock {
                 update.onValue {

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineViewTest.kt
@@ -288,7 +288,6 @@ class MapboxRouteLineViewTest {
             val view = MapboxRouteLineView(options)
             view.initPrimaryRouteLineLayerGroup(MapboxRouteLineUtils.layerGroup1SourceLayerIds)
             view.renderRouteLineUpdate(style, state)
-            verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         }
 
         verify {
@@ -374,7 +373,6 @@ class MapboxRouteLineViewTest {
             val view = MapboxRouteLineView(options)
             view.initPrimaryRouteLineLayerGroup(MapboxRouteLineUtils.layerGroup1SourceLayerIds)
             view.renderRouteLineUpdate(style, state)
-            verify { MapboxRouteLineUtils.initializeLayers(style, options) }
         }
 
         verify {


### PR DESCRIPTION
### Description
The checking for layer initialization was removed from the method that updates the vanishing route line. This method is called several times per second as the puck is moving. The overhead incurred by so frequently checking the layers is unnecessary. This represents a minor optimization.

### Screenshots or Gifs
