### PR TITLE
MapboxTripSession: avoid pause updates for Alternative reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Mapbox welcomes participation and contributions from everyone.
 #### Bug fixes and improvements
 - Fixed an issue where `RouteProgress#BannerInstructions` could've become `null` when `MapboxNavigation#updateLegIndex` was called. [#6717](https://github.com/mapbox/mapbox-navigation-android/pull/6717)
 - Fixed an issue where `RouteProgress#VoiceInstructions` could've become `null` when `MapboxNavigation#updateLegIndex` was called. [#6717](https://github.com/mapbox/mapbox-navigation-android/pull/6717)
+- Fixed an issue where `RouteProgress#BannerInstructions` could've become `null` when setting alternative routes. [#6721](https://github.com/mapbox/mapbox-navigation-android/pull/6721)
 
 ## Mapbox Navigation SDK 2.9.4 - 08 December, 2022
 ### Changelog

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -93,6 +93,7 @@ internal class MapboxTripSession(
                     .also { isUpdatingRoute = false }
             }
             is SetAlternativeRoutesInfo -> {
+                isUpdatingRoute = false
                 NativeSetRouteValue(
                     routes = routes,
                     nativeAlternatives = navigator.setAlternativeRoutes(routes.drop(1))


### PR DESCRIPTION
Backports https://github.com/mapbox/mapbox-navigation-android/pull/6720 to 2.9.