### PR TITLE
[copilot] `startRecording` as soon as `onShouldStartRecording` is called

### DIFF
--- a/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilotImpl.kt
+++ b/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilotImpl.kt
@@ -205,10 +205,10 @@ internal class MapboxCopilotImpl(
     private fun startRecordingHistory(
         historyRecordingSessionState: HistoryRecordingSessionState
     ) {
+        copilotHistoryRecorder.startRecording()
         currentHistoryRecordingSessionState = historyRecordingSessionState
         startSessionTime = System.currentTimeMillis()
         startedAt = currentUtcTime()
-        copilotHistoryRecorder.startRecording()
         driveId = historyRecordingSessionState.sessionId
         driveMode = when (historyRecordingSessionState) {
             is ActiveGuidance -> "active-guidance"


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Noticed that some events were not properly appended to correct session history files, this PR fixes it `startRecording` as soon as `onShouldStartRecording` is called to include deferred events as part of the current history file session.

cc @pahuta @ikryvanos @azarovalex 
