### PR TITLE
[Android Auto] Remove android auto metadata from manifest

### DIFF
--- a/libnavui-androidauto/src/main/AndroidManifest.xml
+++ b/libnavui-androidauto/src/main/AndroidManifest.xml
@@ -8,10 +8,6 @@
     <application>
 
         <meta-data
-            android:name="com.google.android.gms.car.application"
-            android:resource="@xml/automotive_app_desc" />
-
-        <meta-data
             android:name="androidx.car.app.theme"
             android:resource="@style/CarAppTheme"/>
 


### PR DESCRIPTION
### Description
This PR removes the Android Auto metadata from the library. Including this metadata in the manifest assumes that the client app including this library will support Android Auto, but this is not always the case since the app can target AAOS.

Note that support for Android Auto and AAOS in the manifest is exclusive for each platform, i.e., the same apk / aab cannot target both Android Auto and AAOS. Doing so seems to trigger Google rejections on Google Play.

According to the docs:
- Android Auto: https://developer.android.com/training/cars/apps/auto#declare-android-auto-support
```
<application>
    ...
    <meta-data
        android:name="com.google.android.gms.car.application"
        android:resource="@xml/automotive_app_desc"/>
    ...
</application>
```
- AAOS: https://developer.android.com/training/cars/apps/automotive-os#manifest-car-app
```
<application>
    ...
    <meta-data android:name="com.android.automotive"
        android:resource="@xml/automotive_app_desc"/>
    ...
</application>
```

This issue can be easily observed in https://github.com/mapbox/mapbox-navigation-android-examples/tree/main/android-automotive-app after building the apk and analyzing the manifest. It will contain support for both Auto and AAOS, but it should only contain support for AAOS. This PR fixes that.

Kudos to @jvanderwee for finding out!
