### PR TITLE
[Android Auto] Fix car library NavigationManager updateTrip crash

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Fixed issue when `NavigationManager.updateTrip` crashes because navigation is not started https://issuetracker.google.com/u/0/issues/260968395. [#6673](https://github.com/mapbox/mapbox-navigation-android/pull/6673)
 
 ## androidauto-v0.17.0 - 30 November, 2022
 ### Changelog

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManager.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManager.kt
@@ -108,6 +108,7 @@ class MapboxCarNavigationManager internal constructor(
                             "MapboxNavigation.stopTripSession in order to stop navigation."
                     )
                     navigationManager.navigationStarted()
+                    navigationManager.updateTrip(trip)
                 }
             }
         }

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManagerTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/navigation/MapboxCarNavigationManagerTest.kt
@@ -226,8 +226,10 @@ class MapboxCarNavigationManagerTest {
         val expectedErrorMessage = "MapboxCarNavigationManager updateTrip failed"
         verifyOrder {
             navigationManager.navigationStarted()
+            navigationManager.updateTrip(any())
             AndroidAutoLog.logAndroidAutoFailure(expectedErrorMessage, any())
             navigationManager.navigationStarted()
+            navigationManager.updateTrip(any())
         }
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Yesterday I was hunting down any possible race condition that is within our control https://github.com/mapbox/mapbox-navigation-android/pull/6661

After releasing the crash report has still been found. We also found with MapboxCarNavigationManager that it is working correctly. Unfortunately we need a try catch to solve the crash from NavigationManager. I've sent over a request for google to provide a new api to prevent it. https://issuetracker.google.com/u/0/issues/260968395. More details of potential causes can be found in that issuetracker.

Another cause I could think of, is if someone calls navigationEnded outside of the sdk. There is no way for us to know if that happens, and in the case that it does we will log an error.
```
carContext.getCarService(NavigationManager::class.java).navigationEnded()
```

If there is another unknown cause to this issue, then at least the log will help us determine the cause. We also have not been able to reproduce the error inside the example [android-auto-app](https://github.com/mapbox/mapbox-navigation-android/tree/main/android-auto-app)

Filtered logs showing the callbacks that happens when the crash happens.
```
[nav-sdk]: [MapboxAndroidAuto] 2: MapboxNavigationManager onAttached
[nav-sdk]: [MapboxAndroidAuto] 2: MapboxNavigationManager tripSessionStateObserver state: STOPPED
[nav-sdk]: [MapboxAndroidAuto] 2: MapboxNavigationManager tripSessionStateObserver state: STARTED
---------------------------- PROCESS ENDED ----------------------------
---------------------------- PROCESS STARTED --------------------------
 [nav-sdk]: [MapboxAndroidAuto] 2: MapboxNavigationManager onAttached
[nav-sdk]: [MapboxAndroidAuto] 2: MapboxNavigationManager tripSessionStateObserver state: STOPPED
[nav-sdk]: [MapboxAndroidAuto] 2: MapboxNavigationManager tripSessionStateObserver state: STARTED
java.lang.IllegalStateException: Navigation is not started
	at androidx.car.app.navigation.NavigationManager.updateTrip(NavigationManager.java:113)
	at com.mapbox.androidauto.navigation.MapboxCarNavigationManager.routeProgressObserver$lambda-0(MapboxCarNavigationManager.kt:41)
	at com.mapbox.androidauto.navigation.MapboxCarNavigationManager.$r8$lambda$iUg_P4_0eVoXMV009Th8LUTbw0s(Unknown Source:0)
	at com.mapbox.androidauto.navigation.MapboxCarNavigationManager$$ExternalSyntheticLambda0.onRouteProgressChanged(Unknown Source:2)
	at com.mapbox.navigation.core.trip.session.MapboxTripSession.updateRouteProgress(MapboxTripSession.kt:686)
	at com.mapbox.navigation.core.trip.session.MapboxTripSession.access$updateRouteProgress(MapboxTripSession.kt:60)
	at com.mapbox.navigation.core.trip.session.MapboxTripSession$navigatorObserver$1.onStatus(MapboxTripSession.kt:376)°
```