### PR TITLE
[Drop-In UI] Location puck should switch between regular and navigation puck in different camera states

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/map/MapViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/map/MapViewBinder.kt
@@ -3,14 +3,13 @@ package com.mapbox.navigation.dropin.map
 import android.content.Context
 import android.view.ViewGroup
 import com.mapbox.maps.MapView
-import com.mapbox.maps.plugin.locationcomponent.LocationComponentPlugin
-import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.core.internal.extensions.navigationListOf
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.dropin.camera.CameraComponent
 import com.mapbox.navigation.dropin.camera.CameraLayoutObserver
 import com.mapbox.navigation.dropin.databinding.MapboxNavigationViewLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.buildingHighlightComponent
+import com.mapbox.navigation.dropin.internal.extensions.locationPuckComponent
 import com.mapbox.navigation.dropin.internal.extensions.reloadOnChange
 import com.mapbox.navigation.dropin.map.geocoding.GeocodingComponent
 import com.mapbox.navigation.dropin.map.logo.LogoAttributionComponent
@@ -22,11 +21,8 @@ import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
 import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
 import com.mapbox.navigation.ui.maps.internal.ui.LocationComponent
-import com.mapbox.navigation.ui.maps.internal.ui.LocationPuckComponent
 import com.mapbox.navigation.ui.maps.internal.ui.RouteArrowComponent
 import com.mapbox.navigation.ui.maps.internal.ui.RouteLineComponent
-import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
-import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
 import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
 import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 
@@ -73,17 +69,7 @@ abstract class MapViewBinder : UIBinder {
         return navigationListOf(
             CameraLayoutObserver(store, mapView, navigationViewBinding),
             LocationComponent(context.locationProvider),
-            reloadOnChange(
-                navigationState,
-                context.styles.locationPuckOptions
-            ) { navState, _ ->
-                locationPuckComponent(
-                    navState,
-                    mapView.location,
-                    context.locationProvider,
-                    context.styles.locationPuckOptions.value
-                )
-            },
+            context.locationPuckComponent(mapView),
             LogoAttributionComponent(mapView, context.systemBarsInsets),
             reloadOnChange(
                 context.mapStyleLoader.loadedMapStyle,
@@ -124,51 +110,6 @@ abstract class MapViewBinder : UIBinder {
         RouteLineComponent(mapView.getMapboxMap(), mapView, lineOptions, contractProvider = {
             RouteLineComponentContractImpl(context.store, context.mapClickBehavior)
         })
-
-    private fun locationPuckComponent(
-        navigationState: NavigationState,
-        location: LocationComponentPlugin,
-        provider: NavigationLocationProvider,
-        options: LocationPuckOptions
-    ): LocationPuckComponent {
-        return when (navigationState) {
-            NavigationState.FreeDrive -> {
-                LocationPuckComponent(
-                    location,
-                    options.freeDrivePuck,
-                    provider,
-                )
-            }
-            NavigationState.DestinationPreview -> {
-                LocationPuckComponent(
-                    location,
-                    options.destinationPreviewPuck,
-                    provider,
-                )
-            }
-            NavigationState.RoutePreview -> {
-                LocationPuckComponent(
-                    location,
-                    options.routePreviewPuck,
-                    provider,
-                )
-            }
-            NavigationState.ActiveNavigation -> {
-                LocationPuckComponent(
-                    location,
-                    options.activeNavigationPuck,
-                    provider,
-                )
-            }
-            NavigationState.Arrival -> {
-                LocationPuckComponent(
-                    location,
-                    options.arrivalPuck,
-                    provider,
-                )
-            }
-        }
-    }
 
     private fun longPressMapComponent(navigationState: NavigationState, mapView: MapView) =
         when (navigationState) {

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -747,6 +747,7 @@ package com.mapbox.navigation.ui.maps.puck {
     method public android.content.Context getContext();
     method public com.mapbox.maps.plugin.LocationPuck getDestinationPreviewPuck();
     method public com.mapbox.maps.plugin.LocationPuck getFreeDrivePuck();
+    method public com.mapbox.maps.plugin.LocationPuck getIdlePuck();
     method public com.mapbox.maps.plugin.LocationPuck getRoutePreviewPuck();
     method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder toBuilder();
     property public final com.mapbox.maps.plugin.LocationPuck activeNavigationPuck;
@@ -754,6 +755,7 @@ package com.mapbox.navigation.ui.maps.puck {
     property public final android.content.Context context;
     property public final com.mapbox.maps.plugin.LocationPuck destinationPreviewPuck;
     property public final com.mapbox.maps.plugin.LocationPuck freeDrivePuck;
+    property public final com.mapbox.maps.plugin.LocationPuck idlePuck;
     property public final com.mapbox.maps.plugin.LocationPuck routePreviewPuck;
   }
 
@@ -765,6 +767,7 @@ package com.mapbox.navigation.ui.maps.puck {
     method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder defaultPuck(com.mapbox.maps.plugin.LocationPuck defaultPuck);
     method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder destinationPreviewPuck(com.mapbox.maps.plugin.LocationPuck destinationPreviewPuck);
     method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder freeDrivePuck(com.mapbox.maps.plugin.LocationPuck freeDrivePuck);
+    method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder idlePuck(com.mapbox.maps.plugin.LocationPuck idlePuck);
     method public com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder routePreviewPuck(com.mapbox.maps.plugin.LocationPuck routePreviewPuck);
     field public static final com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder.Companion Companion;
   }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptions.kt
@@ -6,6 +6,8 @@ import com.mapbox.maps.plugin.LocationPuck
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.LocationPuck3D
 import com.mapbox.navigation.ui.maps.R
+import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
+import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder
 
 /**
  * Gives options to specify either [LocationPuck2D] or [LocationPuck3D] references to the location
@@ -15,11 +17,12 @@ import com.mapbox.navigation.ui.maps.R
  * `defaultPuck()` on the [Builder] and that would be used for pucks in all navigation states.
  *
  * @param context from which to reference puck drawables
- * @param freeDrivePuck stores the puck appearance to be displayed in free drive state
- * @param destinationPreviewPuck stores the puck appearance to be displayed in destination preview state
- * @param routePreviewPuck stores the puck appearance to be displayed in route preview state
- * @param activeNavigationPuck stores the puck appearance to be displayed in active navigation state
- * @param arrivalPuck stores the puck appearance to be displayed in arrival state
+ * @param freeDrivePuck stores the puck appearance to be displayed in free drive state when in the [NavigationCameraState.FOLLOWING]
+ * @param destinationPreviewPuck stores the puck appearance to be displayed in destination preview state when in the [NavigationCameraState.FOLLOWING]
+ * @param routePreviewPuck stores the puck appearance to be displayed in route preview state when in the [NavigationCameraState.FOLLOWING]
+ * @param activeNavigationPuck stores the puck appearance to be displayed in active navigation state when in the [NavigationCameraState.FOLLOWING]
+ * @param arrivalPuck stores the puck appearance to be displayed in arrival state when in the [NavigationCameraState.FOLLOWING]
+ * @param idlePuck stores the puck appearance to be displayed for all navigation states when in the [NavigationCameraState.IDLE] or the [NavigationCameraState.OVERVIEW]
  */
 class LocationPuckOptions private constructor(
     val context: Context,
@@ -28,6 +31,7 @@ class LocationPuckOptions private constructor(
     val routePreviewPuck: LocationPuck,
     val activeNavigationPuck: LocationPuck,
     val arrivalPuck: LocationPuck,
+    val idlePuck: LocationPuck
 ) {
 
     /**
@@ -39,6 +43,7 @@ class LocationPuckOptions private constructor(
         routePreviewPuck(routePreviewPuck)
         activeNavigationPuck(activeNavigationPuck)
         arrivalPuck(arrivalPuck)
+        idlePuck(idlePuck)
     }
 
     /**
@@ -56,6 +61,7 @@ class LocationPuckOptions private constructor(
         if (routePreviewPuck != other.routePreviewPuck) return false
         if (activeNavigationPuck != other.activeNavigationPuck) return false
         if (arrivalPuck != other.arrivalPuck) return false
+        if (idlePuck != other.idlePuck) return false
 
         return true
     }
@@ -70,6 +76,7 @@ class LocationPuckOptions private constructor(
         result = 31 * result + routePreviewPuck.hashCode()
         result = 31 * result + activeNavigationPuck.hashCode()
         result = 31 * result + arrivalPuck.hashCode()
+        result = 31 * result + idlePuck.hashCode()
         return result
     }
 
@@ -84,6 +91,7 @@ class LocationPuckOptions private constructor(
             "routePreviewPuck=$routePreviewPuck, " +
             "activeNavigationPuck=$activeNavigationPuck, " +
             "arrivalPuck=$arrivalPuck" +
+            "idlePuck=$idlePuck" +
             ")"
     }
 
@@ -92,16 +100,29 @@ class LocationPuckOptions private constructor(
      */
     class Builder(private val context: Context) {
 
-        private var freeDrivePuck: LocationPuck = regularPuck(context)
-        private var destinationPreviewPuck: LocationPuck = regularPuck(context)
-        private var routePreviewPuck: LocationPuck = regularPuck(context)
-        private var activeNavigationPuck: LocationPuck = navigationPuck(context)
-        private var arrivalPuck: LocationPuck = navigationPuck(context)
+        private var freeDrivePuck: LocationPuck
+        private var destinationPreviewPuck: LocationPuck
+        private var routePreviewPuck: LocationPuck
+        private var activeNavigationPuck: LocationPuck
+        private var arrivalPuck: LocationPuck
+        private var idlePuck: LocationPuck
+
+        init {
+            val navigationPuck = navigationPuck(context)
+            val regularPuck = regularPuck(context)
+
+            freeDrivePuck = navigationPuck
+            destinationPreviewPuck = navigationPuck
+            routePreviewPuck = navigationPuck
+            activeNavigationPuck = navigationPuck
+            arrivalPuck = navigationPuck
+            idlePuck = regularPuck
+        }
 
         /**
-         * Apply the same [LocationPuck2D] or [LocationPuck3D] to location puck in all different
-         * navigation states
-         * @param defaultPuck [LocationPuck] to be used in all navigation states
+         * Apply the same [LocationPuck2D] or [LocationPuck3D] to location puck for all navigation states
+         * and any [NavigationCameraState]
+         * @param defaultPuck [LocationPuck] to be used in all states
          */
         fun defaultPuck(defaultPuck: LocationPuck): Builder = apply {
             this.freeDrivePuck = defaultPuck
@@ -109,10 +130,12 @@ class LocationPuckOptions private constructor(
             this.routePreviewPuck = defaultPuck
             this.activeNavigationPuck = defaultPuck
             this.arrivalPuck = defaultPuck
+            this.idlePuck = defaultPuck
         }
 
         /**
          * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in free drive state
+         * when in the [NavigationCameraState.FOLLOWING]
          * @param freeDrivePuck [LocationPuck] to be used in free drive state
          */
         fun freeDrivePuck(freeDrivePuck: LocationPuck): Builder = apply {
@@ -121,6 +144,7 @@ class LocationPuckOptions private constructor(
 
         /**
          * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in destination preview state
+         * when in the [NavigationCameraState.FOLLOWING]
          * @param destinationPreviewPuck [LocationPuck] to be used in destination preview state
          */
         fun destinationPreviewPuck(destinationPreviewPuck: LocationPuck): Builder = apply {
@@ -129,6 +153,7 @@ class LocationPuckOptions private constructor(
 
         /**
          * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in route preview state
+         * when in the [NavigationCameraState.FOLLOWING]
          * @param routePreviewPuck [LocationPuck] to be used in route preview state
          */
         fun routePreviewPuck(routePreviewPuck: LocationPuck): Builder = apply {
@@ -137,6 +162,7 @@ class LocationPuckOptions private constructor(
 
         /**
          * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in active navigation state
+         * when in the [NavigationCameraState.FOLLOWING]
          * @param activeNavigationPuck [LocationPuck] to be used in active navigation state
          */
         fun activeNavigationPuck(activeNavigationPuck: LocationPuck): Builder = apply {
@@ -145,10 +171,21 @@ class LocationPuckOptions private constructor(
 
         /**
          * Apply [LocationPuck2D] or [LocationPuck3D] to location puck in arrival state
+         * when in the [NavigationCameraState.FOLLOWING]
          * @param arrivalPuck [LocationPuck] to be used in arrival state
          */
         fun arrivalPuck(arrivalPuck: LocationPuck): Builder = apply {
             this.arrivalPuck = arrivalPuck
+        }
+
+        /**
+         * Apply [LocationPuck2D] or [LocationPuck3D] to location puck for all navigation states when
+         * in the [NavigationCameraState.IDLE] or the [NavigationCameraState.OVERVIEW].
+         * @param idlePuck [LocationPuck] to be used when in the [NavigationCameraState.IDLE]
+         * or [NavigationCameraState.OVERVIEW]
+         */
+        fun idlePuck(idlePuck: LocationPuck): Builder = apply {
+            this.idlePuck = idlePuck
         }
 
         /**
@@ -163,14 +200,14 @@ class LocationPuckOptions private constructor(
                 destinationPreviewPuck,
                 routePreviewPuck,
                 activeNavigationPuck,
-                arrivalPuck
+                arrivalPuck,
+                idlePuck
             )
         }
 
         companion object {
             /**
-             * Provides access to [LocationPuck2D] more suited for active navigation and arrival
-             * use cases.
+             * Provides access to [LocationPuck2D] more suited for the [NavigationCameraState.FOLLOWING].
              */
             fun navigationPuck(context: Context): LocationPuck = LocationPuck2D(
                 bearingImage = ContextCompat.getDrawable(
@@ -180,8 +217,8 @@ class LocationPuckOptions private constructor(
             )
 
             /**
-             * Provides access to [LocationPuck2D] more suited for free drive,
-             * destination preview and route preview use cases.
+             * Provides access to [LocationPuck2D] more suited for the [NavigationCameraState.IDLE]
+             * and [NavigationCameraState.OVERVIEW].
              */
             fun regularPuck(context: Context): LocationPuck = LocationPuck2D(
                 topImage = ContextCompat.getDrawable(

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptionsTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/puck/LocationPuckOptionsTest.kt
@@ -21,6 +21,7 @@ class LocationPuckOptionsTest :
             .routePreviewPuck(mockk())
             .activeNavigationPuck(mockk())
             .arrivalPuck(mockk())
+            .idlePuck(mockk())
     }
 
     override fun trigger() {


### PR DESCRIPTION
Closes NAVAND-922

### Description
- Updated `MapViewBinder` to switch between regular and navigation puck when camera mode changes.
- Introduced `LocationPuckOptions.idlePuck` field that allows IDLE and OVERVIEW camera mode puck customization. 

### Screenshots or Gifs

_Screen recording of the QA Test App captured on Pixel 6_

https://user-images.githubusercontent.com/2678039/204666779-e67f66c5-7c29-4e6f-8744-d2d25b4129dc.mp4

