### PR TITLE
[Android Auto] Fix compatiblity issue with 2.10.0-beta.3

### DIFF
--- a/libnavui-androidauto/CHANGELOG.md
+++ b/libnavui-androidauto/CHANGELOG.md
@@ -5,6 +5,7 @@ Mapbox welcomes participation and contributions from everyone.
 ## Unreleased
 #### Features
 #### Bug fixes and improvements
+- Fixed incompatibility with nav sdk. [2.10.0-beta.3](https://github.com/mapbox/mapbox-navigation-android/releases/tag/v2.10.0-beta.3). Android Auto head unit will crash immediately. [#6714](https://github.com/mapbox/mapbox-navigation-android/pull/6714)
 
 ## androidauto-v0.18.0 - 09 December, 2022
 ### Changelog

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/lanes/CarLanesImageRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/lanes/CarLanesImageRenderer.kt
@@ -7,7 +7,6 @@ import androidx.car.app.model.CarIcon
 import androidx.car.app.navigation.model.Step
 import com.mapbox.navigation.ui.maneuver.api.MapboxLaneIconsApi
 import com.mapbox.navigation.ui.maneuver.api.MapboxManeuverApi
-import com.mapbox.navigation.utils.internal.ifNonNull
 
 /**
  * This class generates a [CarLanesImage] needed for the lane guidance in android auto.
@@ -31,7 +30,7 @@ class CarLanesImageRenderer(
     fun renderLanesImage(
         lane: com.mapbox.navigation.ui.maneuver.model.Lane?
     ): CarLanesImage? {
-        return ifNonNull(lane) { laneGuidance ->
+        return lane?.let { laneGuidance ->
             val lanes = carLaneIconMapper.mapLanes(laneGuidance)
             val carIcon = carIcon(laneGuidance)
             CarLanesImage(lanes, carIcon)

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/screenmanager/MapboxScreenManager.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/screenmanager/MapboxScreenManager.kt
@@ -12,7 +12,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.mapbox.androidauto.MapboxCarContext
 import com.mapbox.androidauto.internal.context.MapboxCarContextOwner
-import com.mapbox.navigation.utils.internal.logI
+import com.mapbox.androidauto.internal.logAndroidAuto
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -103,14 +103,14 @@ class MapboxScreenManager internal constructor(
         val currentTop = screenStack.peek()
         if (screenManager.stackSize > 0 && screenManager.top == currentTop?.second) {
             if (screenKey == currentTop.first) {
-                logI(TAG) { "createScreen top is already set to $screenKey" }
+                logAndroidAuto("$TAG createScreen top is already set to $screenKey")
                 return screenManager.top
             }
         }
         val factory: MapboxScreenFactory = requireScreenFactory(screenKey)
         return factory.create(carContextOwner.carContext()).also { screen ->
             val event = MapboxScreenEvent(screenKey, MapboxScreenOperation.CREATED)
-            logI(TAG) { "createScreen Push ${screen.javaClass.simpleName}" }
+            logAndroidAuto("$TAG createScreen Push ${screen.javaClass.simpleName}")
             screenManager.push(screen)
             screenStack.push(Pair(screenKey, screen))
             screenKeyMutable.tryEmit(event)
@@ -137,7 +137,7 @@ class MapboxScreenManager internal constructor(
             screenStack.pop()
             screenManager.pop()
             val newTop = screenStack.peek()
-            logI(TAG) { "goBack to ${newTop?.first}." }
+            logAndroidAuto("$TAG goBack to ${newTop?.first}.")
             check(newTop != null && screenManager.top == newTop.second) {
                 "goBack needs the MapboxScreenManager and ScreenManager to have similar screen " +
                     "back-stacks. ScreenManager top is not equal to ${newTop?.first}."
@@ -147,10 +147,10 @@ class MapboxScreenManager internal constructor(
             )
             true
         } else {
-            logI(TAG) {
-                "goBack cannot remove the top because ${screenManager.top::class.simpleName} is " +
-                    "not the top of MapboxScreenManager."
-            }
+            logAndroidAuto(
+                "$TAG goBack cannot remove the top because " +
+                    "${screenManager.top::class.simpleName} is not the top of MapboxScreenManager."
+            )
             false
         }
     }
@@ -219,14 +219,14 @@ class MapboxScreenManager internal constructor(
 
     private fun onReplaceTop(key: String) {
         if (key == screenStack.peek()?.first) {
-            logI(TAG) { "replaceTop exit, the top is already set to $key" }
+            logAndroidAuto("$TAG replaceTop exit, the top is already set to $key")
             return
         }
         val factory: MapboxScreenFactory = requireScreenFactory(key)
         val screen = factory.create(carContextOwner.carContext())
         screenStack.push(Pair(key, screen))
         val screenManager = requireScreenManager()
-        logI(TAG) { "replaceTop $key remove ${screenManager.stackSize} screens" }
+        logAndroidAuto("$TAG replaceTop $key remove ${screenManager.stackSize} screens")
         screenManager.replaceTop(screen)
     }
 
@@ -243,13 +243,13 @@ class MapboxScreenManager internal constructor(
 
     private fun onPush(key: String) {
         if (key == screenStack.peek()?.first) {
-            logI(TAG) { "push exit, the top is already set to $key" }
+            logAndroidAuto("$TAG push exit, the top is already set to $key")
             return
         }
         val factory: MapboxScreenFactory = requireScreenFactory(key)
         val screen = factory.create(carContextOwner.carContext())
         screenStack.push(Pair(key, screen))
-        logI(TAG) { "Push $key on top of ${screenManager?.stackSize} screens" }
+        logAndroidAuto("$TAG Push $key on top of ${screenManager?.stackSize} screens")
         requireScreenManager().push(screen)
     }
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

In androidauto-v0.14.0 we added a reference to a new internal logger https://github.com/mapbox/mapbox-navigation-android/pull/6429/files#diff-2b11dc16c8381b48dcd005d941a0caf38d9fc488c65572d18f242e69b76fce3fR82
in navsdk 2.10.0-beta-3 we fixed an issue with that new internal logger using an api change that is not backwards compatible https://github.com/mapbox/mapbox-navigation-android/pull/6704/files#diff-7644c4d71ba636edcf531827e66e8b86febc6b98885ace62d7a676e275de1457L5

Essentially, androidauto-v0.14.0+ will not be compatible with 2.10-beta-3. This pull request is to make it so we can have a new release of androidauto-v0.18.1 that will be compatible with 2.10-beta-3+.

The fix is to not use the new lazy logger yet.

#### More details

Internal apis are not verified as being backwards compatible so this issue is not caught pre-release. We have also recently started with androidauto automated tests that will catch this type of issue. We have also not yet started the stable/beta android auto release channels so we are not yet releasing with 2.10-beta. How we have been supporting "upgradability" (allowing old versions of androidauto to use new versions of navsdk) is by only using backwards compatible apis (public semver protected). There is still one exception, the [internal logging tool](https://github.com/mapbox/mapbox-navigation-android/blob/93a5e4a1393e0a970314aa158371d85b42e236d4/libnavui-androidauto/src/main/java/com/mapbox/androidauto/internal/AndroidAutoLog.kt#L3-L4) 😅. We may remove the internal logger for this reason.
