### PR TITLE
block until deprecated MapboxNavigation#resetTripSession() finishes

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -143,6 +143,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.lang.reflect.Field
@@ -645,10 +646,18 @@ class MapboxNavigation @VisibleForTesting internal constructor(
      * navigation simulation, or before resetting location to not real (simulated)
      * position without recreation of [MapboxNavigation].
      */
-    @Deprecated(message = "use a function withe the callback instead")
+    @Deprecated(message = "use the overload with the callback instead")
     fun resetTripSession() {
-        resetTripSession {
-            // no-op
+        // using a blocking function to keep parity with the original implementation so that
+        // Nav Native is fully done with the reset when this function returns
+        runBlocking {
+            logD(LOG_CATEGORY) {
+                "Resetting trip session"
+            }
+            navigator.resetRideSession()
+            logI(LOG_CATEGORY) {
+                "Trip session reset"
+            }
         }
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Refs https://github.com/mapbox/mapbox-navigation-android/commit/562e8e7fd1733cceb2a9b54a376035189f724703#r92415581.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
