### PR TITLE
[Drop-In UI] Adjusted Following Camera padding in landscape orientation

### DIFF
--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/camera/CameraLayoutObserver.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/camera/CameraLayoutObserver.kt
@@ -61,8 +61,6 @@ internal class CameraLayoutObserver(
     }
 
     private fun getLandscapePadding(): EdgeInsets {
-        val left = mapView.width.toDouble() - binding.infoPanelLayout.right.toDouble()
-        val right = mapView.width.toDouble() - binding.actionListLayout.left.toDouble()
         val bottom = mapView.height.toDouble() - binding.roadNameLayout.top.toDouble()
         return when (store.state.value.navigation) {
             is NavigationState.FreeDrive -> {
@@ -74,9 +72,9 @@ internal class CameraLayoutObserver(
             is NavigationState.Arrival -> {
                 EdgeInsets(
                     vPaddingLandscape,
-                    hPaddingLandscape + left,
+                    hPaddingLandscape + binding.infoPanelLayout.right.toDouble(),
                     bottom,
-                    right - hPaddingLandscape
+                    hPaddingLandscape
                 )
             }
         }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/CameraLayoutObserverTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/CameraLayoutObserverTest.kt
@@ -119,7 +119,7 @@ class CameraLayoutObserverTest {
 
     @Test
     @Config(qualifiers = "land")
-    fun `landscape - should update left, bottom and right padding for all states except FreeDrive`() =
+    fun `landscape - should update left and bottom padding for all states except FreeDrive`() =
         coroutineRule.runBlockingTest {
             sut.onAttached(mockk())
 
@@ -134,7 +134,7 @@ class CameraLayoutObserverTest {
                 assertEquals("$s|top", action.padding.top, PADDING_V_LAND, 0.001)
                 assertNotEquals("$s|bottom", action.padding.bottom, PADDING_V_LAND, 0.001)
                 assertNotEquals("$s|left", action.padding.left, PADDING_H_LAND, 0.001)
-                assertNotEquals("$s|right", action.padding.right, PADDING_H_LAND, 0.001)
+                assertEquals("$s|right", action.padding.right, PADDING_H_LAND, 0.001)
             }
         }
 


### PR DESCRIPTION
Closes NAVAND-998

### Description
- Adjusted Navigation Camera padding when using NavigationView in the Landscape orientation, and the NavigationCamera is in the Following mode.

### Screenshots or Gifs

_Recording of the QA-Test-App captured on Pixel 6 (Android 13)_

https://user-images.githubusercontent.com/2678039/207156619-c5c5793a-a274-44c4-91d4-8c332ba22ba2.mp4

