### PR TITLE
[Copilot] Fix / support both use cases in which `MapboxNavigationApp` is or is not integrated from the client side

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -137,6 +137,7 @@ ext {
       androidXLifecycleRuntime  : "androidx.lifecycle:lifecycle-runtime-ktx:${version.androidXLifecycle}",
       androidXLifecycleLivedata : "androidx.lifecycle:lifecycle-livedata-ktx:${version.androidXLifecycle}",
       androidXLifecycleViewmodel: "androidx.lifecycle:lifecycle-viewmodel-ktx:${version.androidXLifecycle}",
+      androidXLifecycleProcess  : "androidx.lifecycle:lifecycle-process:${version.androidXLifecycle}",
       androidXLifecycleTesting  : "androidx.lifecycle:lifecycle-runtime-testing:${version.androidXLifecycle}",
 
       // square crew

--- a/libnavigation-copilot/build.gradle
+++ b/libnavigation-copilot/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation dependenciesList.coroutinesAndroid
 
     implementation dependenciesList.androidXWorkManager
+    implementation dependenciesList.androidXLifecycleProcess
 
     testImplementation project(':libtesting-navigation-util')
     testImplementation project(':libtesting-utils')

--- a/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilot.kt
+++ b/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilot.kt
@@ -1,6 +1,9 @@
 package com.mapbox.navigation.copilot
 
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.copilot.MapboxCopilot.push
+import com.mapbox.navigation.copilot.MapboxCopilot.start
+import com.mapbox.navigation.copilot.MapboxCopilot.stop
 import com.mapbox.navigation.copilot.internal.PushStatusObserver
 import com.mapbox.navigation.core.DeveloperMetadataObserver
 import com.mapbox.navigation.core.MapboxNavigation
@@ -78,6 +81,9 @@ object MapboxCopilot : MapboxNavigationObserver {
      * @param mapboxNavigation instance that is being attached
      */
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        if (copilot != null) {
+            return
+        }
         copilot = MapboxCopilotImpl(mapboxNavigation).also { it.start() }
     }
 

--- a/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilotImpl.kt
+++ b/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilotImpl.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.copilot
 import android.content.pm.ApplicationInfo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.gson.Gson
 import com.mapbox.common.UploadOptions
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
@@ -109,15 +110,20 @@ internal class MapboxCopilotImpl(
     }
     private var initRoute = false
     private lateinit var routesObserver: RoutesObserver
+    private val isMapboxNavigationAppSetup = MapboxNavigationApp.isSetup()
 
     /**
      * start
      */
     fun start() {
         registerUserFeedbackCallback(userFeedbackCallback)
-        MapboxNavigationApp.lifecycleOwner.lifecycle.addObserver(
-            foregroundBackgroundLifecycleObserver
-        )
+        if (isMapboxNavigationAppSetup) {
+            MapboxNavigationApp.lifecycleOwner.lifecycle.addObserver(
+                foregroundBackgroundLifecycleObserver
+            )
+        } else {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(foregroundBackgroundLifecycleObserver)
+        }
         mapboxNavigation.registerHistoryRecordingStateChangeObserver(
             historyRecordingStateChangeObserver
         )
@@ -128,9 +134,15 @@ internal class MapboxCopilotImpl(
      */
     fun stop() {
         unregisterUserFeedbackCallback(userFeedbackCallback)
-        MapboxNavigationApp.lifecycleOwner.lifecycle.removeObserver(
-            foregroundBackgroundLifecycleObserver
-        )
+        if (isMapboxNavigationAppSetup) {
+            MapboxNavigationApp.lifecycleOwner.lifecycle.removeObserver(
+                foregroundBackgroundLifecycleObserver
+            )
+        } else {
+            ProcessLifecycleOwner.get().lifecycle.removeObserver(
+                foregroundBackgroundLifecycleObserver
+            )
+        }
         mapboxNavigation.unregisterHistoryRecordingStateChangeObserver(
             historyRecordingStateChangeObserver
         )

--- a/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/CopilotTestUtils.kt
+++ b/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/CopilotTestUtils.kt
@@ -1,13 +1,29 @@
 package com.mapbox.navigation.copilot
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
 
-object CopilotTestUtils {
+internal object CopilotTestUtils {
 
-    internal fun retrieveAttachments(metadata: String): List<AttachmentMetadata> {
+    fun retrieveAttachments(metadata: String): List<AttachmentMetadata> {
         val gson = Gson()
         val itemType = object : TypeToken<List<AttachmentMetadata>>() {}.type
         return gson.fromJson(metadata, itemType)
+    }
+
+    fun prepareLifecycleOwnerMockk(): LifecycleOwner {
+        mockkStatic(MapboxNavigationApp::class)
+        every { MapboxNavigationApp.isSetup() } returns true
+        val mockedLifecycleOwner = mockk<LifecycleOwner>(relaxed = true)
+        val mockedLifecycle = mockk<Lifecycle>(relaxed = true)
+        every { mockedLifecycleOwner.lifecycle } returns mockedLifecycle
+        every { MapboxNavigationApp.lifecycleOwner } returns mockedLifecycleOwner
+        return mockedLifecycleOwner
     }
 }

--- a/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/MapboxCopilotTest.kt
+++ b/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/MapboxCopilotTest.kt
@@ -1,0 +1,136 @@
+package com.mapbox.navigation.copilot
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.copilot.CopilotTestUtils.prepareLifecycleOwnerMockk
+import com.mapbox.navigation.core.MapboxNavigation
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Test
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class MapboxCopilotTest {
+
+    private val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+
+    @After
+    fun teardown() {
+        MapboxCopilot.onDetached(mockedMapboxNavigation)
+        unmockkAll()
+    }
+
+    @Test
+    fun `onAttached starts MapboxCopilotImpl`() {
+        prepareLifecycleOwnerMockk()
+        prepareMapboxCopilotImplStart()
+
+        MapboxCopilot.onAttached(mockedMapboxNavigation)
+
+        verify(exactly = 1) {
+            anyConstructed<MapboxCopilotImpl>().start()
+        }
+    }
+
+    @Test
+    fun `start is called only once if onAttached is called multiple times`() {
+        prepareLifecycleOwnerMockk()
+        prepareMapboxCopilotImplStart()
+
+        MapboxCopilot.onAttached(mockedMapboxNavigation)
+        MapboxCopilot.onAttached(mockedMapboxNavigation)
+        MapboxCopilot.onAttached(mockedMapboxNavigation)
+
+        verify(exactly = 1) {
+            anyConstructed<MapboxCopilotImpl>().start()
+        }
+    }
+
+    @Test
+    fun `onDetached stops MapboxCopilotImpl`() {
+        prepareLifecycleOwnerMockk()
+        prepareMapboxCopilotImplStart()
+        every { anyConstructed<MapboxCopilotImpl>().stop() } just Runs
+        MapboxCopilot.onAttached(mockedMapboxNavigation)
+
+        MapboxCopilot.onDetached(mockedMapboxNavigation)
+
+        verify(exactly = 1) {
+            anyConstructed<MapboxCopilotImpl>().stop()
+        }
+    }
+
+    @Test
+    fun `MapboxCopilotImpl stop is called only once if onDetached is called multiple times`() {
+        prepareLifecycleOwnerMockk()
+        val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        prepareMapboxCopilotImplStart()
+        every { anyConstructed<MapboxCopilotImpl>().stop() } just Runs
+        MapboxCopilot.onAttached(mockedMapboxNavigation)
+
+        MapboxCopilot.onDetached(mockedMapboxNavigation)
+        MapboxCopilot.onDetached(mockedMapboxNavigation)
+        MapboxCopilot.onDetached(mockedMapboxNavigation)
+
+        verify(exactly = 1) {
+            anyConstructed<MapboxCopilotImpl>().stop()
+        }
+    }
+
+    @Test
+    fun `events are pushed if MapboxCopilotImpl is started`() {
+        prepareLifecycleOwnerMockk()
+        val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        prepareMapboxCopilotImplStart()
+        val mockedHistoryEvent = mockk<HistoryEvent>(relaxed = true)
+        every { anyConstructed<MapboxCopilotImpl>().push(any()) } just Runs
+        MapboxCopilot.onAttached(mockedMapboxNavigation)
+
+        MapboxCopilot.push(mockedHistoryEvent)
+
+        verify(exactly = 1) {
+            anyConstructed<MapboxCopilotImpl>().push(eq(mockedHistoryEvent))
+        }
+    }
+
+    @Test
+    fun `events are not pushed if MapboxCopilotImpl is not started`() {
+        prepareLifecycleOwnerMockk()
+        prepareMapboxCopilotImplStart()
+        val mockedHistoryEvent = mockk<HistoryEvent>(relaxed = true)
+        every { anyConstructed<MapboxCopilotImpl>().push(any()) } just Runs
+
+        MapboxCopilot.push(mockedHistoryEvent)
+
+        verify(exactly = 0) {
+            anyConstructed<MapboxCopilotImpl>().push(eq(mockedHistoryEvent))
+        }
+    }
+
+    @Test
+    fun `events are not pushed after MapboxCopilotImpl is stopped`() {
+        prepareLifecycleOwnerMockk()
+        val mockedMapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+        prepareMapboxCopilotImplStart()
+        val mockedHistoryEvent = mockk<HistoryEvent>(relaxed = true)
+        every { anyConstructed<MapboxCopilotImpl>().stop() } just Runs
+        every { anyConstructed<MapboxCopilotImpl>().push(any()) } just Runs
+        MapboxCopilot.onAttached(mockedMapboxNavigation)
+
+        MapboxCopilot.onDetached(mockedMapboxNavigation)
+        MapboxCopilot.push(mockedHistoryEvent)
+
+        verify(exactly = 0) {
+            anyConstructed<MapboxCopilotImpl>().push(eq(mockedHistoryEvent))
+        }
+    }
+
+    private fun prepareMapboxCopilotImplStart() {
+        mockkConstructor(MapboxCopilotImpl::class)
+        every { anyConstructed<MapboxCopilotImpl>().start() } just Runs
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Fixes / supports both use cases in which `MapboxNavigationApp` is or is not integrated from the client side using either `MapboxNavigationApp`s `LifecycleOwner` or `ProcessLifecycleOwner` based on if `MapboxNavigationApp` `isSetup` or not respectively.
