### PR TITLE
[Android Auto] Fix AAOS Google Play release issue

### DIFF
--- a/android-auto-app/build.gradle
+++ b/android-auto-app/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     implementation project(':libnavui-androidauto')
 
     // This library will depend on the latest stable version.
-    implementation("com.mapbox.navigation:ui-dropin:2.9.1")
+    implementation("com.mapbox.navigation:ui-dropin:2.9.3")
 
     // Dependencies needed for this example.
     implementation dependenciesList.androidXAppCompat

--- a/android-auto-app/src/main/AndroidManifest.xml
+++ b/android-auto-app/src/main/AndroidManifest.xml
@@ -20,6 +20,11 @@
             </intent-filter>
         </activity>
 
+        <!-- For AAOS use <meta-data android:name="com.android.automotive" -->
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+
         <service
             android:name=".car.MainCarAppService"
             android:exported="true"

--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -6,6 +6,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 #### Bug fixes and improvements
 - Fixed issue when `NavigationManager.updateTrip` crashes because navigation is not started https://issuetracker.google.com/u/0/issues/260968395. [#6673](https://github.com/mapbox/mapbox-navigation-android/pull/6673)
+- Fixed AAOS Google Play release issue. Previously the AndroidManifest was specific to AA. Now you must specify the `meta-data` type depending on whether you are using AA or AAOS. [#6679](https://github.com/mapbox/mapbox-navigation-android/pull/6679)
 
 ## androidauto-v0.17.0 - 30 November, 2022
 ### Changelog

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     // This defines the minimum version of Navigation which is included in this SDK. To upgrade the
     // Navigation versions, you can specify a newer version in your downstream build.gradle.
-    api("com.mapbox.navigation:android:2.9.2")
+    api("com.mapbox.navigation:android:2.9.3")
 
     // Search is currently in beta so it is not included in this SDK. The functionality of search
     // is included behind this library's api.

--- a/libnavui-androidauto/src/main/AndroidManifest.xml
+++ b/libnavui-androidauto/src/main/AndroidManifest.xml
@@ -8,10 +8,6 @@
     <application>
 
         <meta-data
-            android:name="com.google.android.gms.car.application"
-            android:resource="@xml/automotive_app_desc" />
-
-        <meta-data
             android:name="androidx.car.app.theme"
             android:resource="@style/CarAppTheme"/>
 


### PR DESCRIPTION
### Description

Cherry-picking this remote pull request https://github.com/mapbox/mapbox-navigation-android/pull/6676. Details and links in the other description. 

Essentially, getting the `meta-data` type wrong will result in a Google Play rejection when releasing an AAOS app. Now you must specify the `meta-data` type when using the mapbox-sdk.
- AA: `com.google.android.gms.car.application`
- AAOS:  `com.android.automotive`

This pull request also bumps to the latest Nav-Sdk `2.9.3`