### PR TITLE
Added distance check for recalculating the vanishing route line gradients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Added convenience `MapboxNavigation#moveRoutesFromPreviewToNavigator` method to simplify transition from Routes Preview state to Active Guidance state. [#6617](https://github.com/mapbox/mapbox-navigation-android/pull/6617)
 - Minor performance improvements for `MapboxNavigationViewportDataSource#evaluate`. [#6645](https://github.com/mapbox/mapbox-navigation-android/pull/6645)
 - Minor optimization when updating the vanishing route line by removing check for route line related layers. [#6642](https://github.com/mapbox/mapbox-navigation-android/pull/6642)
+- Added minor optimization to vanishing route line calculations by checking if the incoming point equal to the previous point in order to avoid recalculation and re-rendering. [#6643](https://github.com/mapbox/mapbox-navigation-android/pull/6643)
 
 ## Mapbox Navigation SDK 2.9.2 - 18 November, 2022
 ### Changelog


### PR DESCRIPTION
### Description
Added minor optimization to vanishing route line calculations by checking if the incoming point is within a minimum distance of the previous point. If the distance is small there's no visual difference in the vanishing route line.  This is useful when a car is at rest since the puck updates will continue but if there's no significant change in distance traveled there's no need to incur the overhead of recalculating and rendering the vanishing route line.

### Screenshots or Gifs
