### PR TITLE
fixed an issue with state while reroute request is interrupted by a new reroute request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Fixed approaches list update in `RouteOptionsUpdater`(uses for reroute). It was putting to the origin approach corresponding approach from legacy approach list. [#6540](https://github.com/mapbox/mapbox-navigation-android/pull/6540)
 - Updated the `MapboxRestAreaApi` logic to load a SAPA map only if the upcoming rest stop is at the current step of the route leg. [#6695](https://github.com/mapbox/mapbox-navigation-android/pull/6695)
+- Fixed an issue where `MapboxRerouteController` could deliver a delayed interruption state notifications. Now, the interruption state is always delivered synchronously, as soon as it's available. [#6718](https://github.com/mapbox/mapbox-navigation-android/pull/6718)
 
 ## Mapbox Navigation SDK 2.9.5 - 13 December, 2022
 ### Changelog


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
This PR fixes an issue where if the `MapboxRerouteController`'s request was interrupted directly by a new request, we'd see an incorrect state progression as the `Interrupted` and `Idle` state following an interruption where set asynchronously while we were already executing the new request.

This means that for this type of interaction:
```
controller.reroute(callback)
// some or no delay
controller.reroute(callback)
```
or
```
controller.reroute(callback)
// some or no delay
controller.interrupt()
// some or no delay
controller.reroute(callback)
```

we could see state progression like:
```
Idle
FetchingRoute
Interrupted
Idle
RouteFetched
```

With this fix we're ensuring that we see:
```
Idle
FetchingRoute
Interrupted
Idle
FetchingRoute
RouteFetched
```
when any interruption happens.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
