### PR TITLE
Fix for SAPA map presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Mapbox welcomes participation and contributions from everyone.
 - :warning: Deprecated `MapboxSpeedLimitApi` and `MapboxSpeedLimitView`. [#6687](https://github.com/mapbox/mapbox-navigation-android/pull/6687)
 #### Bug fixes and improvements
 - Fixed approaches list update in `RouteOptionsUpdater`(uses for reroute). It was putting to the origin approach corresponding approach from legacy approach list. [#6540](https://github.com/mapbox/mapbox-navigation-android/pull/6540)
+- Updated the `MapboxRestAreaApi` logic to load a SAPA map only if the upcoming rest stop is at the current step of the route leg. [#6695](https://github.com/mapbox/mapbox-navigation-android/pull/6695)
 
 ## Mapbox Navigation SDK 2.10.0-beta.3 - 08 December, 2022
 ### Changelog

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/restarea/RestAreaProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/guidance/restarea/RestAreaProcessorTest.kt
@@ -3,21 +3,47 @@ package com.mapbox.navigation.ui.maps.guidance.restarea
 import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.api.directions.v5.models.BannerView
+import com.mapbox.api.directions.v5.models.LegStep
+import com.mapbox.api.directions.v5.models.RestStop
+import com.mapbox.api.directions.v5.models.StepIntersection
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory.createValue
 import com.mapbox.common.ResourceData
 import com.mapbox.common.ResourceLoadError
 import com.mapbox.common.ResourceLoadResult
 import com.mapbox.common.ResourceLoadStatus
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
+import com.mapbox.navigation.base.internal.factory.RoadObjectFactory.buildRoadObject
+import com.mapbox.navigation.base.internal.factory.RoadObjectFactory.buildUpcomingRoadObject
+import com.mapbox.navigation.base.internal.factory.RouteProgressFactory.buildRouteProgressObject
+import com.mapbox.navigation.base.trip.model.RouteLegProgress
+import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
+import com.mapbox.navigation.base.trip.model.RouteStepProgress
+import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
 import com.mapbox.navigation.ui.maps.guidance.restarea.model.MapboxRestAreaOptions
 import com.mapbox.navigation.ui.utils.internal.SvgUtil
+import com.mapbox.navigator.Amenity
+import com.mapbox.navigator.AmenityType
+import com.mapbox.navigator.GraphPosition
+import com.mapbox.navigator.MatchedRoadObjectLocation
+import com.mapbox.navigator.Position
+import com.mapbox.navigator.RoadObject
+import com.mapbox.navigator.RoadObjectMetadata
+import com.mapbox.navigator.RoadObjectProvider
+import com.mapbox.navigator.RoadObjectType
+import com.mapbox.navigator.ServiceAreaInfo
+import com.mapbox.navigator.ServiceAreaType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.util.Date
+import java.util.*
 
 class RestAreaProcessorTest {
 
@@ -202,6 +228,162 @@ class RestAreaProcessorTest {
         unmockkObject(SvgUtil)
     }
 
+    @Test
+    @Suppress("MaxLineLength")
+    fun `process CheckUpcomingRestStop should return SAPA map url if upcoming rest stop is on current step`() {
+        val restAreaLocation = Point.fromLngLat(1.0, 2.0)
+        val restAreaMapUri = "http://example.com/rest-area-map/1.png"
+        val nativeRestAreaObject = nativeRestAreaObjectWith(
+            name = "rest-area-1",
+            location = restAreaLocation,
+            mapUri = restAreaMapUri
+        )
+
+        val routeProgress = routeProgressWith(
+            currentLegStep = legStepWith(
+                intersections = listOf(
+                    StepIntersection.builder()
+                        .rawLocation(restAreaLocation.coordinates().toDoubleArray())
+                        .restStop(
+                            RestStop.builder()
+                                .type("rest_area")
+                                .name("my rest area")
+                                .build()
+                        )
+                        .build()
+                )
+            ),
+            upcomingRoadObjects = listOf<UpcomingRoadObject>(
+                buildUpcomingRoadObject(
+                    roadObject = buildRoadObject(nativeRestAreaObject),
+                    distanceToStart = 1.0,
+                    distanceInfo = null
+                )
+            )
+        )
+
+        val result = RestAreaProcessor.process(
+            RestAreaAction.CheckUpcomingRestStop(routeProgress)
+        ) as? RestAreaResult.RestAreaMapAvailable
+
+        assertNotNull("expected RestAreaResult.RestAreaMapAvailable", result)
+        assertEquals(restAreaMapUri, result?.sapaMapUrl)
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `process CheckUpcomingRestStop should NOT return SAPA map url if upcoming rest stop is NOT on current step`() {
+        val restAreaLocation = Point.fromLngLat(1.0, 2.0)
+        val restAreaMapUri = "http://example.com/rest-area-map/1.png"
+        val nativeRestAreaObject = nativeRestAreaObjectWith(
+            name = "rest-area-1",
+            location = restAreaLocation,
+            mapUri = restAreaMapUri
+        )
+
+        val routeProgress = routeProgressWith(
+            currentLegStep = legStepWith(
+                intersections = listOf(
+                    StepIntersection.builder()
+                        .rawLocation(
+                            Point.fromLngLat(0.0, 0.0)
+                                .coordinates()
+                                .toDoubleArray()
+                        )
+                        .build()
+                )
+            ),
+            upcomingRoadObjects = listOf<UpcomingRoadObject>(
+                buildUpcomingRoadObject(
+                    roadObject = buildRoadObject(nativeRestAreaObject),
+                    distanceToStart = 1.0,
+                    distanceInfo = null
+                )
+            )
+        )
+
+        val result = RestAreaProcessor.process(
+            RestAreaAction.CheckUpcomingRestStop(routeProgress)
+        )
+
+        assertTrue(
+            "expected RestAreaResult.RestAreaMapUnavailable",
+            result is RestAreaResult.RestAreaMapUnavailable
+        )
+    }
+
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
+    private fun routeProgressWith(
+        currentLegStep: LegStep,
+        upcomingRoadObjects: List<UpcomingRoadObject>
+    ): RouteProgress = buildRouteProgressObject(
+        route = mockk(),
+        bannerInstructions = null,
+        voiceInstructions = null,
+        currentState = RouteProgressState.TRACKING,
+        currentLegProgress = mockk<RouteLegProgress> {
+            every { legIndex } returns 0
+            every { routeLeg } returns null
+            every { distanceTraveled } returns 0f
+            every { distanceRemaining } returns 100f
+            every { durationRemaining } returns 123.0
+            every { fractionTraveled } returns 0.1f
+            every { currentStepProgress } returns mockk<RouteStepProgress> {
+                every { step } returns currentLegStep
+            }
+            every { upcomingStep } returns null
+            every { geometryIndex } returns 0
+        },
+        upcomingStepPoints = null,
+        inTunnel = false,
+        distanceRemaining = 100f,
+        distanceTraveled = 10f,
+        durationRemaining = 123.0,
+        fractionTraveled = 0.1f,
+        remainingWaypoints = 0,
+        upcomingRoadObjects = upcomingRoadObjects,
+        stale = false,
+        alternativeRouteId = null,
+        currentRouteGeometryIndex = 0
+    )
+
+    private fun nativeRestAreaObjectWith(name: String, location: Point, mapUri: String) =
+        RoadObject(
+            name,
+            0.0,
+            MatchedRoadObjectLocation(
+                NativeStub.MatchedPointLocation(
+                    Position(
+                        GraphPosition(1, 0.0),
+                        location
+                    )
+                )
+            ),
+            RoadObjectType.SERVICE_AREA,
+            RoadObjectProvider.MAPBOX,
+            RoadObjectMetadata(
+                ServiceAreaInfo(
+                    ServiceAreaType.REST_AREA,
+                    name,
+                    listOf(
+                        Amenity(AmenityType.GAS_STATION, "Get GAS", "FuelItUp")
+                    ),
+                    mapUri
+                )
+            ),
+            true
+        )
+
+    private fun legStepWith(intersections: List<StepIntersection>): LegStep =
+        LegStep.builder()
+            .distance(100.0)
+            .duration(123.0)
+            .mode("driving")
+            .maneuver(mockk())
+            .weight(1.0)
+            .intersections(intersections)
+            .build()
+
     private fun getComponentGuidanceViewType(): BannerComponents {
         return BannerComponents.builder()
             .type(BannerComponents.GUIDANCE_VIEW)
@@ -252,5 +434,13 @@ class RestAreaProcessorTest {
             transferredBytes,
             contentType
         )
+    }
+
+    object NativeStub {
+        class MatchedPointLocation(
+            private val pos: Position
+        ) : com.mapbox.navigator.MatchedPointLocation(0) {
+            override fun getPosition(): Position = pos
+        }
     }
 }

--- a/qa-test-app/src/main/AndroidManifest.xml
+++ b/qa-test-app/src/main/AndroidManifest.xml
@@ -79,6 +79,9 @@
         <activity android:name=".view.RoutesPreviewActivity" />
         <activity android:name=".view.SpeedInfoActivity"
             android:theme="@style/Theme.Fullscreen" />
+        <activity
+            android:name=".view.componentinstaller.RestAreaActivity"
+            android:theme="@style/Theme.AppCompat.NoActionBar" />
     </application>
 
 </manifest>

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -30,6 +30,7 @@ import com.mapbox.navigation.qa_test_app.view.TripOverviewActivity
 import com.mapbox.navigation.qa_test_app.view.UpcomingRoadObjectsActivity
 import com.mapbox.navigation.qa_test_app.view.componentinstaller.ComponentsActivity
 import com.mapbox.navigation.qa_test_app.view.componentinstaller.ComponentsAltActivity
+import com.mapbox.navigation.qa_test_app.view.componentinstaller.RestAreaActivity
 import com.mapbox.navigation.qa_test_app.view.customnavview.MapboxNavigationViewCustomizedActivity
 import com.mapbox.navigation.qa_test_app.view.main.SelectDestinationDialogFragment
 import com.mapbox.navigation.qa_test_app.view.util.RouteDrawingActivity
@@ -233,6 +234,13 @@ object TestActivitySuite {
             R.string.speed_info_activity_description
         ) { activity ->
             activity.startActivity<SpeedInfoActivity>()
+        },
+        TestActivityDescription(
+            "Rest Area Example",
+            R.string.rest_area_activity_description,
+            category = CATEGORY_COMPONENTS
+        ) { activity ->
+            activity.startActivity<RestAreaActivity>()
         },
     )
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/utils/MapboxNavigationEx.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/utils/MapboxNavigationEx.kt
@@ -1,0 +1,62 @@
+package com.mapbox.navigation.qa_test_app.utils
+
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.NavigationRouterCallback
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.core.MapboxNavigation
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal suspend fun MapboxNavigation.fetchRoute(
+    origin: Point,
+    destination: Point,
+): List<NavigationRoute> =
+    fetchRoute(
+        RouteOptions.builder()
+            .applyDefaultNavigationOptions()
+            .applyLanguageAndVoiceUnitOptions(navigationOptions.applicationContext)
+            .layersList(listOf(getZLevel(), null))
+            .coordinatesList(listOf(origin, destination))
+            .alternatives(true)
+            .build()
+    )
+
+internal suspend fun MapboxNavigation.fetchRoute(
+    routeOptions: RouteOptions
+): List<NavigationRoute> = suspendCancellableCoroutine { cont ->
+    val requestId = requestRoutes(
+        routeOptions,
+        object : NavigationRouterCallback {
+            override fun onRoutesReady(
+                routes: List<NavigationRoute>,
+                routerOrigin: RouterOrigin
+            ) {
+                cont.resume(routes)
+            }
+
+            override fun onFailure(
+                reasons: List<RouterFailure>,
+                routeOptions: RouteOptions
+            ) {
+                cont.resumeWithException(FetchRouteError(reasons, routeOptions))
+            }
+
+            override fun onCanceled(
+                routeOptions: RouteOptions,
+                routerOrigin: RouterOrigin
+            ) = Unit
+        }
+    )
+    cont.invokeOnCancellation { cancelRouteRequest(requestId) }
+}
+
+internal class FetchRouteError(
+    val reasons: List<RouterFailure>,
+    val routeOptions: RouteOptions
+) : Error()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/RestAreaActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/RestAreaActivity.kt
@@ -1,0 +1,191 @@
+package com.mapbox.navigation.qa_test_app.view.componentinstaller
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.mapbox.geojson.Point
+import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.internal.extensions.flowRouteProgress
+import com.mapbox.navigation.core.internal.extensions.flowRoutesUpdated
+import com.mapbox.navigation.core.replay.MapboxReplayer
+import com.mapbox.navigation.core.replay.ReplayLocationEngine
+import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
+import com.mapbox.navigation.core.replay.route.ReplayRouteMapper
+import com.mapbox.navigation.qa_test_app.databinding.LayoutActivityRestAreaBinding
+import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.qa_test_app.utils.fetchRoute
+import com.mapbox.navigation.qa_test_app.view.componentinstaller.components.MapMarkersLegSteps
+import com.mapbox.navigation.qa_test_app.view.componentinstaller.components.MapMarkersRestStops
+import com.mapbox.navigation.qa_test_app.view.componentinstaller.components.RestAreaGuideMap
+import com.mapbox.navigation.qa_test_app.view.componentinstaller.components.SimpleFollowingCamera
+import com.mapbox.navigation.qa_test_app.view.util.observe
+import com.mapbox.navigation.ui.base.installer.installComponents
+import com.mapbox.navigation.ui.maps.guidance.restarea.api.MapboxRestAreaApi
+import com.mapbox.navigation.ui.maps.locationPuck
+import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
+import com.mapbox.navigation.ui.maps.routeArrow
+import com.mapbox.navigation.ui.maps.routeLine
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+@SuppressLint("MissingPermission")
+class RestAreaActivity : AppCompatActivity() {
+
+    private lateinit var binding: LayoutActivityRestAreaBinding
+    private lateinit var mapboxNavigation: MapboxNavigation
+
+    private val mapboxMap: MapboxMap get() = binding.mapView.getMapboxMap()
+
+    private val mapboxReplayer = MapboxReplayer()
+    private val replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
+
+    private var started: Boolean = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = LayoutActivityRestAreaBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        initStyle()
+        initNavigation()
+        initControls()
+        initObservers()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mapboxReplayer.finish()
+        mapboxNavigation.onDestroy()
+    }
+
+    private fun initStyle() {
+        mapboxMap.loadStyleUri(MAPBOX_STREETS)
+    }
+
+    private fun initNavigation() {
+        mapboxNavigation = MapboxNavigationProvider.create(
+            NavigationOptions.Builder(this)
+                .accessToken(getMapboxRouteAccessToken(this))
+                .locationEngine(ReplayLocationEngine(mapboxReplayer))
+                .build()
+        )
+        mapboxNavigation.startTripSession()
+        mapboxReplayer.pushRealLocation(this, 0.0)
+        mapboxReplayer.play()
+
+        mapboxNavigation.installComponents(this) {
+            locationPuck(binding.mapView)
+            routeArrow(binding.mapView)
+            routeLine(binding.mapView) {
+                options = MapboxRouteLineOptions.Builder(this@RestAreaActivity)
+                    .withRouteLineResources(RouteLineResources.Builder().build())
+                    .withRouteLineBelowLayerId("road-label")
+                    .build()
+            }
+            component(SimpleFollowingCamera(binding.mapView))
+            component(
+                RestAreaGuideMap(
+                    MapboxRestAreaApi(getMapboxRouteAccessToken(this@RestAreaActivity)),
+                    binding.restAreaView
+                )
+            )
+            component(MapMarkersRestStops(binding.mapView))
+            component(MapMarkersLegSteps(binding.mapView))
+        }
+    }
+
+    private fun initControls() {
+        binding.startButton.setOnClickListener {
+            if (!started) {
+                TestCoordinates.of(binding.spinnerRoutes.selectedItem as? String)?.also {
+                    fetchAndSetRoute(it.coordinates)
+                    started = true
+                }
+            } else {
+                mapboxNavigation.setNavigationRoutes(emptyList())
+                started = false
+            }
+            binding.startButton.text = if (started) "STOP" else "START"
+            binding.spinnerRoutes.isEnabled = !started
+        }
+    }
+
+    private fun initObservers() {
+        mapboxNavigation.flowRoutesUpdated().observe(this) { result ->
+            if (result.navigationRoutes.isNotEmpty()) {
+                startSimulation(result.navigationRoutes[0])
+            } else {
+                stopSimulation()
+            }
+        }
+
+        mapboxNavigation.flowRouteProgress().observe(this) { routeProgress ->
+            replayProgressObserver.onRouteProgressChanged(routeProgress)
+        }
+    }
+
+    private fun startSimulation(navigationRoutes: NavigationRoute) {
+        stopSimulation()
+        val replayEvents = ReplayRouteMapper()
+            .mapDirectionsRouteGeometry(navigationRoutes.directionsRoute)
+        mapboxReplayer.pushEvents(replayEvents)
+        mapboxReplayer.seekTo(replayEvents.first())
+        mapboxReplayer.play()
+    }
+
+    private fun stopSimulation() {
+        mapboxReplayer.stop()
+        mapboxReplayer.clearEvents()
+        mapboxReplayer.pushRealLocation(this, 0.0)
+    }
+
+    private fun fetchAndSetRoute(coordinates: Pair<Point, Point>) {
+        val (origin, destination) = coordinates
+        lifecycleScope.launch {
+            val routes = mapboxNavigation.fetchRoute(origin, destination)
+            mapboxNavigation.setNavigationRoutes(routes)
+        }
+    }
+
+    private fun getMapboxRouteAccessToken(context: Context): String {
+        val tokenResId = context.resources
+            .getIdentifier("mapbox_access_token_sapa", "string", context.packageName)
+        return if (tokenResId != 0) {
+            context.getString(tokenResId)
+        } else {
+            Toast.makeText(this, "Missing mapbox_access_token_sapa", Toast.LENGTH_LONG).show()
+            Utils.getMapboxAccessToken(this)
+        }
+    }
+
+    private enum class TestCoordinates(
+        val coordinates: Pair<Point, Point>
+    ) {
+        SAPA_TOKYO_LONG(
+            Point.fromLngLat(139.65973759944154, 35.69781247239969) to
+                Point.fromLngLat(139.75685114382554, 35.672241648222666)
+        ),
+
+        // same as SAPA_TOKYO_LONG but closer to the REST_STOP
+        SAPA_TOKYO_SHORT(
+            Point.fromLngLat(139.690511, 35.695178) to
+                Point.fromLngLat(139.75685114382554, 35.672241648222666)
+        );
+
+        companion object {
+            fun of(value: String?): TestCoordinates? = value?.let {
+                runCatching { valueOf(value) }.getOrNull()
+            }
+        }
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/MapMarkersLegSteps.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/MapMarkersLegSteps.kt
@@ -1,0 +1,53 @@
+package com.mapbox.navigation.qa_test_app.view.componentinstaller.components
+
+import com.mapbox.maps.MapView
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
+import com.mapbox.maps.plugin.annotation.annotations
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
+import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.extensions.flowRoutesUpdated
+import com.mapbox.navigation.qa_test_app.view.util.IconFactory
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+
+@ExperimentalPreviewMapboxNavigationAPI
+class MapMarkersLegSteps(
+    private val mapView: MapView
+) : UIComponent() {
+
+    private var annotationManager = mapView.annotations.createPointAnnotationManager()
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+
+        val annotation = PointAnnotationOptions()
+            .withIconAnchor(IconAnchor.BOTTOM)
+        val iconFactory = IconFactory(mapView.context)
+
+        mapboxNavigation.flowRoutesUpdated()
+            .onEach { annotationManager.deleteAll() }
+            .mapNotNull { it.navigationRoutes.firstOrNull()?.directionsRoute?.legs() }
+            .observe { legs ->
+                legs.forEachIndexed { legIndex, routeLeg ->
+                    routeLeg.steps()?.forEachIndexed { stepIndex, legStep ->
+                        legStep.intersections()?.firstOrNull()?.also {
+                            val icon = iconFactory.pinIconWithText("$legIndex.$stepIndex")
+                            annotationManager.create(
+                                annotation
+                                    .withIconImage(icon)
+                                    .withPoint(it.location())
+                            )
+                        }
+                    }
+                }
+            }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        super.onDetached(mapboxNavigation)
+        annotationManager.deleteAll()
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/MapMarkersRestStops.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/MapMarkersRestStops.kt
@@ -1,0 +1,59 @@
+package com.mapbox.navigation.qa_test_app.view.componentinstaller.components
+
+import android.graphics.Color
+import com.mapbox.geojson.Point
+import com.mapbox.maps.MapView
+import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
+import com.mapbox.maps.plugin.annotation.annotations
+import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
+import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.trip.model.roadobject.RoadObjectType
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.extensions.flowRoutesUpdated
+import com.mapbox.navigation.qa_test_app.view.util.IconFactory
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.onEach
+
+@ExperimentalPreviewMapboxNavigationAPI
+class MapMarkersRestStops(
+    private val mapView: MapView
+) : UIComponent() {
+
+    private var annotationManager = mapView.annotations.createPointAnnotationManager()
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+
+        val icon = IconFactory(mapView.context).pinIconWithText(
+            "zzZ",
+            Color.parseColor("#00ccff")
+        )
+        val annotation = PointAnnotationOptions()
+            .withIconImage(icon)
+            .withIconAnchor(IconAnchor.BOTTOM)
+
+        mapboxNavigation.flowRoutesUpdated()
+            .onEach { annotationManager.deleteAll() }
+            .mapNotNull {
+                it.navigationRoutes.firstOrNull()?.upcomingRoadObjects
+            }
+            .observe { upcomingRoadObjects ->
+                upcomingRoadObjects.mapNotNull {
+                    if (it.roadObject.objectType == RoadObjectType.REST_STOP) {
+                        (it.roadObject.location.shape as? Point)
+                    } else {
+                        null
+                    }
+                }.forEach {
+                    annotationManager.create(annotation.withPoint(it))
+                }
+            }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        super.onDetached(mapboxNavigation)
+        annotationManager.deleteAll()
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/MapMarkersRestStops.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/MapMarkersRestStops.kt
@@ -27,7 +27,7 @@ class MapMarkersRestStops(
         super.onAttached(mapboxNavigation)
 
         val icon = IconFactory(mapView.context).pinIconWithText(
-            "zzZ",
+            "REST\nSTOP",
             Color.parseColor("#00ccff")
         )
         val annotation = PointAnnotationOptions()

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/RestAreaGuideMap.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/RestAreaGuideMap.kt
@@ -1,0 +1,36 @@
+package com.mapbox.navigation.qa_test_app.view.componentinstaller.components
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.extensions.flowRouteProgress
+import com.mapbox.navigation.core.internal.extensions.flowRoutesUpdated
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import com.mapbox.navigation.ui.maps.guidance.restarea.api.MapboxRestAreaApi
+import com.mapbox.navigation.ui.maps.guidance.restarea.view.MapboxRestAreaGuideMapView
+
+@ExperimentalPreviewMapboxNavigationAPI
+class RestAreaGuideMap(
+    private val restAreaApi: MapboxRestAreaApi,
+    private val restAreaView: MapboxRestAreaGuideMapView,
+) : UIComponent() {
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+
+        mapboxNavigation.flowRouteProgress().observe { routeProgress ->
+            restAreaApi.generateUpcomingRestAreaGuideMap(routeProgress) {
+                restAreaView.render(it)
+            }
+        }
+        mapboxNavigation.flowRoutesUpdated().observe {
+            if (it.navigationRoutes.isEmpty()) {
+                restAreaApi.cancelAll()
+            }
+        }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation) {
+        super.onDetached(mapboxNavigation)
+        restAreaApi.cancelAll()
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/SimpleFollowingCamera.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/componentinstaller/components/SimpleFollowingCamera.kt
@@ -1,0 +1,40 @@
+package com.mapbox.navigation.qa_test_app.view.componentinstaller.components
+
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.MapView
+import com.mapbox.maps.plugin.animation.MapAnimationOptions
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.extensions.flowLocationMatcherResult
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import kotlinx.coroutines.flow.map
+
+@ExperimentalPreviewMapboxNavigationAPI
+class SimpleFollowingCamera(
+    private val mapView: MapView
+) : UIComponent() {
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+
+        mapboxNavigation.flowLocationMatcherResult()
+            .map { it.enhancedLocation }
+            .observe { location ->
+                val mapAnimationOptionsBuilder = MapAnimationOptions.Builder()
+                mapAnimationOptionsBuilder.duration(1500L)
+                mapView.camera.easeTo(
+                    CameraOptions.Builder()
+                        .center(Point.fromLngLat(location.longitude, location.latitude))
+                        .bearing(location.bearing.toDouble())
+                        .pitch(45.0)
+                        .zoom(17.0)
+                        .padding(EdgeInsets(1000.0, 0.0, 0.0, 0.0))
+                        .build(),
+                    mapAnimationOptionsBuilder.build()
+                )
+            }
+    }
+}

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/NavigationViewController.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/NavigationViewController.kt
@@ -3,26 +3,18 @@ package com.mapbox.navigation.qa_test_app.view.customnavview
 import android.location.Location
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
-import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
-import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.route.NavigationRoute
-import com.mapbox.navigation.base.route.NavigationRouterCallback
-import com.mapbox.navigation.base.route.RouterFailure
-import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.internal.extensions.flowNewRawLocation
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.dropin.NavigationView
+import com.mapbox.navigation.qa_test_app.utils.fetchRoute
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import com.mapbox.navigation.utils.internal.toPoint
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 internal class NavigationViewController(
     lifecycleOwner: LifecycleOwner,
@@ -66,46 +58,4 @@ internal class NavigationViewController(
         val mapboxNavigation = this.mapboxNavigation.filterNotNull().first()
         return mapboxNavigation.fetchRoute(origin, destination)
     }
-
-    private suspend fun MapboxNavigation.fetchRoute(
-        origin: Point,
-        destination: Point
-    ): List<NavigationRoute> = suspendCancellableCoroutine { cont ->
-        val routeOptions = RouteOptions.builder()
-            .applyDefaultNavigationOptions()
-            .applyLanguageAndVoiceUnitOptions(navigationOptions.applicationContext)
-            .layersList(listOf(getZLevel(), null))
-            .coordinatesList(listOf(origin, destination))
-            .alternatives(true)
-            .build()
-        val requestId = requestRoutes(
-            routeOptions,
-            object : NavigationRouterCallback {
-                override fun onRoutesReady(
-                    routes: List<NavigationRoute>,
-                    routerOrigin: RouterOrigin
-                ) {
-                    cont.resume(routes)
-                }
-
-                override fun onFailure(
-                    reasons: List<RouterFailure>,
-                    routeOptions: RouteOptions
-                ) {
-                    cont.resumeWithException(FetchRouteError(reasons, routeOptions))
-                }
-
-                override fun onCanceled(
-                    routeOptions: RouteOptions,
-                    routerOrigin: RouterOrigin
-                ) = Unit
-            }
-        )
-        cont.invokeOnCancellation { cancelRouteRequest(requestId) }
-    }
-
-    private class FetchRouteError(
-        val reasons: List<RouterFailure>,
-        val routeOptions: RouteOptions
-    ) : Error()
 }

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/IconFactory.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/util/IconFactory.kt
@@ -1,0 +1,36 @@
+package com.mapbox.navigation.qa_test_app.view.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.view.LayoutInflater
+import androidx.annotation.ColorInt
+import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.view.drawToBitmap
+import com.mapbox.navigation.qa_test_app.R
+import com.mapbox.navigation.qa_test_app.databinding.LayoutMapMarkerWithTextBinding
+
+internal class IconFactory(private val context: Context) {
+
+    /**
+     * Pin with Text
+     * @see [R.layout.layout_map_marker_with_text]
+     */
+    fun pinIconWithText(
+        text: String,
+        @ColorInt tintColor: Int? = null,
+        @ColorInt textColor: Int? = null
+    ): Bitmap {
+        val binding = LayoutMapMarkerWithTextBinding.inflate(LayoutInflater.from(context))
+        tintColor?.also { color ->
+            DrawableCompat.setTint(DrawableCompat.wrap(binding.image.drawable), color)
+        }
+        binding.text.text = text
+        textColor?.also { binding.text.setTextColor(it) }
+        return binding.root.run {
+            // Cause the view to re-layout
+            measure(measuredWidth, measuredHeight)
+            layout(0, 0, measuredWidth, measuredHeight)
+            drawToBitmap()
+        }
+    }
+}

--- a/qa-test-app/src/main/res/drawable/ic_text_marker.xml
+++ b/qa-test-app/src/main/res/drawable/ic_text_marker.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:left="23dp" android:width="4dp" android:height="50dp">
+        <shape android:shape="rectangle">
+            <stroke android:color="@color/primary" android:width="2dp" />
+        </shape>
+    </item>
+    <item
+        android:width="50dp" android:height="40dp">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/primary" />
+            <stroke android:color="@color/secondary" android:width="1dp" />
+            <corners android:radius="5dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/qa-test-app/src/main/res/layout/layout_activity_rest_area.xml
+++ b/qa-test-app/src/main/res/layout/layout_activity_rest_area.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:keepScreenOn="true"
+    >
+
+  <com.mapbox.maps.MapView
+      android:id="@+id/mapView"
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      app:layout_constraintBottom_toTopOf="@id/controlsPanel"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      />
+
+  <FrameLayout
+      android:layout_width="150dp"
+      android:layout_height="100dp"
+      android:layout_marginStart="4dp"
+      android:layout_marginTop="50dp"
+      android:background="#33000000"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      >
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:textAlignment="center"
+        android:text="SAPA map\nnot available"
+        />
+
+    <com.mapbox.navigation.ui.maps.guidance.restarea.view.MapboxRestAreaGuideMapView
+        android:id="@+id/restAreaView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+  </FrameLayout>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+      android:id="@+id/controlsPanel"
+      android:layout_width="0dp"
+      android:layout_height="60dp"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      >
+
+    <Button
+        android:id="@+id/startButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="5dp"
+        android:text="start"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
+
+    <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/spinnerRoutes"
+        android:layout_width="0dp"
+        android:layout_height="40dp"
+        android:layout_marginEnd="5dp"
+        android:layout_marginStart="5dp"
+        android:elevation="2dp"
+        android:entries="@array/rest_area_routes"
+        android:spinnerMode="dropdown"
+        app:layout_constraintBottom_toBottomOf="@+id/startButton"
+        app:layout_constraintEnd_toStartOf="@+id/startButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/startButton"
+        />
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/qa-test-app/src/main/res/layout/layout_map_marker_with_text.xml
+++ b/qa-test-app/src/main/res/layout/layout_map_marker_with_text.xml
@@ -6,19 +6,18 @@
 
   <androidx.appcompat.widget.AppCompatImageView
       android:id="@+id/image"
-      android:layout_width="29dp"
-      android:layout_height="36dp"
-      android:src="@drawable/mapbox_ic_marker"/>
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:src="@drawable/ic_text_marker"/>
 
   <TextView
       android:id="@+id/text"
-      android:layout_width="29dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="7dp"
-      android:textAlignment="center"
-      android:textSize="11sp"
+      android:layout_width="50dp"
+      android:layout_height="38dp"
+      android:gravity="center"
+      android:textSize="10sp"
       android:textColor="#000"
       android:textStyle="bold"
-      tools:text="zzZ" />
+      tools:text="Rest\nStop" />
 
 </FrameLayout>

--- a/qa-test-app/src/main/res/layout/layout_map_marker_with_text.xml
+++ b/qa-test-app/src/main/res/layout/layout_map_marker_with_text.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+  <androidx.appcompat.widget.AppCompatImageView
+      android:id="@+id/image"
+      android:layout_width="29dp"
+      android:layout_height="36dp"
+      android:src="@drawable/mapbox_ic_marker"/>
+
+  <TextView
+      android:id="@+id/text"
+      android:layout_width="29dp"
+      android:layout_height="wrap_content"
+      android:layout_marginTop="7dp"
+      android:textAlignment="center"
+      android:textSize="11sp"
+      android:textColor="#000"
+      android:textStyle="bold"
+      tools:text="zzZ" />
+
+</FrameLayout>

--- a/qa-test-app/src/main/res/values/strings.xml
+++ b/qa-test-app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="route_preivew_activity_description" translatable="false">Example of how to use routes privew</string>
     <string name="drop_in_buttons_activity_description" translatable="false">Screen for viewing SDK buttons.</string>
     <string name="speed_info_activity_description" translatable="false">Example of how to use Mapbox SpeedInfo View</string>
+    <string name="rest_area_activity_description" translatable="false">Demonstrates the use of Rest Area API</string>
 
     <string-array name="drop_in_info_panel_overrides" translatable="false">
         <item>--</item>
@@ -75,5 +76,9 @@
         <item>DRIVING</item>
         <item>WALKING</item>
         <item>CYCLING</item>
+    </string-array>
+    <string-array name="rest_area_routes" translatable="false">
+        <item>SAPA_TOKYO_SHORT</item>
+        <item>SAPA_TOKYO_LONG</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Closes NAVAND-887

### Description
libanavui-maps:
  - Updated RestAreaProcessor to return SAPA map URL only if the upcoming rest stop is on the current step.

QA-Test-App:
  - Added RestAreaActivity that simulates an example route with SAPA map, and uses MapboxRestAreaApi and MapboxRestAreaGuideMapView
  - Small refactoring to increase code reuse.

### Screenshots or Gifs
_Screen recording of the QA-Test-App  "Rest Area Example" captured on Pixel 6_

https://user-images.githubusercontent.com/2678039/206286049-26ca0b86-9ec7-46d3-a31d-56033838abb2.mp4

### Testing 

> **NOTE:** Loading SAPA maps requires an access token with the correct access level

Before running the QA-Test-App "Rest Area Example", please add a `mapbox_access_token_sapa`  string resource with the SAPA enabled access token to your `qa-test-app/src/main/res/values/mapbox_access_token.xml` file:

```xml
<string name="mapbox_access_token_sapa" translatable="false">SAPA_ACCESS_TOKEN</string>
```
Please contact me via SLACK for the access token.
