### PR TITLE
fix reroute interruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed `BannerInstructions` issue where the banner instruction might have been removed from `RouteProgress` at some point around a edge's leg. [#6684](https://github.com/mapbox/mapbox-navigation-android/pull/6684)
 - Added `MapboxNavigation#resetTripSession(callback)` and deprecated the counterpart without a callback. [#6685](https://github.com/mapbox/mapbox-navigation-android/pull/6685)
 - Fixed memory leak in `ReplayProgressObserver` which happened after route refresh. [#6691](https://github.com/mapbox/mapbox-navigation-android/pull/6691)
+- Fixed a rare issue where a reroute relative to old routes might have occurred after setting new routes. [#6693](https://github.com/mapbox/mapbox-navigation-android/pull/6693)
 
 ## Mapbox Navigation SDK 2.9.4 - 08 December, 2022
 ### Changelog


### PR DESCRIPTION
The problem was that there was a probability that even though we cancel the reroute request using `MapboxRerouteController#interrupt`, we might still get the result value in callback (`onNewRoutes`) afterwards. Which might have happened for various reasons:
1) The native callback is invoked right before we cancel the request, but before we pass the routes to `MapboxNavigation` in a new coroutine, new routes are set (entering `routeUpdateMutex.withLock`);
2) The native callback is invoked right after we cancel the request. That's probably related to multithreading and it doesn't seem right but the proposed solution accounts for this reason as well.

Now everything will be properly cancelled and we won't receive any values after interrupting the request.