### PR TITLE
migrate to Navigator.resetRideSession with callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Fixed an issue where `RouteProgress#BannerInstructions` could've become `null` when `MapboxNavigation#updateLegIndex` was called. [#6684](https://github.com/mapbox/mapbox-navigation-android/pull/6684)
 - Fixed an issue where `RouteProgress#VoiceInstructions` could've become `null` when `MapboxNavigation#updateLegIndex` was called. [#6689](https://github.com/mapbox/mapbox-navigation-android/pull/6689)
+- Fixed `BannerInstructions` issue where the banner instruction might have been removed from `RouteProgress` at some point around a edge's leg. [#6684](https://github.com/mapbox/mapbox-navigation-android/pull/6684)
+- Added `MapboxNavigation#resetTripSession(callback)` and deprecated the counterpart without a callback. [#6685](https://github.com/mapbox/mapbox-navigation-android/pull/6685)
 
 ## Mapbox Navigation SDK 2.10.0-beta.2 - 01 December, 2022
 ### Changelog

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxNavigationTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/MapboxNavigationTest.kt
@@ -1,0 +1,48 @@
+package com.mapbox.navigation.instrumentation_tests.core
+
+import android.location.Location
+import androidx.test.espresso.Espresso
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.instrumentation_tests.activity.EmptyTestActivity
+import com.mapbox.navigation.instrumentation_tests.utils.MapboxNavigationRule
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.resetTripSessionAndWaitForResult
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.sdkTest
+import com.mapbox.navigation.testing.ui.BaseTest
+import com.mapbox.navigation.testing.ui.utils.getMapboxAccessTokenFromResources
+import com.mapbox.navigation.testing.ui.utils.runOnMainSync
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class MapboxNavigationTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.java) {
+
+    @get:Rule
+    val mapboxNavigationRule = MapboxNavigationRule()
+
+    private lateinit var mapboxNavigation: MapboxNavigation
+
+    override fun setupMockLocation(): Location = mockLocationUpdatesRule.generateLocationUpdate {
+        latitude = 38.894721
+        longitude = -77.031991
+    }
+
+    @Before
+    fun setup() {
+        Espresso.onIdle()
+
+        runOnMainSync {
+            mapboxNavigation = MapboxNavigationProvider.create(
+                NavigationOptions.Builder(activity)
+                    .accessToken(getMapboxAccessTokenFromResources(activity))
+                    .build()
+            )
+        }
+    }
+
+    @Test
+    fun trip_session_resets_successfully() = sdkTest {
+        mapboxNavigation.resetTripSessionAndWaitForResult()
+    }
+}

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/TestUtils.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/TestUtils.kt
@@ -116,6 +116,11 @@ private suspend fun MapboxNavigation.waitForRoutesUpdate(
         .first()
 }
 
+suspend fun MapboxNavigation.resetTripSessionAndWaitForResult() =
+    suspendCancellableCoroutine<Unit> { cont ->
+        resetTripSession { cont.resume(Unit) }
+    }
+
 inline fun <T> withLogOnTimeout(message: String, body: () -> T): T {
     try {
         return body()

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -65,7 +65,8 @@ package com.mapbox.navigation.core {
     method public void requestRoadGraphDataUpdate(com.mapbox.navigation.core.RoadGraphDataUpdateCallback callback);
     method @Deprecated public long requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.RouterCallback routesRequestCallback);
     method public long requestRoutes(com.mapbox.api.directions.v5.models.RouteOptions routeOptions, com.mapbox.navigation.base.route.NavigationRouterCallback callback);
-    method public void resetTripSession();
+    method @Deprecated public void resetTripSession();
+    method public void resetTripSession(com.mapbox.navigation.core.TripSessionResetCallback callback);
     method public void setArrivalController(com.mapbox.navigation.core.arrival.ArrivalController? arrivalController = com.mapbox.navigation.core.arrival.AutoArrivalController());
     method public void setArrivalController();
     method public void setNavigationRoutes(java.util.List<com.mapbox.navigation.base.route.NavigationRoute> routes, int initialLegIndex = 0, com.mapbox.navigation.core.RoutesSetCallback? callback = null);
@@ -151,6 +152,10 @@ package com.mapbox.navigation.core {
   public final class RoutesSetSuccess {
     method public java.util.Map<java.lang.String,com.mapbox.navigation.core.RoutesSetError> getIgnoredAlternatives();
     property public final java.util.Map<java.lang.String,com.mapbox.navigation.core.RoutesSetError> ignoredAlternatives;
+  }
+
+  public fun interface TripSessionResetCallback {
+    method public void onTripSessionReset();
   }
 
 }
@@ -777,13 +782,13 @@ package com.mapbox.navigation.core.routealternatives {
   }
 
   public final class AlternativeRouteMetadata {
-    method public int getAlternativeId();
+    method @Deprecated public int getAlternativeId();
     method public com.mapbox.navigation.core.routealternatives.AlternativeRouteIntersection getForkIntersectionOfAlternativeRoute();
     method public com.mapbox.navigation.core.routealternatives.AlternativeRouteIntersection getForkIntersectionOfPrimaryRoute();
     method public com.mapbox.navigation.core.routealternatives.AlternativeRouteInfo getInfoFromFork();
     method public com.mapbox.navigation.core.routealternatives.AlternativeRouteInfo getInfoFromStartOfPrimary();
     method public com.mapbox.navigation.base.route.NavigationRoute getNavigationRoute();
-    property public final int alternativeId;
+    property @Deprecated public final int alternativeId;
     property public final com.mapbox.navigation.core.routealternatives.AlternativeRouteIntersection forkIntersectionOfAlternativeRoute;
     property public final com.mapbox.navigation.core.routealternatives.AlternativeRouteIntersection forkIntersectionOfPrimaryRoute;
     property public final com.mapbox.navigation.core.routealternatives.AlternativeRouteInfo infoFromFork;
@@ -825,6 +830,9 @@ package com.mapbox.navigation.core.routealternatives {
 }
 
 package com.mapbox.navigation.core.routeoptions {
+
+  public final class RouteOptionsExKt {
+  }
 
   public final class RouteOptionsUpdater {
     ctor public RouteOptionsUpdater();

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -125,6 +125,7 @@ import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.navigation.utils.internal.logD
 import com.mapbox.navigation.utils.internal.logE
+import com.mapbox.navigation.utils.internal.logI
 import com.mapbox.navigation.utils.internal.monitorChannelWithException
 import com.mapbox.navigator.AlertsServiceOptions
 import com.mapbox.navigator.ConfigHandle
@@ -638,11 +639,38 @@ class MapboxNavigation @VisibleForTesting internal constructor(
 
     /**
      * Reset the session with the same configuration. The location becomes unknown,
-     * but the [NavigationOptions] stay the same. This can be used to transport the
-     * navigator to a new location.
+     * but the [NavigationOptions] stay the same.
+     *
+     * Call this function before significant change of location, e.g. when restarting
+     * navigation simulation, or before resetting location to not real (simulated)
+     * position without recreation of [MapboxNavigation].
      */
+    @Deprecated(message = "use a function withe the callback instead")
     fun resetTripSession() {
-        navigator.resetRideSession()
+        resetTripSession {
+            // no-op
+        }
+    }
+
+    /**
+     * Reset the session with the same configuration. The location becomes unknown,
+     * but the [NavigationOptions] stay the same.
+     *
+     * Call this function before significant change of location, e.g. when restarting
+     * navigation simulation, or before resetting location to not real (simulated)
+     * position without recreation of [MapboxNavigation].
+     */
+    fun resetTripSession(callback: TripSessionResetCallback) {
+        logD(LOG_CATEGORY) {
+            "Resetting trip session"
+        }
+        mainJobController.scope.launch(Dispatchers.Main.immediate) {
+            navigator.resetRideSession()
+            logI(LOG_CATEGORY) {
+                "Trip session reset"
+            }
+            callback.onTripSessionReset()
+        }
     }
 
     /**

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/TripSessionResetCallback.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/TripSessionResetCallback.kt
@@ -1,0 +1,12 @@
+package com.mapbox.navigation.core
+
+/**
+ * Callback invoked when [MapboxNavigation.resetTripSession] finishes.
+ */
+fun interface TripSessionResetCallback {
+    /**
+     * Invoked when resetting the trip finishes and the matching history is removed
+     * which can be helpful to transition the user to new location in simulated environments.
+     */
+    fun onTripSessionReset()
+}

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -333,7 +333,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         createMapboxNavigation()
         mapboxNavigation.onDestroy()
 
-        verify(exactly = 1) { navigator.resetRideSession() }
+        coVerify(exactly = 1) { navigator.resetRideSession() }
     }
 
     @Test
@@ -770,7 +770,16 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         createMapboxNavigation()
         mapboxNavigation.resetTripSession()
 
-        verify { navigator.resetRideSession() }
+        coVerify { navigator.resetRideSession() }
+    }
+
+    @Test
+    fun `resetTripSession should reset the navigator and call back`() {
+        createMapboxNavigation()
+        val callback = mockk<TripSessionResetCallback>(relaxUnitFun = true)
+        mapboxNavigation.resetTripSession(callback)
+
+        verify { callback.onTripSessionReset() }
     }
 
     @Test

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -17,7 +17,6 @@ import com.mapbox.navigator.FixLocation
 import com.mapbox.navigator.GraphAccessor
 import com.mapbox.navigator.HistoryRecorderHandle
 import com.mapbox.navigator.NavigationStatus
-import com.mapbox.navigator.NavigatorConfig
 import com.mapbox.navigator.NavigatorObserver
 import com.mapbox.navigator.PredictiveCacheController
 import com.mapbox.navigator.RoadObjectMatcher
@@ -57,12 +56,7 @@ interface MapboxNativeNavigator {
         router: RouterInterface,
     )
 
-    /**
-     * Reset the navigator state with the same configuration. The location becomes unknown,
-     * but the [NavigatorConfig] stays the same. This can be used to transport the
-     * navigator to a new location.
-     */
-    fun resetRideSession()
+    suspend fun resetRideSession()
 
     // Route following
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -121,8 +121,10 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
         }
     }
 
-    override fun resetRideSession() {
-        navigator!!.resetRideSession()
+    override suspend fun resetRideSession() = suspendCancellableCoroutine<Unit> {
+        navigator!!.reset {
+            it.resume(Unit)
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Removes usage of the deprecated `resetRideSession` and exposes a new one with a callback.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
