### PR TITLE
NavigatorObserver: fix race condition on invoking TripSession#updateLegIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Fixed `BannerInstructions` issue: the banner instruction might be removed from `RouteProgress` at some point around a edge's leg. [#6684](https://github.com/mapbox/mapbox-navigation-android/pull/6684)
 
 ## Mapbox Navigation SDK 2.10.0-beta.2 - 01 December, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/BannerInstructionEvent.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/BannerInstructionEvent.kt
@@ -1,34 +1,58 @@
 package com.mapbox.navigation.core.trip.session
 
 import com.mapbox.api.directions.v5.models.BannerInstructions
+import com.mapbox.navigation.utils.internal.ifNonNull
 
-internal class BannerInstructionEvent {
+internal class BannerInstructionEvent private constructor() {
 
-    var latestInstructionIndex: Int? = null
+    var latestInstructionWrapper: LatestInstructionWrapper? = null
         private set
+
+    val latestInstructionIndex: Int?
+        get() = latestInstructionWrapper?.latestInstructionIndex
+
+    val latestBannerInstructions: BannerInstructions?
+        get() = latestInstructionWrapper?.latestBannerInstructions
 
     var bannerInstructions: BannerInstructions? = null
         private set
 
-    var latestBannerInstructions: BannerInstructions? = null
-        private set
+    companion object {
+        operator fun invoke(): BannerInstructionEvent = BannerInstructionEvent()
+    }
 
     fun isOccurring(bannerInstructions: BannerInstructions?, instructionIndex: Int?): Boolean {
         return updateCurrentBanner(bannerInstructions, instructionIndex)
     }
 
-    fun invalidateLatestBannerInstructions() {
-        latestBannerInstructions = null
-        latestInstructionIndex = null
+    fun invalidateLatestBannerInstructions(latestInstructionWrapper: LatestInstructionWrapper?) {
+        if (latestInstructionWrapper == this.latestInstructionWrapper) {
+            this.latestInstructionWrapper = null
+        }
     }
 
     private fun updateCurrentBanner(banner: BannerInstructions?, instructionIndex: Int?): Boolean {
         bannerInstructions = banner
         if (bannerInstructions != null && bannerInstructions!! != latestBannerInstructions) {
-            latestBannerInstructions = bannerInstructions
-            latestInstructionIndex = instructionIndex
+            latestInstructionWrapper =
+                LatestInstructionWrapper.createOrNull(instructionIndex, bannerInstructions)
             return true
         }
         return false
+    }
+
+    data class LatestInstructionWrapper(
+        val latestInstructionIndex: Int,
+        val latestBannerInstructions: BannerInstructions
+    ) {
+        companion object {
+            fun createOrNull(
+                latestInstructionIndex: Int?,
+                latestBannerInstructions: BannerInstructions?
+            ): LatestInstructionWrapper? =
+                ifNonNull(latestInstructionIndex, latestBannerInstructions) { idx, instruction ->
+                    LatestInstructionWrapper(idx, instruction)
+                }
+        }
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -179,7 +179,7 @@ internal class MapboxTripSession(
             this@MapboxTripSession.primaryRoute = newPrimaryRoute
             roadObjects = newPrimaryRoute?.upcomingRoadObjects ?: emptyList()
             isOffRoute = false
-            invalidateLatestInstructions()
+            invalidateLatestInstructions(bannerInstructionEvent.latestInstructionWrapper)
             routeProgress = null
         }.mapValue {
             it.alternatives
@@ -588,9 +588,10 @@ internal class MapboxTripSession(
         var legIndexUpdated = false
         updateLegIndexJob = mainJobController.scope.launch {
             try {
+                val latestInstructionWrapper = bannerInstructionEvent.latestInstructionWrapper
                 legIndexUpdated = navigator.updateLegIndex(legIndex)
                 if (legIndexUpdated) {
-                    invalidateLatestInstructions()
+                    invalidateLatestInstructions(latestInstructionWrapper)
                 }
             } finally {
                 callback.onLegIndexUpdatedCallback(legIndexUpdated)
@@ -698,8 +699,14 @@ internal class MapboxTripSession(
         }
     }
 
-    private fun invalidateLatestInstructions() {
-        bannerInstructionEvent.invalidateLatestBannerInstructions()
+    /**
+     * Invalidate latest banner instruction. To get the latest banner instruction wrapper call
+     * [BannerInstructionEvent.latestInstructionWrapper]
+     */
+    private fun invalidateLatestInstructions(
+        latestInstructionWrapper: BannerInstructionEvent.LatestInstructionWrapper?
+    ) {
+        bannerInstructionEvent.invalidateLatestBannerInstructions(latestInstructionWrapper)
         lastVoiceInstruction = null
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/BannerInstructionEventTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/BannerInstructionEventTest.kt
@@ -96,9 +96,31 @@ class BannerInstructionEventTest {
         val anyBannerInstructions: BannerInstructions = mockk()
         bannerInstructionEvent.isOccurring(anyBannerInstructions, 0)
 
-        bannerInstructionEvent.invalidateLatestBannerInstructions()
+        bannerInstructionEvent
+            .invalidateLatestBannerInstructions(bannerInstructionEvent.latestInstructionWrapper)
 
         assertNull(bannerInstructionEvent.latestBannerInstructions)
         assertNull(bannerInstructionEvent.latestInstructionIndex)
+        assertNull(bannerInstructionEvent.latestInstructionWrapper)
+    }
+
+    @Test
+    fun invalidateNonExistingLatestBannerInstructions() {
+        val bannerInstructionEvent = BannerInstructionEvent()
+        val anyBannerInstructions: BannerInstructions = mockk()
+        bannerInstructionEvent.isOccurring(anyBannerInstructions, 0)
+
+        bannerInstructionEvent
+            .invalidateLatestBannerInstructions(mockk())
+
+        assertEquals(
+            BannerInstructionEvent.LatestInstructionWrapper(0, anyBannerInstructions),
+            bannerInstructionEvent.latestInstructionWrapper
+        )
+        assertEquals(
+            anyBannerInstructions,
+            bannerInstructionEvent.latestBannerInstructions
+        )
+        assertEquals(0, bannerInstructionEvent.latestInstructionIndex,)
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -46,6 +46,7 @@ import io.mockk.Runs
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -129,6 +130,7 @@ class MapboxTripSessionTest {
     private val navigationStatus: NavigationStatus = mockk(relaxed = true)
     private val routeProgress: RouteProgress = mockk()
     private val threadController = spyk<ThreadController>()
+    private val bannerInstructionEvent = spyk(BannerInstructionEvent())
 
     private val parentJob = SupervisorJob()
     private val testScope = CoroutineScope(parentJob + coroutineRule.testDispatcher)
@@ -147,6 +149,7 @@ class MapboxTripSessionTest {
         mockkObject(MapboxNativeNavigatorImpl)
         mockkStatic("com.mapbox.navigation.core.navigator.NavigatorMapper")
         mockkStatic("com.mapbox.navigation.core.navigator.LocationEx")
+        mockkObject(BannerInstructionEvent.Companion)
         mockkObject(RoadObjectFactory)
         mockkStatic(LocationEngineProvider::class)
         every { LocationEngineProvider.getBestLocationEngine(any()) } returns mockk()
@@ -154,6 +157,7 @@ class MapboxTripSessionTest {
         every { fixLocation.toLocation() } returns location
         every { keyFixPoints.toLocations() } returns keyPoints
         every { threadController.getMainScopeAndRootJob() } returns JobControl(parentJob, testScope)
+        every { BannerInstructionEvent.invoke() } returns bannerInstructionEvent
         navigationOptions = NavigationOptions.Builder(context).build()
         tripSession = buildTripSession()
 
@@ -1660,11 +1664,40 @@ class MapboxTripSessionTest {
             }
         }
 
+    /*
+        navigator.updateLegIndex(legIndex) might force invoking NavigatorObserver and one adds
+        new latest banner instructions to BannerInstructionEvent. That's why requires pre-save
+        latest banner instructions to remove legacy instructions only
+     */
+    @Test
+    fun `updateLegIndex latest banner instructions pre-save to later clen up them`() =
+        coroutineRule.runBlockingTest {
+            val idx = -1
+            val mockLatestInstructionWrapper =
+                mockk<BannerInstructionEvent.LatestInstructionWrapper>()
+            every {
+                bannerInstructionEvent.latestInstructionWrapper
+            } returns mockLatestInstructionWrapper
+            coEvery { navigator.updateLegIndex(idx) } coAnswers {
+                true
+            }
+
+            tripSession.updateLegIndex(idx, mockk(relaxUnitFun = true))
+
+            coVerifyOrder {
+                bannerInstructionEvent.latestInstructionWrapper
+                navigator.updateLegIndex(idx)
+                bannerInstructionEvent
+                    .invalidateLatestBannerInstructions(mockLatestInstructionWrapper)
+            }
+        }
+
     @After
     fun cleanUp() {
         unmockkObject(MapboxNativeNavigatorImpl)
         unmockkStatic("com.mapbox.navigation.core.navigator.NavigatorMapper")
         unmockkStatic("com.mapbox.navigation.core.navigator.LocationEx")
+        unmockkObject(BannerInstructionEvent.Companion)
         unmockkObject(RoadObjectFactory)
         unmockkStatic(LocationEngineProvider::class)
     }


### PR DESCRIPTION
NavigatorObserver: fix race condition on invoking TripSession#updateLegIndex

`!!!` the fix required to be cherry-picked to `2.7`, `2.8`, `2.9`

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
