### PR TITLE
[Android Auto] Fix trip session state race condition

### DIFF
--- a/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
+++ b/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
@@ -31,7 +31,7 @@ class CarAppSyncComponent private constructor() : MapboxNavigationObserver {
     private var navigationView: NavigationView? = null
     private var session: Session? = null
 
-    fun setNavigationView(navigationView: NavigationView) {
+    fun attachNavigationView(navigationView: NavigationView) {
         this.navigationView = navigationView
         navigationView.lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onCreate(owner: LifecycleOwner) {

--- a/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/app/MainActivity.kt
+++ b/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/app/MainActivity.kt
@@ -3,11 +3,9 @@ package com.mapbox.navigation.examples.androidauto.app
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.examples.androidauto.CarAppSyncComponent
 import com.mapbox.navigation.examples.androidauto.databinding.MapboxActivityNavigationViewBinding
 
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: MapboxActivityNavigationViewBinding
 
@@ -20,6 +18,6 @@ class MainActivity : AppCompatActivity() {
         // This allows to simulate your location
 //        binding.navigationView.api.routeReplayEnabled(true)
 
-        CarAppSyncComponent.getInstance().setNavigationView(binding.navigationView)
+        CarAppSyncComponent.getInstance().attachNavigationView(binding.navigationView)
     }
 }

--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -15,7 +15,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Renamed `RoadLabelRenderer` to `CarRoadLabelRenderer`. [#6588](https://github.com/mapbox/mapbox-navigation-android/pull/6588)
 - Made `ActiveGuidanceScreen` internal in favor of `MapboxScreen.ACTIVE_GUIDANCE`. [#6588](https://github.com/mapbox/mapbox-navigation-android/pull/6588)
 - Made `NeedsLocationPermissionsScreen` internal in favor of `MapboxScreen.NEEDS_LOCATION_PERMISSION`. [#6588](https://github.com/mapbox/mapbox-navigation-android/pull/6588)
-- Fixed race condition where `NavigationManager.updateTrip` can be called after `navigationEnded` is called. This is a likely cause to a crash seen. 
+- Fixed race condition where `NavigationManager.updateTrip` can be called after `navigationEnded` is called. This is a likely cause to a crash seen. [#6661](https://github.com/mapbox/mapbox-navigation-android/pull/6661)
  
 ## androidauto-v0.16.0 - 04 November, 2022
 ### Changelog

--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -15,7 +15,8 @@ Mapbox welcomes participation and contributions from everyone.
 - Renamed `RoadLabelRenderer` to `CarRoadLabelRenderer`. [#6588](https://github.com/mapbox/mapbox-navigation-android/pull/6588)
 - Made `ActiveGuidanceScreen` internal in favor of `MapboxScreen.ACTIVE_GUIDANCE`. [#6588](https://github.com/mapbox/mapbox-navigation-android/pull/6588)
 - Made `NeedsLocationPermissionsScreen` internal in favor of `MapboxScreen.NEEDS_LOCATION_PERMISSION`. [#6588](https://github.com/mapbox/mapbox-navigation-android/pull/6588)
-
+- Fixed race condition where `NavigationManager.updateTrip` can be called after `navigationEnded` is called. This is a likely cause to a crash seen. 
+ 
 ## androidauto-v0.16.0 - 04 November, 2022
 ### Changelog
 [Changes between 0.15.0 and 0.16.0](https://github.com/mapbox/mapbox-navigation-android/compare/androidauto-v0.15.0...androidauto-v0.16.0)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManager.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManager.kt
@@ -85,15 +85,11 @@ class MapboxCarNavigationManager internal constructor(
         logAndroidAuto("MapboxNavigationManager onDetached")
         this.mapboxNavigation = null
         carTelemetry.onDetached(mapboxNavigation)
-        mapboxNavigation.unregisterTripSessionStateObserver(tripSessionStateObserver)
         mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
+        mapboxNavigation.unregisterTripSessionStateObserver(tripSessionStateObserver)
 
-        // clearNavigationManagerCallback() can't be called during active navigation.
-        // However, this callback lets AA stop the trip session which we don't want it to do if
-        // the user simply exited AA but is still navigating via the phone app. Since
-        // there is only one instance of MapboxNavigation allowing AA to stop the trip
-        // session when the MainCarSession is inactive but possibly the phone app. is
-        // actively navigating would cause unpredictable side effects.
+        // Tell android auto navigation stopped. Navigation can continue with mapbox navigation
+        // on another device.
         navigationManager.navigationEnded()
         navigationManager.clearNavigationManagerCallback()
     }

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManager.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManager.kt
@@ -37,7 +37,9 @@ class MapboxCarNavigationManager internal constructor(
     private val routeProgressObserver = RouteProgressObserver { routeProgress ->
         val maneuverApi = maneuverApi ?: return@RouteProgressObserver
         val trip = CarManeuverMapper.from(routeProgress, maneuverApi)
-        navigationManager.updateTrip(trip)
+        if (mapboxNavigation?.getTripSessionState() == TripSessionState.STARTED) {
+            navigationManager.updateTrip(trip)
+        }
     }
 
     private val tripSessionStateObserver = TripSessionStateObserver { tripSessionState ->

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManagerTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManagerTest.kt
@@ -21,11 +21,9 @@ import io.mockk.mockkObject
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
-import io.mockk.verifyOrder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.collect
 import org.junit.After
 import org.junit.Assert.assertEquals


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

The android auto NavigationManager will crash if you call some functions when the state does not make sense. The state is not held by MapboxCarNavigationManager, so the issue happens when assumptions are broken.

I'm searching for a crash and found a potential cause. Reproduced the issue with a test and fixed the issue. If this approach fails, I think we can introduce a boolean inside `MapboxCarNavigationManager` that keeps track of the state given to `NavigationManager`.

### Explanation

The crash comes from routeProgress, the only way to create this crash would be if MapboxNavigation emited route progress after a `TripSessionState.STOPPED` event. So I'm changing the order that `tripSessionStateObserver` is unsubscribed as maybe it's possible that a status update is racing with the trip session state.

```
    private val tripSessionStateObserver = TripSessionStateObserver { tripSessionState ->
        when (tripSessionState) {
            TripSessionState.STARTED -> navigationManager.navigationStarted()
            TripSessionState.STOPPED -> navigationManager.navigationEnded()
        }
    }
```

```
13:21:17.730 W  java.lang.IllegalStateException: Navigation is not started
13:21:17.730 W  	at androidx.car.app.navigation.NavigationManager.updateTrip(NavigationManager.java:113)
13:21:17.730 W  	at com.mapbox.androidauto.MapboxCarNavigationManager.routeProgressObserver$lambda-0(MapboxCarNavigationManager.kt:40)
13:21:17.730 W  	at com.mapbox.androidauto.MapboxCarNavigationManager.$r8$lambda$cPlCE4Ub0Hux7DJvZke7FEQPeZc(Unknown Source:0)
13:21:17.730 W  	at com.mapbox.androidauto.MapboxCarNavigationManager$$ExternalSyntheticLambda0.onRouteProgressChanged(Unknown Source:2)
13:21:17.730 W  	at com.mapbox.navigation.core.trip.session.MapboxTripSession.updateRouteProgress(MapboxTripSession.kt:686)
13:21:17.731 W  	at com.mapbox.navigation.core.trip.session.MapboxTripSession.access$updateRouteProgress(MapboxTripSession.kt:60)
13:21:17.731 W  	at com.mapbox.navigation.core.trip.session.MapboxTripSession$navigatorObserver$1.onStatus(MapboxTripSession.kt:376)
```

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
