### PR TITLE
deliver reroute failure synchronously when options update fails

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/MapboxNavigationRule.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/MapboxNavigationRule.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.instrumentation_tests.utils
 
 import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.testing.ui.utils.runOnMainSync
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
@@ -10,11 +11,15 @@ import org.junit.runner.Description
  * After each test run ensures that [MapboxNavigation] is destroyed.
  */
 class MapboxNavigationRule : TestWatcher() {
-    override fun starting(description: Description?) {
-        check(MapboxNavigationProvider.isCreated().not())
+    override fun starting(description: Description) {
+        runOnMainSync {
+            check(MapboxNavigationProvider.isCreated().not())
+        }
     }
 
-    override fun finished(description: Description?) {
-        MapboxNavigationProvider.destroy()
+    override fun finished(description: Description) {
+        runOnMainSync {
+            MapboxNavigationProvider.destroy()
+        }
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -20,6 +20,7 @@ import com.mapbox.navigation.utils.internal.JobControl
 import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.navigation.utils.internal.logD
+import com.mapbox.navigation.utils.internal.logW
 import kotlinx.coroutines.launch
 import java.util.concurrent.CopyOnWriteArraySet
 
@@ -174,13 +175,11 @@ internal class MapboxRerouteController @VisibleForTesting constructor(
                         request(callback, modifiedRerouteOption)
                     }
                     is RouteOptionsUpdater.RouteOptionsResult.Error -> {
-                        mainJobController.scope.launch {
-                            state = RerouteState.Failed(
-                                message = "Cannot combine route options",
-                                throwable = routeOptionsResult.error
-                            )
-                            state = RerouteState.Idle
-                        }
+                        state = RerouteState.Failed(
+                            message = "Cannot combine route options",
+                            throwable = routeOptionsResult.error
+                        )
+                        state = RerouteState.Idle
                     }
                 }
             }
@@ -191,10 +190,11 @@ internal class MapboxRerouteController @VisibleForTesting constructor(
         if (state == RerouteState.FetchingRoute) {
             requestId?.also { id ->
                 directionsSession.cancelRouteRequest(id)
-                logD(
-                    "Route request interrupted",
-                    LOG_CATEGORY
-                )
+                logD(LOG_CATEGORY) {
+                    "Route request interrupted"
+                }
+            } ?: logW(LOG_CATEGORY) {
+                "Tried interrupting but there's no ongoing request"
             }
         }
     }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
This PR fixes an issue where `MapboxNavigation` was cleaned up from a worker thread in instrumentation tests that could lead to failures like the one caught in https://github.com/mapbox/mapbox-navigation-android/pull/6650#issuecomment-1331908631.

While investigating, I also noticed a situation where we could run into the same problem in a single-threaded scenario due to the reroute options updating error being posted back to the message queue instead of being invoked synchronously.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
