### PR TITLE
Fix ReplayRouteSession route state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Mapbox Java `v6.9.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.9.0))
 - Mapbox Android Core `v5.0.2` ([release notes](https://github.com/mapbox/mapbox-events-android/releases/tag/core-5.0.2))
 
+- Fixed issues in `ReplayRouteSession`. The routes observer was never unregistered. Alternative route selection resets replay to the beginning. DropInUi changing portrait and landscape modes resets replay to the beginning. [#6675](https://github.com/mapbox/mapbox-navigation-android/pull/6675)
 
 ## Mapbox Navigation SDK 2.10.0-beta.2 - 01 December, 2022
 ### Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed memory leak in `ReplayProgressObserver` which happened after route refresh. [#6691](https://github.com/mapbox/mapbox-navigation-android/pull/6691)
 - Fixed a rare issue where a reroute relative to old routes might have occurred after setting new routes. [#6693](https://github.com/mapbox/mapbox-navigation-android/pull/6693)
 - Added experimental `MapboxRouteLineOptions#shareLineGeometrySources` option to enable route line's GeoJson source data sharing between multiple instances of the map. [#6680](https://github.com/mapbox/mapbox-navigation-android/pull/6680)
+- Fixed issues in `ReplayRouteSession`. The routes observer was never unregistered. Alternative route selection resets replay to the beginning. DropInUi changing portrait and landscape modes resets replay to the beginning. [#6675](https://github.com/mapbox/mapbox-navigation-android/pull/6675)
 
 ## Mapbox Navigation SDK 2.9.4 - 08 December, 2022
 ### Changelog
@@ -30,7 +31,6 @@ This release depends on, and has been tested with, the following Mapbox dependen
 - Mapbox Java `v6.9.0` ([release notes](https://github.com/mapbox/mapbox-java/releases/tag/v6.9.0))
 - Mapbox Android Core `v5.0.2` ([release notes](https://github.com/mapbox/mapbox-events-android/releases/tag/core-5.0.2))
 
-- Fixed issues in `ReplayRouteSession`. The routes observer was never unregistered. Alternative route selection resets replay to the beginning. DropInUi changing portrait and landscape modes resets replay to the beginning. [#6675](https://github.com/mapbox/mapbox-navigation-android/pull/6675)
 
 ## Mapbox Navigation SDK 2.10.0-beta.2 - 01 December, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayPolylineDecodeStream.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayPolylineDecodeStream.kt
@@ -94,4 +94,15 @@ class ReplayPolylineDecodeStream(
         }
         return points
     }
+
+    /**
+     * Skip the next [count] points of the geometry. Less points are skipped if there are less than
+     * [count] points left in the iterator.
+     *
+     * @param count the number of points to skip.
+     */
+    fun skip(count: Int) {
+        var skipped = 0
+        while (skipped++ <= count && hasNext()) { next() }
+    }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteSession.kt
@@ -9,6 +9,7 @@ import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
@@ -17,6 +18,7 @@ import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.history.ReplayEventBase
 import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
 import com.mapbox.navigation.core.replay.history.ReplayEventsObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 import com.mapbox.navigation.utils.internal.logW
 import java.util.Collections
 
@@ -58,11 +60,23 @@ class ReplayRouteSession : MapboxNavigationObserver {
     private lateinit var replayRouteMapper: ReplayRouteMapper
     private var mapboxNavigation: MapboxNavigation? = null
     private var lastLocationEvent: ReplayEventUpdateLocation? = null
-    private var routesObserver: RoutesObserver? = null
-    private var currentRouteId: String? = null
+    private var currentRoute: NavigationRoute? = null
+
+    private val routeProgressObserver = RouteProgressObserver { routeProgress ->
+        if (currentRoute?.id != routeProgress.navigationRoute.id) {
+            currentRoute = routeProgress.navigationRoute
+            onRouteChanged(routeProgress)
+        }
+    }
+
+    private val routesObserver = RoutesObserver { result ->
+        if (result.navigationRoutes.isEmpty()) {
+            mapboxNavigation?.resetReplayLocation()
+        }
+    }
 
     private val replayEventsObserver = ReplayEventsObserver { events ->
-        if (isLastEventPlayed(events)) {
+        if (currentRoute != null && isLastEventPlayed(events)) {
             pushMorePoints()
         }
     }
@@ -92,17 +106,10 @@ class ReplayRouteSession : MapboxNavigationObserver {
         this.mapboxNavigation = mapboxNavigation
         mapboxNavigation.stopTripSession()
         mapboxNavigation.startReplayTripSession()
-
-        routesObserver = RoutesObserver { result ->
-            if (result.navigationRoutes.isEmpty()) {
-                currentRouteId = null
-                mapboxNavigation.resetReplayLocation()
-            } else if (result.navigationRoutes.first().id != currentRouteId) {
-                onRouteChanged(result.navigationRoutes.first())
-            }
-        }.also { mapboxNavigation.registerRoutesObserver(it) }
+        mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+        mapboxNavigation.registerRoutesObserver(routesObserver)
         mapboxNavigation.mapboxReplayer.registerObserver(replayEventsObserver)
-        mapboxNavigation.resetReplayLocation()
+        mapboxNavigation.mapboxReplayer.play()
     }
 
     private fun MapboxNavigation.resetReplayLocation() {
@@ -123,14 +130,18 @@ class ReplayRouteSession : MapboxNavigationObserver {
     }
 
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
-        this.mapboxNavigation = null
+        mapboxNavigation.unregisterRoutesObserver(routesObserver)
+        mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
         mapboxNavigation.mapboxReplayer.unregisterObserver(replayEventsObserver)
         mapboxNavigation.mapboxReplayer.stop()
         mapboxNavigation.mapboxReplayer.clearEvents()
         mapboxNavigation.stopTripSession()
+        this.mapboxNavigation = null
+        this.currentRoute = null
     }
 
-    private fun onRouteChanged(navigationRoute: NavigationRoute) {
+    private fun onRouteChanged(routeProgress: RouteProgress) {
+        val navigationRoute = routeProgress.navigationRoute
         val mapboxReplayer = mapboxNavigation?.mapboxReplayer ?: return
         mapboxReplayer.clearEvents()
         mapboxReplayer.play()
@@ -144,9 +155,12 @@ class ReplayRouteSession : MapboxNavigationObserver {
             }
             return
         }
-        currentRouteId = navigationRoute.id
         polylineDecodeStream = ReplayPolylineDecodeStream(geometry, 6)
-        mapboxNavigation?.resetTripSession()
+
+        // Skip up to the current geometry index. There is some imprecision here because the
+        // distance traveled is not equal to a route index.
+        polylineDecodeStream.skip(routeProgress.currentRouteGeometryIndex)
+
         pushMorePoints()
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteSessionTest.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.TripSessionResetCallback
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesUpdatedResult
 import com.mapbox.navigation.core.replay.MapboxReplayer
@@ -57,6 +58,9 @@ class ReplayRouteSessionTest {
         every { navigationOptions } returns options
         every { registerRoutesObserver(capture(routesObserver)) } just runs
         every { registerRouteProgressObserver(capture(routeProgressObserver)) } just runs
+        every { resetTripSession(any()) } answers {
+            firstArg<TripSessionResetCallback>().onTripSessionReset()
+        }
     }
     private val bestLocationEngine: LocationEngine = mockk {
         every { getLastLocation(any()) } just runs
@@ -109,7 +113,7 @@ class ReplayRouteSessionTest {
 
         verifyOrder {
             replayer.clearEvents()
-            mapboxNavigation.resetTripSession()
+            mapboxNavigation.resetTripSession(any())
             replayer.play()
         }
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Fixing issues in `ReplayRouteSession`.

- The routes observer was never unregistered.
- Alternative route selection resets replay to the beginning.
- DropInUi changing portrait and landscape modes resets replay to the beginning.

### More details

Here is a similar issue where we added Alternative Route support in the `ReplayProgressObserver`. https://github.com/mapbox/mapbox-navigation-android/pull/5586. Essentially, when the route changes it needs to calculate the `distanceTraveled` and skip some replay events. The `ReplayProgressObserver` uses an [indexAlong](https://github.com/mapbox/mapbox-navigation-android/blob/e1ae50f4a5d3b357e29a3b0f65961d69a60b3c56/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserver.kt#L74-L96) function, where the new way can use the new memory efficient `ReplayPolylineDecodeStream.skip`. 

There is probably a leaking routeProgressObserver in the last beta for anything using `ReplayRouteSession`. I found it while digging into the issues. I've added a test to cover it. It was registered in onAttached, and not unregistered in onDetached. Simple fix.

The DropInUi fix is slightly lucky, because the `ReplayRouteSession` is not meant to carry information from `onDetatched`->`onAttached`. The `TripSessionComponent` is tied to the `NavigationView` lifecycle, so the configuration changes trigger onDetached/onAttached events. I'm considering the alternative route fix the true fix, and DropInUi a lucky beneficiary. This is also how we discovered the `ReplayRouteSession` issue. More details below. 

### More more details

The original approach uses the `RoutesObserver` to decide the current route https://github.com/mapbox/mapbox-navigation-android/pull/6636. This new approach uses the `RouteProgressObserver` in a way that is similar to `ReplayProgressObserver`.  This decision is to support DropInUi, the behavior of the callbacks act in such a way that information can be carried from onDetatched/onAttached. I am in favor of making it so onDetached does not happen when a configuration changes, but that will require changes to `TripSessionComponent`. 

I have been thinking about how to handle configuration changes with `MapboxNavigationObserver`, there is a draft here https://github.com/mapbox/mapbox-navigation-android/pull/6484. We can design certain observers to be aware when configurations are changing and maintain state while it is happening. I'm not excited by it because a configuration change does not mean the observer will be re-attached, in which case the state can leak. It feels better to attach the observer to a better lifecycle, such as the Application CarAppLifecycle or ViewModel. Or other ideas.