### PR TITLE
Fixed memory leak in ReplayProgressObserver on route refresh NN-308

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed an issue where `RouteProgress#VoiceInstructions` could've become `null` when `MapboxNavigation#updateLegIndex` was called. [#6689](https://github.com/mapbox/mapbox-navigation-android/pull/6689)
 - Fixed `BannerInstructions` issue where the banner instruction might have been removed from `RouteProgress` at some point around a edge's leg. [#6684](https://github.com/mapbox/mapbox-navigation-android/pull/6684)
 - Added `MapboxNavigation#resetTripSession(callback)` and deprecated the counterpart without a callback. [#6685](https://github.com/mapbox/mapbox-navigation-android/pull/6685)
+- Fixed memory leak in `ReplayProgressObserver` which happened after route refresh. [#6691](https://github.com/mapbox/mapbox-navigation-android/pull/6691)
 
 ## Mapbox Navigation SDK 2.10.0-beta.2 - 01 December, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserver.kt
@@ -26,7 +26,8 @@ class ReplayProgressObserver @JvmOverloads constructor(
     private val replayRouteMapper: ReplayRouteMapper = ReplayRouteMapper()
 ) : RouteProgressObserver {
 
-    private var currentRouteLeg: RouteLeg? = null
+    private var lastRouteId: String? = null
+    private var currentLegIndex: Int? = null
 
     /**
      * @param options allow you to control the driver and car behavior.
@@ -47,8 +48,13 @@ class ReplayProgressObserver @JvmOverloads constructor(
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
         val currentLegProgress = routeProgress.currentLegProgress
         val routeProgressRouteLeg = currentLegProgress?.routeLeg
-        if (routeProgressRouteLeg != currentRouteLeg && currentLegProgress != null) {
-            this.currentRouteLeg = routeProgressRouteLeg
+        val routeId = routeProgress.navigationRoute.id
+        val legIndex = currentLegProgress?.legIndex
+        if ((this.lastRouteId != routeId || this.currentLegIndex != legIndex) &&
+            currentLegProgress != null
+        ) {
+            this.lastRouteId = routeId
+            this.currentLegIndex = legIndex
             onRouteLegChanged(routeProgressRouteLeg, currentLegProgress.distanceTraveled)
         }
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserver.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserver.kt
@@ -26,8 +26,7 @@ class ReplayProgressObserver @JvmOverloads constructor(
     private val replayRouteMapper: ReplayRouteMapper = ReplayRouteMapper()
 ) : RouteProgressObserver {
 
-    private var lastRouteId: String? = null
-    private var currentLegIndex: Int? = null
+    private var currentLegIdentifier: RouteLegIdentifier? = null
 
     /**
      * @param options allow you to control the driver and car behavior.
@@ -48,13 +47,9 @@ class ReplayProgressObserver @JvmOverloads constructor(
     override fun onRouteProgressChanged(routeProgress: RouteProgress) {
         val currentLegProgress = routeProgress.currentLegProgress
         val routeProgressRouteLeg = currentLegProgress?.routeLeg
-        val routeId = routeProgress.navigationRoute.id
-        val legIndex = currentLegProgress?.legIndex
-        if ((this.lastRouteId != routeId || this.currentLegIndex != legIndex) &&
-            currentLegProgress != null
-        ) {
-            this.lastRouteId = routeId
-            this.currentLegIndex = legIndex
+        val legIdentifier = routeProgress.getCurrentRouteLegIdentifier()
+        if (currentLegIdentifier != legIdentifier && currentLegProgress != null) {
+            currentLegIdentifier = legIdentifier
             onRouteLegChanged(routeProgressRouteLeg, currentLegProgress.distanceTraveled)
         }
     }
@@ -100,4 +95,13 @@ class ReplayProgressObserver @JvmOverloads constructor(
         }
         return index
     }
+}
+
+private data class RouteLegIdentifier(
+    val routeId: String,
+    val legIndex: Int
+)
+
+private fun RouteProgress.getCurrentRouteLegIdentifier(): RouteLegIdentifier? {
+    return currentLegProgress?.let { RouteLegIdentifier(this.navigationRoute.id, it.legIndex) }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
@@ -59,15 +59,16 @@ class ReplayProgressObserverTest {
         val refreshedRoute = testRoute.update(
             directionsRouteBlock = {
                 this.toBuilder()
-                    .legs(this.legs()?.map {
-                        it.toBuilder()
-                            .annotation(
-                                createRouteLegAnnotation(
-                                    congestionNumeric = listOf(25, 84)
+                    .legs(
+                        this.legs()?.map {
+                            it.toBuilder()
+                                .annotation(
+                                    createRouteLegAnnotation(
+                                        congestionNumeric = listOf(25, 84)
+                                    )
                                 )
-                            )
-                            .build()
-                    }
+                                .build()
+                        }
                     )
                     .build()
             },

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
@@ -2,13 +2,14 @@ package com.mapbox.navigation.core.replay.route
 
 import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.geojson.utils.PolylineUtils
-import com.mapbox.navigation.base.internal.route.refreshRoute
 import com.mapbox.navigation.base.internal.route.update
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.history.ReplayEventBase
 import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
+import com.mapbox.navigation.testing.factories.createDirectionsResponse
+import com.mapbox.navigation.testing.factories.createDirectionsRoute
 import com.mapbox.navigation.testing.factories.createNavigationRoutes
 import com.mapbox.navigation.testing.factories.createRouteLeg
 import com.mapbox.navigation.testing.factories.createRouteLegAnnotation
@@ -34,7 +35,7 @@ class ReplayProgressObserverTest {
         every { replayRouteMapper.mapRouteLegGeometry(any()) } returns mockEventsForShortRoute()
 
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgress(mockk(), mockDistanceTraveled = 0.0f)
+            mockValidRouteProgress(mockDistanceTraveled = 0.0f)
         )
 
         verifyOrder {
@@ -50,17 +51,24 @@ class ReplayProgressObserverTest {
 
         val testRoute = createNavigationRoutes()[0]
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgressWithRoute(testRoute, 0, mockDistanceTraveled = 10.0f)
+            mockValidRouteProgress(testRoute, 0, mockDistanceTraveled = 10.0f)
         )
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgressWithRoute(testRoute, 0, mockDistanceTraveled = 50.0f)
+            mockValidRouteProgress(testRoute, 0, mockDistanceTraveled = 50.0f)
         )
         val refreshedRoute = testRoute.update(
             directionsRouteBlock = {
                 this.toBuilder()
                     .legs(this.legs()?.map {
                         it.toBuilder()
-                            .annotation(createRouteLegAnnotation(congestionNumeric = listOf(25, 84))).build() })
+                            .annotation(
+                                createRouteLegAnnotation(
+                                    congestionNumeric = listOf(25, 84)
+                                )
+                            )
+                            .build()
+                    }
+                    )
                     .build()
             },
             directionsResponseBlock = {
@@ -68,7 +76,7 @@ class ReplayProgressObserverTest {
             }
         )
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgressWithRoute(refreshedRoute, 0, mockDistanceTraveled = 55.0f)
+            mockValidRouteProgress(refreshedRoute, 0, mockDistanceTraveled = 55.0f)
         )
 
         verify(exactly = 1) {
@@ -81,12 +89,30 @@ class ReplayProgressObserverTest {
     @Test
     fun `should push new events for new route leg`() {
         every { replayRouteMapper.mapRouteLegGeometry(any()) } returns mockEventsForShortRoute()
-
+        val firstRouteLeg: RouteLeg = createRouteLeg()
+        val secondRouteLeg: RouteLeg = createRouteLeg()
+        val testRoute = createNavigationRoutes(
+            response = createDirectionsResponse(
+                routes = listOf(
+                    createDirectionsRoute(
+                        legs = listOf(firstRouteLeg, secondRouteLeg)
+                    )
+                )
+            )
+        ).first()
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgress(mockk(), mockDistanceTraveled = 10.0f)
+            mockValidRouteProgress(
+                route = testRoute,
+                currentLegIndex = 0,
+                mockDistanceTraveled = 10.0f
+            )
         )
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgress(mockk(), mockDistanceTraveled = 50.0f)
+            mockValidRouteProgress(
+                route = testRoute,
+                currentLegIndex = 1,
+                mockDistanceTraveled = 50.0f
+            )
         )
 
         verify(exactly = 2) {
@@ -107,7 +133,7 @@ class ReplayProgressObserverTest {
         every { mapboxReplayer.seekTo(capture(seekToSlot)) } just Runs
 
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgress(mockk(), 0.0f)
+            mockValidRouteProgress(mockDistanceTraveled = 0.0f)
         )
 
         // Seek to first location because 0.0 distance traveled
@@ -127,7 +153,7 @@ class ReplayProgressObserverTest {
         every { mapboxReplayer.seekTo(capture(seekToSlot)) } just Runs
 
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgress(mockk(), 90.0f)
+            mockValidRouteProgress(mockDistanceTraveled = 90.0f)
         )
 
         // Seek to the 3rd event timestamp because 90 meters has been traveled
@@ -145,7 +171,7 @@ class ReplayProgressObserverTest {
         every { mapboxReplayer.seekTo(capture(seekToSlot)) } just Runs
 
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgress(mockk(), 90.0f)
+            mockValidRouteProgress(mockDistanceTraveled = 90.0f)
         )
 
         assertFalse(eventsSlot.isCaptured)
@@ -154,8 +180,17 @@ class ReplayProgressObserverTest {
 
     @Test
     fun `should seekTo alternative route with distanceTraveled`() {
-        val firstRouteLeg: RouteLeg = mockk()
-        val secondRouteLeg: RouteLeg = mockk()
+        val firstRouteLeg: RouteLeg = createRouteLeg()
+        val secondRouteLeg: RouteLeg = createRouteLeg()
+        val testRoute = createNavigationRoutes(
+            response = createDirectionsResponse(
+                routes = listOf(
+                    createDirectionsRoute(
+                        legs = listOf(firstRouteLeg, secondRouteLeg)
+                    )
+                )
+            )
+        ).first()
         every { replayRouteMapper.mapRouteLegGeometry(firstRouteLeg) } returns mockEvents(
             """yg{bgA|cufhFoEiAiA[}i@oNoD_As@QqdAeX"""
         )
@@ -168,10 +203,18 @@ class ReplayProgressObserverTest {
         every { mapboxReplayer.seekTo(capture(seekToSlot)) } just Runs
 
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgress(firstRouteLeg, 0.0f)
+            mockValidRouteProgress(
+                route = testRoute,
+                currentLegIndex = 0,
+                mockDistanceTraveled = 0.0f
+            )
         )
         replayProgressObserver.onRouteProgressChanged(
-            mockValidRouteProgress(secondRouteLeg, 90.0f)
+            mockValidRouteProgress(
+                route = testRoute,
+                currentLegIndex = 1,
+                mockDistanceTraveled = 90.0f
+            )
         )
 
         val alternativeRouteEvents = eventsSlot[1]
@@ -182,19 +225,9 @@ class ReplayProgressObserverTest {
     }
 
     private fun mockValidRouteProgress(
-        mockRouteLeg: RouteLeg,
-        mockDistanceTraveled: Float
-    ): RouteProgress = mockk {
-        every { currentLegProgress } returns mockk {
-            every { routeLeg } returns mockRouteLeg
-            every { distanceTraveled } returns mockDistanceTraveled
-        }
-    }
-
-    private fun mockValidRouteProgressWithRoute(
-        route: NavigationRoute,
-        currentLegIndex: Int,
-        mockDistanceTraveled: Float
+        route: NavigationRoute = createNavigationRoutes().first(),
+        currentLegIndex: Int = 0,
+        mockDistanceTraveled: Float = 0.0f
     ): RouteProgress = mockk {
         every { navigationRoute } returns route
         every { currentLegProgress } returns mockk {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayProgressObserverTest.kt
@@ -8,8 +8,8 @@ import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.history.ReplayEventBase
 import com.mapbox.navigation.core.replay.history.ReplayEventUpdateLocation
-import com.mapbox.navigation.testing.factories.createDirectionsResponse
 import com.mapbox.navigation.testing.factories.createDirectionsRoute
+import com.mapbox.navigation.testing.factories.createNavigationRoute
 import com.mapbox.navigation.testing.factories.createNavigationRoutes
 import com.mapbox.navigation.testing.factories.createRouteLeg
 import com.mapbox.navigation.testing.factories.createRouteLegAnnotation
@@ -91,15 +91,11 @@ class ReplayProgressObserverTest {
         every { replayRouteMapper.mapRouteLegGeometry(any()) } returns mockEventsForShortRoute()
         val firstRouteLeg: RouteLeg = createRouteLeg()
         val secondRouteLeg: RouteLeg = createRouteLeg()
-        val testRoute = createNavigationRoutes(
-            response = createDirectionsResponse(
-                routes = listOf(
-                    createDirectionsRoute(
-                        legs = listOf(firstRouteLeg, secondRouteLeg)
-                    )
-                )
+        val testRoute = createNavigationRoute(
+            directionsRoute = createDirectionsRoute(
+                legs = listOf(firstRouteLeg, secondRouteLeg)
             )
-        ).first()
+        )
         replayProgressObserver.onRouteProgressChanged(
             mockValidRouteProgress(
                 route = testRoute,
@@ -182,15 +178,11 @@ class ReplayProgressObserverTest {
     fun `should seekTo alternative route with distanceTraveled`() {
         val firstRouteLeg: RouteLeg = createRouteLeg()
         val secondRouteLeg: RouteLeg = createRouteLeg()
-        val testRoute = createNavigationRoutes(
-            response = createDirectionsResponse(
-                routes = listOf(
-                    createDirectionsRoute(
-                        legs = listOf(firstRouteLeg, secondRouteLeg)
-                    )
-                )
+        val testRoute = createNavigationRoute(
+            directionsRoute = createDirectionsRoute(
+                legs = listOf(firstRouteLeg, secondRouteLeg)
             )
-        ).first()
+        )
         every { replayRouteMapper.mapRouteLegGeometry(firstRouteLeg) } returns mockEvents(
             """yg{bgA|cufhFoEiAiA[}i@oNoD_As@QqdAeX"""
         )
@@ -225,7 +217,7 @@ class ReplayProgressObserverTest {
     }
 
     private fun mockValidRouteProgress(
-        route: NavigationRoute = createNavigationRoutes().first(),
+        route: NavigationRoute = createNavigationRoute(),
         currentLegIndex: Int = 0,
         mockDistanceTraveled: Float = 0.0f
     ): RouteProgress = mockk {

--- a/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
+++ b/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
@@ -20,10 +20,11 @@ fun createNavigationRoute(
 ): NavigationRoute {
     return createNavigationRoutes(
         response = createDirectionsResponse(
-            routes = listOf(directionsRoute)
+            routes = listOf(directionsRoute),
+            uuid = directionsRoute.requestUuid()
         ),
         routesInfoMapper = { routeInfo },
-        waypointsMapper = { waypoints }
+        waypointsMapper = { waypoints },
     ).first()
 }
 

--- a/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
+++ b/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/factories/NavigationRouteFactory.kt
@@ -22,8 +22,8 @@ fun createNavigationRoute(
         response = createDirectionsResponse(
             routes = listOf(directionsRoute)
         ),
-        routesInfoMapper = { _ -> routeInfo },
-        waypointsMapper = { _ -> waypoints }
+        routesInfoMapper = { routeInfo },
+        waypointsMapper = { waypoints }
     ).first()
 }
 
@@ -31,8 +31,8 @@ fun createNavigationRoutes(
     response: DirectionsResponse = createDirectionsResponse(),
     options: RouteOptions = response.routes().first().routeOptions()!!,
     routerOrigin: RouterOrigin = RouterOrigin.Offboard,
-    routesInfoMapper: (DirectionsRoute) -> RouteInfo = { _ -> createRouteInfo() },
-    waypointsMapper: (DirectionsRoute) -> List<Waypoint> = { _ -> createWaypoints() }
+    routesInfoMapper: (DirectionsRoute) -> RouteInfo = { createRouteInfo() },
+    waypointsMapper: (DirectionsRoute) -> List<Waypoint> = { createWaypoints() }
 ): List<NavigationRoute> {
     val parser = TestSDKRouteParser(
         routesInfoMapper = routesInfoMapper,
@@ -47,8 +47,8 @@ fun createNavigationRoutes(
 }
 
 class TestSDKRouteParser(
-    private val routesInfoMapper: (DirectionsRoute) -> RouteInfo = { _ -> createRouteInfo() },
-    private val waypointsMapper: (DirectionsRoute) -> List<Waypoint> = { _ -> createWaypoints() }
+    private val routesInfoMapper: (DirectionsRoute) -> RouteInfo = { createRouteInfo() },
+    private val waypointsMapper: (DirectionsRoute) -> List<Waypoint> = { createWaypoints() }
 ) : SDKRouteParser {
     override fun parseDirectionsResponse(
         response: String,
@@ -70,8 +70,8 @@ fun createRouteInterfacesFromDirectionRequestResponse(
     requestUri: String,
     response: String,
     routerOrigin: RouterOrigin = RouterOrigin.Offboard,
-    routesInfoMapper: (DirectionsRoute) -> RouteInfo = { _ -> createRouteInfo() },
-    waypointsMapper: (DirectionsRoute) -> List<Waypoint> = { _ -> createWaypoints() }
+    routesInfoMapper: (DirectionsRoute) -> RouteInfo = { createRouteInfo() },
+    waypointsMapper: (DirectionsRoute) -> List<Waypoint> = { createWaypoints() }
 ): List<RouteInterface> {
     return DirectionsResponse.fromJson(response).routes()
         .map { directionsRoute ->

--- a/libtesting-thirdparty/src/main/java/com/mapbox/navigation/testing/factories/DirectionsResponseFactories.kt
+++ b/libtesting-thirdparty/src/main/java/com/mapbox/navigation/testing/factories/DirectionsResponseFactories.kt
@@ -23,7 +23,7 @@ import com.mapbox.api.directions.v5.models.StepManeuver
 import com.mapbox.geojson.Point
 
 fun createDirectionsResponse(
-    uuid: String = "testUUID",
+    uuid: String? = "testUUID",
     routes: List<DirectionsRoute> = listOf(createDirectionsRoute()),
     unrecognizedProperties: Map<String, JsonElement>? = null,
 ): DirectionsResponse {


### PR DESCRIPTION
`ReplayProgressObserver` creates and pushes events for a new route leg when it changes. It identifies switch to a new route leg by comparing saved route leg with the one from `RouteProgress`. `RouteLeg` object stops being equal when annotations changes during route refresh. This makes `ReplayProgressOberver` to think that route leg has changed and it generates and appends new events. There are so many events for a long route that it causes OOM. 

Fix is tested on the long route in 1tap which used to be crash with java OOM pretty fast. See NN-308 for more details