### PR TITLE
[Drop-In UI] Fixed the last audio instruction repeat on the next session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Added building highlight on arrival support to `NavigationView`. Added new customization options `ViewOptionsCustomization.enableBuildingHighlightOnArrival` and  `ViewOptionsCustomization.buildingHighlightOptions`. [#6651](https://github.com/mapbox/mapbox-navigation-android/pull/6651)
 - Added `ComponentInstaller` for the `BuildingHighlightComponent` that offers simplified integration of the `MapboxBuildingsApi` and `MapboxBuildingView`. [#6651](https://github.com/mapbox/mapbox-navigation-android/pull/6651)
 #### Bug fixes and improvements
+- Fixed an issue in the `NavigationView` where the last audio instruction from the previous session becomes the 1st on the next session. [#6662](https://github.com/mapbox/mapbox-navigation-android/pull/6662)
 - Fixed crash in `PermissionsLauncherFragment` occurring on device rotation. [#6635](https://github.com/mapbox/mapbox-navigation-android/pull/6635)
 - Fixed a rare `java.lang.IllegalArgumentException: The Path cannot loop back on itself.` exception when using `NavigationLocationProvider`. [#6641](https://github.com/mapbox/mapbox-navigation-android/pull/6641)
 - Started clearing route geometry cache when no routes (neither routes used for Active Guidance nor previewed ones) are available. [#6617](https://github.com/mapbox/mapbox-navigation-android/pull/6617)

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/MapboxVoiceInstructions.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/MapboxVoiceInstructions.kt
@@ -11,9 +11,6 @@ import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.distinctUntilChangedBy
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
 
 /**
@@ -23,7 +20,7 @@ import kotlinx.coroutines.flow.mapLatest
 class MapboxVoiceInstructions {
 
     private val voiceInstructionsFlow =
-        MutableStateFlow<State>(MapboxVoiceInstructionsState(true, null))
+        MutableStateFlow(MapboxVoiceInstructionsState(true, null))
     private val routesFlow = MutableStateFlow<List<NavigationRoute>>(emptyList())
     private val tripSessionStateFlow = MutableStateFlow(TripSessionState.STOPPED)
 
@@ -32,9 +29,15 @@ class MapboxVoiceInstructions {
     }
     private val routesObserver = RoutesObserver {
         routesFlow.value = it.navigationRoutes
+        if (it.navigationRoutes.isEmpty()) {
+            voiceInstructionsFlow.value = MapboxVoiceInstructionsState()
+        }
     }
     private val tripSessionStateObserver = TripSessionStateObserver {
         tripSessionStateFlow.value = it
+        if (it == TripSessionState.STOPPED) {
+            voiceInstructionsFlow.value = MapboxVoiceInstructionsState()
+        }
     }
 
     fun registerObservers(mapboxNavigation: MapboxNavigation) {
@@ -51,32 +54,11 @@ class MapboxVoiceInstructions {
         resetFlows()
     }
 
-    fun voiceInstructions(): Flow<State> {
-        return tripSessionStateFlow
-            .flatMapLatest { tripSessionState ->
-                if (tripSessionState == TripSessionState.STARTED) {
-                    routesUpdatedResultToVoiceInstructions()
-                } else {
-                    flowOf(MapboxVoiceInstructionsState(false, null))
-                }
-            }
-    }
+    fun voiceInstructions(): Flow<State> = voiceInstructionsFlow
 
     fun voiceLanguage(): Flow<String?> {
         return routesFlow
             .mapLatest { it.firstOrNull()?.directionsRoute?.voiceLanguage() }
-    }
-
-    private fun routesUpdatedResultToVoiceInstructions(): Flow<State> {
-        return routesFlow
-            .distinctUntilChangedBy { it.isEmpty() }
-            .flatMapLatest { routes ->
-                if (routes.isNotEmpty()) {
-                    voiceInstructionsFlow
-                } else {
-                    flowOf(MapboxVoiceInstructionsState(false, null))
-                }
-            }
     }
 
     private fun resetFlows() {

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/MapboxVoiceInstructions.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/MapboxVoiceInstructions.kt
@@ -22,7 +22,6 @@ class MapboxVoiceInstructions {
     private val voiceInstructionsFlow =
         MutableStateFlow(MapboxVoiceInstructionsState(true, null))
     private val routesFlow = MutableStateFlow<List<NavigationRoute>>(emptyList())
-    private val tripSessionStateFlow = MutableStateFlow(TripSessionState.STOPPED)
 
     private val voiceInstructionsObserver = VoiceInstructionsObserver {
         voiceInstructionsFlow.value = MapboxVoiceInstructionsState(true, it)
@@ -34,7 +33,6 @@ class MapboxVoiceInstructions {
         }
     }
     private val tripSessionStateObserver = TripSessionStateObserver {
-        tripSessionStateFlow.value = it
         if (it == TripSessionState.STOPPED) {
             voiceInstructionsFlow.value = MapboxVoiceInstructionsState()
         }
@@ -64,7 +62,6 @@ class MapboxVoiceInstructions {
     private fun resetFlows() {
         voiceInstructionsFlow.value = MapboxVoiceInstructionsState(true, null)
         routesFlow.value = emptyList()
-        tripSessionStateFlow.value = TripSessionState.STOPPED
     }
 
     interface State {


### PR DESCRIPTION
Closes NAVAND-68

### Description
- Fixed an issue where the last audio instruction from the previous session becomes the 1st on the next session.
  - Resetting `MapboxVoiceInstructions.voiceInstructionsFlow` when `MapboxNavigation.navigationRoutes` is set to empty list or `TripSessionState` changes to `STOPPED`.