### PR TITLE
Fix actions runner version

### DIFF
--- a/.github/workflows/set_reviewers.yml
+++ b/.github/workflows/set_reviewers.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The version '3.7.7' with architecture 'x64' was not found for Ubuntu 22.04. We need to fix ubuntu version