### PR TITLE
[NAVSDK-755] minor optimization for camera state getter in MapboxNavigationViewportDataSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed a rare `java.lang.IllegalArgumentException: The Path cannot loop back on itself.` exception when using `NavigationLocationProvider`. [#6641](https://github.com/mapbox/mapbox-navigation-android/pull/6641)
 - Started clearing route geometry cache when no routes (neither routes used for Active Guidance nor previewed ones) are available. [#6617](https://github.com/mapbox/mapbox-navigation-android/pull/6617)
 - Added convenience `MapboxNavigation#moveRoutesFromPreviewToNavigator` method to simplify transition from Routes Preview state to Active Guidance state. [#6617](https://github.com/mapbox/mapbox-navigation-android/pull/6617)
+- Minor performance improvements for `MapboxNavigationViewportDataSource#evaluate`. [#6645](https://github.com/mapbox/mapbox-navigation-android/pull/6645)
 
 ## Mapbox Navigation SDK 2.9.2 - 18 November, 2022
 ### Changelog


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Capturing from:
![c133d40b-f7d7-4bef-88cc-83bf598e1fea](https://user-images.githubusercontent.com/16925074/203761230-68239bf7-d23e-41ac-85d6-fc61b8049cbb.png)

and
![ddcde72b-cd92-4a47-9da9-1e1fedcc034f](https://user-images.githubusercontent.com/16925074/203761248-45cc2cc4-5153-4c85-834f-e8bbe4707f02.png)

the `MapboxMap#cameraState` calls add unnecessary CPU usage. I'm consolidating 6 getter calls into only one to provide a minor optimization.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
