### PR TITLE
Potential optimizations for camera cancelAnimation

### DIFF
--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -23,6 +23,7 @@ import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.generated.CircleLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
+import com.mapbox.maps.logI
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
@@ -127,6 +128,7 @@ class MapboxCameraAnimationsActivity :
         set(value) {
             field = value
             viewportDataSource.followingPadding = value
+            logI("kyle_debug", "followingEdgeInsets->evaluate")
             viewportDataSource.evaluate()
         }
 
@@ -183,8 +185,9 @@ class MapboxCameraAnimationsActivity :
                 )
             }
 
-            viewportDataSource.evaluate()
             if (locationMatcherResult.isTeleport) {
+                logI("kyle_debug", "onNewLocationMatcherResult->evaluate")
+                viewportDataSource.evaluate()
                 navigationCamera.resetFrame()
             }
         }
@@ -192,6 +195,7 @@ class MapboxCameraAnimationsActivity :
 
     private val routeProgressObserver = RouteProgressObserver { routeProgress ->
         viewportDataSource.onRouteProgressChanged(routeProgress)
+        logI("kyle_debug", "RouteProgressObserver->evaluate")
         viewportDataSource.evaluate()
 
         routeLineAPI?.updateWithRouteProgress(routeProgress) { result ->
@@ -219,6 +223,7 @@ class MapboxCameraAnimationsActivity :
             startSimulation(result.navigationRoutes[0])
             viewportDataSource.onRouteChanged(result.routes.first())
             viewportDataSource.overviewPadding = overviewEdgeInsets
+            logI("kyle_debug", "RoutesObserver->evaluate")
             viewportDataSource.evaluate()
             navigationCamera.requestNavigationCameraToOverview()
         } else {
@@ -346,6 +351,7 @@ class MapboxCameraAnimationsActivity :
                 followingEdgeInsets.bottom,
                 200.0 * pixelDensity
             )
+            logI("kyle_debug", "gravitateLeft->evaluate")
             viewportDataSource.evaluate()
         }
 
@@ -356,6 +362,7 @@ class MapboxCameraAnimationsActivity :
                 followingEdgeInsets.bottom,
                 20.0
             )
+            logI("kyle_debug", "gravitateRight->evaluate")
             viewportDataSource.evaluate()
         }
 
@@ -366,6 +373,7 @@ class MapboxCameraAnimationsActivity :
                 240.0 * pixelDensity,
                 followingEdgeInsets.right
             )
+            logI("kyle_debug", "gravitateTop->evaluate")
             viewportDataSource.evaluate()
         }
 
@@ -376,6 +384,7 @@ class MapboxCameraAnimationsActivity :
                 20.0,
                 followingEdgeInsets.right
             )
+            logI("kyle_debug", "gravitateBottom->evaluate")
             viewportDataSource.evaluate()
         }
     }
@@ -525,6 +534,7 @@ class MapboxCameraAnimationsActivity :
                     }
                     complexFollowingNorth = false
                 }
+                logI("kyle_debug", "animationType(${animationType})->evaluate")
                 viewportDataSource.evaluate()
                 if (animationType == AnimationType.Following) {
                     navigationCamera.requestNavigationCameraToFollowing()
@@ -541,6 +551,7 @@ class MapboxCameraAnimationsActivity :
             }
             AnimationType.Overview -> {
                 viewportDataSource.overviewPadding = overviewEdgeInsets
+                logI("kyle_debug", "animationType(${animationType})->evaluate")
                 viewportDataSource.evaluate()
                 navigationCamera.requestNavigationCameraToOverview()
             }
@@ -577,12 +588,14 @@ class MapboxCameraAnimationsActivity :
                         viewportDataSource.followingBearingPropertyOverride(
                             TurfMeasurement.bearing(center, it)
                         )
+                        logI("kyle_debug", "animationType(${animationType})->evaluate")
                         viewportDataSource.evaluate()
                     }
                 } else {
                     lookAtPoint = null
                     viewportDataSource.additionalPointsToFrameForFollowing(emptyList())
                     viewportDataSource.followingBearingPropertyOverride(null)
+                    logI("kyle_debug", "animationType(${animationType})->evaluate")
                     viewportDataSource.evaluate()
                 }
             }

--- a/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
+++ b/examples/src/main/java/com/mapbox/navigation/examples/core/camera/MapboxCameraAnimationsActivity.kt
@@ -23,7 +23,6 @@ import com.mapbox.maps.extension.style.layers.addLayer
 import com.mapbox.maps.extension.style.layers.generated.CircleLayer
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
-import com.mapbox.maps.logI
 import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.animation.camera
@@ -128,7 +127,6 @@ class MapboxCameraAnimationsActivity :
         set(value) {
             field = value
             viewportDataSource.followingPadding = value
-            logI("kyle_debug", "followingEdgeInsets->evaluate")
             viewportDataSource.evaluate()
         }
 
@@ -186,7 +184,6 @@ class MapboxCameraAnimationsActivity :
             }
 
             if (locationMatcherResult.isTeleport) {
-                logI("kyle_debug", "onNewLocationMatcherResult->evaluate")
                 viewportDataSource.evaluate()
                 navigationCamera.resetFrame()
             }
@@ -195,7 +192,6 @@ class MapboxCameraAnimationsActivity :
 
     private val routeProgressObserver = RouteProgressObserver { routeProgress ->
         viewportDataSource.onRouteProgressChanged(routeProgress)
-        logI("kyle_debug", "RouteProgressObserver->evaluate")
         viewportDataSource.evaluate()
 
         routeLineAPI?.updateWithRouteProgress(routeProgress) { result ->
@@ -223,7 +219,6 @@ class MapboxCameraAnimationsActivity :
             startSimulation(result.navigationRoutes[0])
             viewportDataSource.onRouteChanged(result.routes.first())
             viewportDataSource.overviewPadding = overviewEdgeInsets
-            logI("kyle_debug", "RoutesObserver->evaluate")
             viewportDataSource.evaluate()
             navigationCamera.requestNavigationCameraToOverview()
         } else {
@@ -351,7 +346,6 @@ class MapboxCameraAnimationsActivity :
                 followingEdgeInsets.bottom,
                 200.0 * pixelDensity
             )
-            logI("kyle_debug", "gravitateLeft->evaluate")
             viewportDataSource.evaluate()
         }
 
@@ -362,7 +356,6 @@ class MapboxCameraAnimationsActivity :
                 followingEdgeInsets.bottom,
                 20.0
             )
-            logI("kyle_debug", "gravitateRight->evaluate")
             viewportDataSource.evaluate()
         }
 
@@ -373,7 +366,6 @@ class MapboxCameraAnimationsActivity :
                 240.0 * pixelDensity,
                 followingEdgeInsets.right
             )
-            logI("kyle_debug", "gravitateTop->evaluate")
             viewportDataSource.evaluate()
         }
 
@@ -384,7 +376,6 @@ class MapboxCameraAnimationsActivity :
                 20.0,
                 followingEdgeInsets.right
             )
-            logI("kyle_debug", "gravitateBottom->evaluate")
             viewportDataSource.evaluate()
         }
     }
@@ -534,7 +525,6 @@ class MapboxCameraAnimationsActivity :
                     }
                     complexFollowingNorth = false
                 }
-                logI("kyle_debug", "animationType(${animationType})->evaluate")
                 viewportDataSource.evaluate()
                 if (animationType == AnimationType.Following) {
                     navigationCamera.requestNavigationCameraToFollowing()
@@ -551,7 +541,6 @@ class MapboxCameraAnimationsActivity :
             }
             AnimationType.Overview -> {
                 viewportDataSource.overviewPadding = overviewEdgeInsets
-                logI("kyle_debug", "animationType(${animationType})->evaluate")
                 viewportDataSource.evaluate()
                 navigationCamera.requestNavigationCameraToOverview()
             }
@@ -588,14 +577,12 @@ class MapboxCameraAnimationsActivity :
                         viewportDataSource.followingBearingPropertyOverride(
                             TurfMeasurement.bearing(center, it)
                         )
-                        logI("kyle_debug", "animationType(${animationType})->evaluate")
                         viewportDataSource.evaluate()
                     }
                 } else {
                     lookAtPoint = null
                     viewportDataSource.additionalPointsToFrameForFollowing(emptyList())
                     viewportDataSource.followingBearingPropertyOverride(null)
-                    logI("kyle_debug", "animationType(${animationType})->evaluate")
                     viewportDataSource.evaluate()
                 }
             }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/NavigationCamera.kt
@@ -3,9 +3,11 @@ package com.mapbox.navigation.ui.maps.camera
 import android.animation.Animator
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
+import android.os.SystemClock
 import androidx.annotation.UiThread
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.logI
 import com.mapbox.maps.plugin.animation.CameraAnimationsLifecycleListener
 import com.mapbox.maps.plugin.animation.CameraAnimationsPlugin
 import com.mapbox.maps.plugin.animation.animator.CameraAnimator
@@ -153,6 +155,7 @@ class NavigationCamera(
     private val sourceUpdateObserver =
         ViewportDataSourceUpdateObserver {
                 viewportData ->
+            logI("kyle_debug", "viewportDataSourceUpdated->updateFrame")
             updateFrame(viewportData, instant = false)
         }
 
@@ -328,6 +331,7 @@ class NavigationCamera(
      * based on the latest data obtained with [ViewportDataSource.getViewportData].
      */
     fun resetFrame() {
+        logI("kyle_debug", "resetFrame->updateFrame")
         val viewportData = viewportDataSource.getViewportData()
         updateFrame(viewportData, instant = true)
     }
@@ -335,6 +339,7 @@ class NavigationCamera(
     private fun updateFrame(viewportData: ViewportData, instant: Boolean) {
         when (state) {
             FOLLOWING -> {
+                val startTime = SystemClock.elapsedRealtimeNanos()
                 startAnimation(
                     stateTransition.updateFrameForFollowing(
                         viewportData.cameraForFollowing,
@@ -344,6 +349,9 @@ class NavigationCamera(
                     },
                     instant
                 )
+                val endTime = SystemClock.elapsedRealtimeNanos()
+                val deltaTime = (endTime - startTime) * 10e-9
+                logI("kyle_debug", "updateFrame $deltaTime")
             }
             OVERVIEW -> {
                 startAnimation(
@@ -450,6 +458,7 @@ class NavigationCamera(
             finishAnimation(animation as AnimatorSet)
             transitionEndListeners.forEach { it.onTransitionEnd(isCanceled) }
             transitionEndListeners.clear()
+            logI("kyle_debug", "viewportDataSourceUpdated->onAnimationEnd")
             updateFrame(viewportDataSource.getViewportData(), instant = false)
         }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
@@ -10,7 +10,6 @@ import com.mapbox.maps.CameraState
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
-import com.mapbox.maps.logI
 import com.mapbox.maps.toCameraOptions
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.internal.utils.isSameRoute
@@ -335,7 +334,6 @@ class MapboxNavigationViewportDataSource(
      * @see [getViewportData]
      */
     fun evaluate() {
-        logI("kyle_debug", "evaluate->viewportDataSourceUpdated")
         val cameraState = mapboxMap.cameraState
         updateFollowingData(cameraState)
         updateOverviewData(cameraState)

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt
@@ -10,6 +10,7 @@ import com.mapbox.maps.CameraState
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.logI
 import com.mapbox.maps.toCameraOptions
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.internal.utils.isSameRoute
@@ -334,6 +335,7 @@ class MapboxNavigationViewportDataSource(
      * @see [getViewportData]
      */
     fun evaluate() {
+        logI("kyle_debug", "evaluate->viewportDataSourceUpdated")
         val cameraState = mapboxMap.cameraState
         updateFollowingData(cameraState)
         updateOverviewData(cameraState)


### PR DESCRIPTION
There are reports that `NavigationCamera.cancelAnimation` is responsible for a relatively large amount of compute time during navigation. Considering the nav-sdk is essentially a camera following a location, that makes sense but it is also worth investigating the best performance possible. I'm opening this draft to share ideas, surface findings, and take notes.

## Ideas

One quick way to optimize `cancelAnimation`, is to call it less. I found that removing the `evaluate` from `onNewLocationMatcherResult` will reduce the calls by 50%. This seems like a good idea because evaluate is called from `onRouteProgressUpdate` which happens almost immediately after `onNewLocationMatcherResult`.

## Questions

### When is Navigation.cancelAnimation called?

The most frequent call is from a public function [MapboxNavigationViewportDataSource.evaluate()](https://github.com/mapbox/mapbox-navigation-android/blob/791325017283c025712227fd0f5f4bebf3a2fccd/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSource.kt#L336). Every time the data changes, the developer calls evaluate and the previous animation is canceled while the new one is evaluated.

### How long does it take to cancelAnimation?

On a Google Pixel 4XL it has been taking ~25 ms. This is in a large part due to the use of Android's [AnimatorSet.cancel](https://developer.android.com/reference/android/animation/AnimatorSet).


```
12:49:46.890 perfLog  AnimatorSet.cancel 18.98 ms
12:49:46.890 perfLog  AnimatorSet.unregister 5 children 0.88 ms
12:49:46.890 perfLog  cancelAnimation 24.09 ms
12:49:46.891 perfLog updateFrame **36.22 ms**

12:49:47.787 perfLog  AnimatorSet.cancel 18.19 ms
12:49:47.787 perfLog  AnimatorSet.unregister 5 children 0.39 ms
12:49:47.787 perfLog  cancelAnimation 22.47 ms
12:49:47.788 perfLog updateFrame **33.28 ms**

12:49:48.787 perfLog  AnimatorSet.cancel 17.86 ms
12:49:48.788 perfLog  AnimatorSet.unregister 5 children 0.47 ms
12:49:48.788 perfLog  cancelAnimation 22.15 ms
12:49:48.789 perfLog updateFrame **33.47 ms**

12:49:49.693 perfLog  AnimatorSet.cancel 19.59 ms
12:49:49.693 perfLog  AnimatorSet.unregister 5 children 0.42 ms
12:49:49.693 perfLog  cancelAnimation 23.90 ms
12:49:49.694 perfLog updateFrame **35.15 ms**
````

### How frequent should `evaluate` be called?

I'm wondering this myself. I assume it should be called once per second because that was the original design. The `AnimatorSet` is responsible for making it so a once per second location update can be smoothed. 

To this point, with high frequency locations there must be a point where animations are no longer needed. For example, if location updates are coming in at 60 hz, there is no need to evaluate multi-frame animations.

### Should evaluate be called by both `onRouteProgressChanged` and `onNewLocationMatcherResult`?

The onNewLocationMatcherResult is essentially a route progress update. So if you are using both to call `evaluate`, it seems you are canceling work unnecessarily.