### PR TITLE
[Drop-In UI] Add support for new speed info view to Drop-In

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ Mapbox welcomes participation and contributions from everyone.
 #### Features
 - Introduced `MapboxSpeedInfoApi` and `MapboxSpeedInfoView`. The combination of API and View can be used to render posted and current speed limit at user's current location. [#6687](https://github.com/mapbox/mapbox-navigation-android/pull/6687)
 - :warning: Deprecated `MapboxSpeedLimitApi` and `MapboxSpeedLimitView`. [#6687](https://github.com/mapbox/mapbox-navigation-android/pull/6687)
+- Added support to use `MapboxSpeedInfoView` as default view to render posted and current speed in Drop-In UI. [#6743](https://github.com/mapbox/mapbox-navigation-android/pull/6743)
+  - Introduced `ViewStyleCustomization.speedInfoOptions` to style the `MapboxSpeedInfoView` using Drop-In UI. [#6743](https://github.com/mapbox/mapbox-navigation-android/pull/6743)
+  - Introduced `ViewBinderCustomization.legacySpeedLimitBinder()` and `ViewBinderCustomization.defaultSpeedInfoBinder` to facilitate the simple use of legacy `MapboxSpeedLimitView` and new `MapboxSpeedInfoView`. [#6743](https://github.com/mapbox/mapbox-navigation-android/pull/6743)
+  - :warning: Deprecated `ViewStyleCustomization.setSpeedLimitStyle` and `ViewStyleCustomization.setSpeedLimitTextAppearance`. [#6743](https://github.com/mapbox/mapbox-navigation-android/pull/6743)
+  To use the legacy speed limit view, add the following code:
+```kotlin
+binding.navigationView.customizeViewBinders {
+    binding.navigationView.customizeViewBinders {
+        speedLimitBinder = legacySpeedLimitBinder()
+    }
+}
+```
 #### Bug fixes and improvements
 - Fixed approaches list update in `RouteOptionsUpdater`(uses for reroute). It was putting to the origin approach corresponding approach from legacy approach list. [#6540](https://github.com/mapbox/mapbox-navigation-android/pull/6540)
 - Updated the `MapboxRestAreaApi` logic to load a SAPA map only if the upcoming rest stop is at the current step of the route leg. [#6695](https://github.com/mapbox/mapbox-navigation-android/pull/6695)

--- a/libnavui-dropin/api/current.txt
+++ b/libnavui-dropin/api/current.txt
@@ -61,7 +61,8 @@ package com.mapbox.navigation.dropin {
   }
 
   public final class ViewBinderCustomization {
-    ctor public ViewBinderCustomization();
+    ctor @Deprecated public ViewBinderCustomization();
+    method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? defaultSpeedInfoBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getActionButtonsBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getActionCameraModeButtonBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getActionCompassButtonBinder();
@@ -88,6 +89,7 @@ package com.mapbox.navigation.dropin {
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getRightFrameBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getRoadNameBinder();
     method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? getSpeedLimitBinder();
+    method public com.mapbox.navigation.ui.base.lifecycle.UIBinder? legacySpeedLimitBinder();
     method public void setActionButtonsBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setActionCameraModeButtonBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
     method public void setActionCompassButtonBinder(com.mapbox.navigation.ui.base.lifecycle.UIBinder?);
@@ -253,8 +255,9 @@ package com.mapbox.navigation.dropin {
     method public Integer? getRoadNameBackground();
     method public Integer? getRoadNameTextAppearance();
     method public Integer? getRoutePreviewButtonStyle();
-    method public Integer? getSpeedLimitStyle();
-    method public Integer? getSpeedLimitTextAppearance();
+    method public com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions? getSpeedInfoOptions();
+    method @Deprecated public Integer? getSpeedLimitStyle();
+    method @Deprecated public Integer? getSpeedLimitTextAppearance();
     method public Integer? getStartNavigationButtonStyle();
     method public Integer? getTripProgressStyle();
     method public void setArrivalTextAppearance(Integer?);
@@ -274,8 +277,9 @@ package com.mapbox.navigation.dropin {
     method public void setRoadNameBackground(Integer?);
     method public void setRoadNameTextAppearance(Integer?);
     method public void setRoutePreviewButtonStyle(Integer?);
-    method public void setSpeedLimitStyle(Integer?);
-    method public void setSpeedLimitTextAppearance(Integer?);
+    method public void setSpeedInfoOptions(com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions?);
+    method @Deprecated public void setSpeedLimitStyle(Integer?);
+    method @Deprecated public void setSpeedLimitTextAppearance(Integer?);
     method public void setStartNavigationButtonStyle(Integer?);
     method public void setTripProgressStyle(Integer?);
     property public final Integer? arrivalTextAppearance;
@@ -295,8 +299,9 @@ package com.mapbox.navigation.dropin {
     property public final Integer? roadNameBackground;
     property public final Integer? roadNameTextAppearance;
     property public final Integer? routePreviewButtonStyle;
-    property public final Integer? speedLimitStyle;
-    property public final Integer? speedLimitTextAppearance;
+    property public final com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions? speedInfoOptions;
+    property @Deprecated public final Integer? speedLimitStyle;
+    property @Deprecated public final Integer? speedLimitTextAppearance;
     property public final Integer? startNavigationButtonStyle;
     property public final Integer? tripProgressStyle;
     field public static final com.mapbox.navigation.dropin.ViewStyleCustomization.Companion Companion;
@@ -320,8 +325,9 @@ package com.mapbox.navigation.dropin {
     method @DrawableRes public int defaultRoadNameBackground();
     method @StyleRes public int defaultRoadNameTextAppearance();
     method @StyleRes public int defaultRoutePreviewButtonStyle();
-    method @StyleRes public int defaultSpeedLimitStyle();
-    method @StyleRes public int defaultSpeedLimitTextAppearance();
+    method public com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions defaultSpeedInfoOptions();
+    method @Deprecated @StyleRes public int defaultSpeedLimitStyle();
+    method @Deprecated @StyleRes public int defaultSpeedLimitTextAppearance();
     method @StyleRes public int defaultStartNavigationButtonStyle();
     method @StyleRes public int defaultTripProgressStyle();
   }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewBinderCustomization.kt
@@ -5,14 +5,27 @@ import com.mapbox.navigation.dropin.actionbutton.ActionButtonDescription
 import com.mapbox.navigation.dropin.actionbutton.ActionButtonsBinder
 import com.mapbox.navigation.dropin.infopanel.InfoPanelBinder
 import com.mapbox.navigation.dropin.map.MapViewBinder
+import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
+import com.mapbox.navigation.dropin.speedlimit.SpeedInfoViewBinder
+import com.mapbox.navigation.dropin.speedlimit.SpeedLimitViewBinder
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
+import com.mapbox.navigation.utils.internal.ifNonNull
 
 /**
  * A class that allows you to define [UIBinder] for various different views used by the
  * [NavigationView]. If not specified, [NavigationView] uses the default [UIBinder] defined for
  * each of these views.
  */
-class ViewBinderCustomization {
+class ViewBinderCustomization internal constructor(private val navContext: NavigationViewContext?) {
+
+    /**
+     * constructor
+     */
+    @Deprecated(
+        message = "The constructor, if used, would return null when legacySpeedLimitBinder() and " +
+            "defaultSpeedLimitBinder() are invoked"
+    )
+    constructor() : this(null)
 
     /**
      * Customize the speed limit view by providing your own [UIBinder].
@@ -181,4 +194,24 @@ class ViewBinderCustomization {
      * Use [MapViewBinder.defaultBinder] to reset to default.
      */
     var mapViewBinder: MapViewBinder? = null
+
+    /**
+     * Invoke the function to use the legacy speed limit binder.
+     * @return UIBinder
+     */
+    fun legacySpeedLimitBinder(): UIBinder? {
+        return ifNonNull(navContext) {
+            SpeedLimitViewBinder(it)
+        }
+    }
+
+    /**
+     * Invoke the function to use the default speed limit binder.
+     * @return UIBinder
+     */
+    fun defaultSpeedInfoBinder(): UIBinder? {
+        return ifNonNull(navContext) {
+            SpeedInfoViewBinder(it)
+        }
+    }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/ViewStyleCustomization.kt
@@ -26,6 +26,8 @@ import com.mapbox.navigation.ui.maneuver.view.MapboxManeuverView
 import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
 import com.mapbox.navigation.ui.maps.roadname.view.MapboxRoadNameView
 import com.mapbox.navigation.ui.maps.view.MapboxCameraModeButton
+import com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions
+import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView
 import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView
 import com.mapbox.navigation.ui.tripprogress.view.MapboxTripProgressView
 import com.mapbox.navigation.ui.voice.view.MapboxAudioGuidanceButton
@@ -92,18 +94,10 @@ class ViewStyleCustomization {
     var tripProgressStyle: Int? = null
 
     /**
-     * Provide custom [MapboxSpeedLimitView] style.
-     * Use [defaultSpeedLimitStyle] to reset to default.
+     * Provide options to style [MapboxSpeedInfoView] MUTCD and VIENNA configuration .
+     * Use [defaultSpeedInfoOptions] to reset to default.
      */
-    @StyleRes
-    var speedLimitStyle: Int? = null
-
-    /**
-     * Provide custom [MapboxSpeedLimitView] [TextAppearance].
-     * Use [defaultSpeedLimitTextAppearance] to reset to default.
-     */
-    @StyleRes
-    var speedLimitTextAppearance: Int? = null
+    var speedInfoOptions: MapboxSpeedInfoOptions? = null
 
     /**
      * Provide custom [MapboxRoadNameView] [TextAppearance].
@@ -182,6 +176,28 @@ class ViewStyleCustomization {
      */
     var locationPuckOptions: LocationPuckOptions? = null
 
+    /**
+     * Provide custom [MapboxSpeedLimitView] style.
+     * Use [defaultSpeedLimitStyle] to reset to default.
+     */
+    @StyleRes
+    @Deprecated(
+        message = "The parent MapboxSpeedLimitView is deprecated",
+        replaceWith = ReplaceWith("speedInfoOptions")
+    )
+    var speedLimitStyle: Int? = null
+
+    /**
+     * Provide custom [MapboxSpeedLimitView] [TextAppearance].
+     * Use [defaultSpeedLimitTextAppearance] to reset to default.
+     */
+    @StyleRes
+    @Deprecated(
+        message = "The parent MapboxSpeedLimitView is deprecated",
+        replaceWith = ReplaceWith("speedInfoOptions")
+    )
+    var speedLimitTextAppearance: Int? = null
+
     companion object {
         /**
          * Default info panel peek height in pixels.
@@ -239,18 +255,6 @@ class ViewStyleCustomization {
          */
         @StyleRes
         fun defaultTripProgressStyle(): Int = R.style.DropInStyleTripProgressView
-
-        /**
-         * Default [MapboxSpeedLimitView] style.
-         */
-        @StyleRes
-        fun defaultSpeedLimitStyle(): Int = R.style.DropInStyleSpeedLimit
-
-        /**
-         * Default [MapboxSpeedLimitView] [TextAppearance].
-         */
-        @StyleRes
-        fun defaultSpeedLimitTextAppearance(): Int = R.style.DropInSpeedLimitTextAppearance
 
         /**
          * Default [MapboxRoadNameView] [TextAppearance].
@@ -366,6 +370,32 @@ class ViewStyleCustomization {
          */
         fun defaultLocationPuckOptions(context: Context): LocationPuckOptions =
             LocationPuckOptions.Builder(context).build()
+
+        /**
+         * Default [MapboxSpeedInfoOptions]
+         */
+        fun defaultSpeedInfoOptions(): MapboxSpeedInfoOptions =
+            MapboxSpeedInfoOptions.Builder().build()
+
+        /**
+         * Default [MapboxSpeedLimitView] style.
+         */
+        @Deprecated(
+            message = "The parent MapboxSpeedLimitView is deprecated",
+            replaceWith = ReplaceWith("speedInfoOptions")
+        )
+        @StyleRes
+        fun defaultSpeedLimitStyle(): Int = R.style.DropInStyleSpeedLimit
+
+        /**
+         * Default [MapboxSpeedLimitView] [TextAppearance].
+         */
+        @Deprecated(
+            message = "The parent MapboxSpeedLimitView is deprecated",
+            replaceWith = ReplaceWith("speedInfoOptions")
+        )
+        @StyleRes
+        fun defaultSpeedLimitTextAppearance(): Int = R.style.DropInSpeedLimitTextAppearance
 
         private fun defaultMutcdProperties() = MapboxExitProperties.PropertiesMutcd(
             exitBackground = R.drawable.mapbox_dropin_exit_board_background,

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewContext.kt
@@ -68,7 +68,7 @@ internal class NavigationViewContext(
     )
 
     fun applyBinderCustomization(action: ViewBinderCustomization.() -> Unit) {
-        val customization = ViewBinderCustomization().apply(action)
+        val customization = ViewBinderCustomization(this).apply(action)
         uiBinders.applyCustomization(customization)
     }
 

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewStyles.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewStyles.kt
@@ -5,6 +5,7 @@ import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.navigation.dropin.ViewStyleCustomization
 import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
 import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
+import com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -39,10 +40,8 @@ internal class NavigationViewStyles(context: Context) {
     private var _startNavigationButtonStyle: MutableStateFlow<Int> =
         MutableStateFlow(ViewStyleCustomization.defaultStartNavigationButtonStyle())
 
-    private val _speedLimitStyle: MutableStateFlow<Int> =
-        MutableStateFlow(ViewStyleCustomization.defaultSpeedLimitStyle())
-    private val _speedLimitTextAppearance: MutableStateFlow<Int> =
-        MutableStateFlow(ViewStyleCustomization.defaultSpeedLimitTextAppearance())
+    private val _speedInfoOptions: MutableStateFlow<MapboxSpeedInfoOptions> =
+        MutableStateFlow(ViewStyleCustomization.defaultSpeedInfoOptions())
     private val _roadNameBackground: MutableStateFlow<Int> =
         MutableStateFlow(ViewStyleCustomization.defaultRoadNameBackground())
     private val _roadNameTextAppearance: MutableStateFlow<Int> =
@@ -55,6 +54,14 @@ internal class NavigationViewStyles(context: Context) {
         MutableStateFlow(ViewStyleCustomization.defaultArrivalTextAppearance())
     private val _locationPuckOptions: MutableStateFlow<LocationPuckOptions> =
         MutableStateFlow(ViewStyleCustomization.defaultLocationPuckOptions(context))
+
+    @Deprecated(message = "The parent MapboxSpeedLimitView is deprecated")
+    private val _speedLimitStyle: MutableStateFlow<Int> =
+        MutableStateFlow(ViewStyleCustomization.defaultSpeedLimitStyle())
+
+    @Deprecated(message = "The parent MapboxSpeedLimitView is deprecated")
+    private val _speedLimitTextAppearance: MutableStateFlow<Int> =
+        MutableStateFlow(ViewStyleCustomization.defaultSpeedLimitTextAppearance())
 
     val infoPanelPeekHeight: StateFlow<Int> = _infoPanelPeekHeight.asStateFlow()
     val infoPanelMarginStart: StateFlow<Int> = _infoPanelMarginStart.asStateFlow()
@@ -71,8 +78,7 @@ internal class NavigationViewStyles(context: Context) {
     val endNavigationButtonStyle: StateFlow<Int> = _endNavigationButtonStyle.asStateFlow()
     val startNavigationButtonStyle: StateFlow<Int> = _startNavigationButtonStyle.asStateFlow()
 
-    val speedLimitStyle: StateFlow<Int> = _speedLimitStyle.asStateFlow()
-    val speedLimitTextAppearance: StateFlow<Int> = _speedLimitTextAppearance.asStateFlow()
+    val speedInfoOptions: StateFlow<MapboxSpeedInfoOptions> = _speedInfoOptions.asStateFlow()
     val destinationMarkerAnnotationOptions: StateFlow<PointAnnotationOptions> =
         _destinationMarkerAnnotationOptions.asStateFlow()
     val roadNameBackground: StateFlow<Int> = _roadNameBackground.asStateFlow()
@@ -80,6 +86,18 @@ internal class NavigationViewStyles(context: Context) {
     val maneuverViewOptions: StateFlow<ManeuverViewOptions> = _maneuverViewOptions.asStateFlow()
     val arrivalTextAppearance: StateFlow<Int> = _arrivalTextAppearance.asStateFlow()
     val locationPuckOptions: StateFlow<LocationPuckOptions> = _locationPuckOptions.asStateFlow()
+
+    @Deprecated(
+        message = "The parent MapboxSpeedLimitView is deprecated",
+        replaceWith = ReplaceWith("speedInfoStyle")
+    )
+    val speedLimitStyle: StateFlow<Int> = _speedLimitStyle.asStateFlow()
+
+    @Deprecated(
+        message = "The parent MapboxSpeedLimitView is deprecated",
+        replaceWith = ReplaceWith("speedInfoStyle")
+    )
+    val speedLimitTextAppearance: StateFlow<Int> = _speedLimitTextAppearance.asStateFlow()
 
     fun applyCustomization(customization: ViewStyleCustomization) {
         customization.infoPanelPeekHeight?.also { _infoPanelPeekHeight.value = it }
@@ -97,9 +115,8 @@ internal class NavigationViewStyles(context: Context) {
         customization.endNavigationButtonStyle?.also { _endNavigationButtonStyle.value = it }
         customization.startNavigationButtonStyle?.also { _startNavigationButtonStyle.value = it }
 
-        customization.speedLimitStyle?.also { _speedLimitStyle.value = it }
+        customization.speedInfoOptions?.also { _speedInfoOptions.value = it }
         customization.maneuverViewOptions?.also { _maneuverViewOptions.value = it }
-        customization.speedLimitTextAppearance?.also { _speedLimitTextAppearance.value = it }
         customization.destinationMarkerAnnotationOptions?.also {
             _destinationMarkerAnnotationOptions.value = it
         }
@@ -107,5 +124,8 @@ internal class NavigationViewStyles(context: Context) {
         customization.roadNameTextAppearance?.also { _roadNameTextAppearance.value = it }
         customization.arrivalTextAppearance?.also { _arrivalTextAppearance.value = it }
         customization.locationPuckOptions?.also { _locationPuckOptions.value = it }
+
+        customization.speedLimitStyle?.also { _speedLimitStyle.value = it }
+        customization.speedLimitTextAppearance?.also { _speedLimitTextAppearance.value = it }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/speedlimit/SpeedInfoViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/speedlimit/SpeedInfoViewBinder.kt
@@ -6,36 +6,32 @@ import androidx.transition.Scene
 import androidx.transition.TransitionManager
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.dropin.R
-import com.mapbox.navigation.dropin.databinding.MapboxSpeedLimitLayoutBinding
+import com.mapbox.navigation.dropin.databinding.MapboxSpeedInfoLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.reloadOnChange
 import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
 import com.mapbox.navigation.ui.base.lifecycle.UIBinder
-import com.mapbox.navigation.ui.speedlimit.internal.SpeedLimitComponent
+import com.mapbox.navigation.ui.speedlimit.internal.SpeedInfoComponent
 
-@Deprecated(
-    message = "The binder is deprecated as it is incapable of rendering user's current speed",
-    replaceWith = ReplaceWith("SpeedInfoViewBinder", imports = arrayOf("SpeedInfoViewBinder"))
-)
-internal class SpeedLimitViewBinder(
+internal class SpeedInfoViewBinder(
     val context: NavigationViewContext
 ) : UIBinder {
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
         val scene = Scene.getSceneForLayout(
             viewGroup,
-            R.layout.mapbox_speed_limit_layout,
+            R.layout.mapbox_speed_info_layout,
             viewGroup.context
         )
         TransitionManager.go(scene, Fade())
-        val binding = MapboxSpeedLimitLayoutBinding.bind(viewGroup)
+        val binding = MapboxSpeedInfoLayoutBinding.bind(viewGroup)
 
         return reloadOnChange(
-            context.styles.speedLimitStyle,
-            context.styles.speedLimitTextAppearance
-        ) { style, textAppearance ->
-            SpeedLimitComponent(
-                style = style,
-                textAppearance = textAppearance,
-                speedLimitView = binding.speedLimitView,
+            context.styles.speedInfoOptions,
+            context.options.distanceFormatterOptions,
+        ) { options, distanceFormatter ->
+            SpeedInfoComponent(
+                speedInfoOptions = options,
+                speedInfoView = binding.speedInfoView,
+                distanceFormatterOptions = distanceFormatter,
             )
         }
     }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/speedlimit/SpeedLimitCoordinator.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/speedlimit/SpeedLimitCoordinator.kt
@@ -23,7 +23,7 @@ internal class SpeedLimitCoordinator(
             context.uiBinders.speedLimit
         ) { show, binder ->
             if (show) {
-                binder ?: SpeedLimitViewBinder(context)
+                binder ?: SpeedInfoViewBinder(context)
             } else {
                 EmptyBinder()
             }

--- a/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
@@ -69,7 +69,7 @@
                 <FrameLayout
                     android:id="@+id/speedLimitLayout"
                     android:layout_width="75dp"
-                    android:layout_height="86dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginStart="4dp"
                     android:layout_marginTop="8dp"
                     app:layout_constraintStart_toEndOf="@id/guidanceLayout"

--- a/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
@@ -63,7 +63,7 @@
                 <FrameLayout
                     android:id="@+id/speedLimitLayout"
                     android:layout_width="75dp"
-                    android:layout_height="86dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
                     android:layout_marginTop="8dp"
                     app:layout_constraintStart_toStartOf="parent"

--- a/libnavui-dropin/src/main/res/layout/mapbox_speed_info_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_speed_info_layout.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:parentTag="android.widget.FrameLayout">
+
+    <com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView
+        android:id="@+id/speedInfoView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</merge>

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewBinderTest.kt
@@ -86,7 +86,7 @@ internal class NavigationViewBinderTest {
         sut.applyCustomization(customization())
 
         sut.applyCustomization(
-            ViewBinderCustomization().apply {
+            ViewBinderCustomization(mockk()).apply {
                 speedLimitBinder = UIBinder.USE_DEFAULT
                 maneuverBinder = UIBinder.USE_DEFAULT
                 roadNameBinder = UIBinder.USE_DEFAULT
@@ -153,7 +153,7 @@ internal class NavigationViewBinderTest {
         assertTrue(sut.mapViewBinder.value is MapboxMapViewBinder)
     }
 
-    private fun customization() = ViewBinderCustomization().apply {
+    private fun customization() = ViewBinderCustomization(mockk()).apply {
         speedLimitBinder = EmptyBinder()
         maneuverBinder = EmptyBinder()
         roadNameBinder = EmptyBinder()

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewStylesTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/navigationview/NavigationViewStylesTest.kt
@@ -9,6 +9,8 @@ import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.ViewStyleCustomization
 import com.mapbox.navigation.ui.maneuver.model.ManeuverViewOptions
 import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
+import com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions
+import com.mapbox.navigation.ui.speedlimit.model.SpeedInfoStyle
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -57,6 +59,7 @@ class NavigationViewStylesTest {
         assertEquals(c.roadNameTextAppearance, sut.roadNameTextAppearance.value)
         assertEquals(c.arrivalTextAppearance, sut.arrivalTextAppearance.value)
         assertEquals(c.locationPuckOptions, sut.locationPuckOptions.value)
+        assertEquals(c.speedInfoOptions, sut.speedInfoOptions.value)
     }
 
     private fun customization() = ViewStyleCustomization().apply {
@@ -80,6 +83,21 @@ class NavigationViewStylesTest {
         roadNameBackground = android.R.drawable.spinner_background
         roadNameTextAppearance = android.R.style.TextAppearance_DeviceDefault_Large
         arrivalTextAppearance = android.R.style.TextAppearance_DeviceDefault_Large
+        speedInfoOptions = MapboxSpeedInfoOptions.Builder().speedInfoStyle(
+            SpeedInfoStyle().apply {
+                mutcdLayoutBackground = android.R.drawable.spinner_background
+                postedSpeedMutcdLayoutBackground = android.R.drawable.spinner_background
+                postedSpeedLegendTextAppearance = android.R.style.TextAppearance_DeviceDefault_Large
+                postedSpeedMutcdTextAppearance = android.R.style.TextAppearance_DeviceDefault_Large
+                postedSpeedUnitTextAppearance = android.R.style.TextAppearance_DeviceDefault_Large
+                currentSpeedMutcdTextAppearance = android.R.style.TextAppearance_DeviceDefault_Large
+
+                viennaLayoutBackground = android.R.drawable.spinner_background
+                postedSpeedViennaLayoutBackground = android.R.drawable.spinner_background
+                postedSpeedViennaTextAppearance = android.R.style.TextAppearance_DeviceDefault_Large
+                currentSpeedViennaTextAppearance = android.R.style.TextAppearance_DeviceDefault
+            }
+        ).build()
         locationPuckOptions = LocationPuckOptions
             .Builder(ctx)
             .freeDrivePuck(

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/speedlimit/SpeedInfoViewBinderTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/speedlimit/SpeedInfoViewBinderTest.kt
@@ -1,0 +1,124 @@
+package com.mapbox.navigation.dropin.speedlimit
+
+import android.content.Context
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.dropin.R
+import com.mapbox.navigation.dropin.internal.extensions.ReloadingComponent
+import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
+import com.mapbox.navigation.dropin.navigationview.NavigationViewModel
+import com.mapbox.navigation.dropin.testutil.TestLifecycleOwner
+import com.mapbox.navigation.dropin.util.TestStore
+import com.mapbox.navigation.testing.LoggingFrontendTestRule
+import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.speedlimit.internal.SpeedInfoComponent
+import com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions
+import com.mapbox.navigation.ui.speedlimit.model.SpeedInfoStyle
+import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class SpeedInfoViewBinderTest {
+
+    @get:Rule
+    val loggerRule = LoggingFrontendTestRule()
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+
+    private lateinit var ctx: Context
+    private lateinit var navContext: NavigationViewContext
+    private lateinit var mapboxNavigation: MapboxNavigation
+    private lateinit var sut: SpeedInfoViewBinder
+
+    @Before
+    fun setUp() {
+        ctx = ApplicationProvider.getApplicationContext()
+        navContext = NavigationViewContext(
+            context = ctx,
+            lifecycleOwner = TestLifecycleOwner(),
+            viewModel = NavigationViewModel(),
+            storeProvider = { TestStore() }
+        )
+        mapboxNavigation = mockk(relaxed = true)
+
+        sut = SpeedInfoViewBinder(navContext)
+    }
+
+    @Test
+    fun `bind should inflate speed limit layout`() {
+        val rootLayout = FrameLayout(ctx)
+
+        sut.bind(rootLayout)
+
+        assertNotNull(
+            "Expected MapboxSpeedInfoView",
+            rootLayout.findViewById<MapboxSpeedInfoView>(R.id.speedInfoView)
+        )
+    }
+
+    @Test
+    fun `bind should return ReloadingComponent that attaches SpeedInfoComponent`() =
+        runBlockingTest {
+            val rootLayout = FrameLayout(ctx)
+            val reloadComponent = sut.bind(rootLayout) as ReloadingComponent<*>
+            reloadComponent.onAttached(mapboxNavigation)
+
+            assertTrue(reloadComponent.childComponent is SpeedInfoComponent)
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `bind should return ReloadingComponent that reloads child component on style change`() =
+        coroutineRule.runBlockingTest {
+            val rootLayout = FrameLayout(ctx)
+            val reloadComponent = sut.bind(rootLayout) as ReloadingComponent<*>
+            reloadComponent.onAttached(mapboxNavigation)
+
+            val firstComponent = reloadComponent.childComponent
+            navContext.applyStyleCustomization {
+                speedInfoOptions = MapboxSpeedInfoOptions
+                    .Builder()
+                    .speedInfoStyle(
+                        SpeedInfoStyle().apply {
+                            mutcdLayoutBackground = android.R.drawable.spinner_background
+                        }
+                    )
+                    .build()
+            }
+
+            assertNotEquals(firstComponent, reloadComponent.childComponent)
+        }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `bind should return ReloadingComponent that reloads child component on distanceFormatter change`() =
+        coroutineRule.runBlockingTest {
+            val rootLayout = FrameLayout(ctx)
+            val reloadComponent = sut.bind(rootLayout) as ReloadingComponent<*>
+            reloadComponent.onAttached(mapboxNavigation)
+
+            val firstComponent = reloadComponent.childComponent
+            navContext.applyOptionsCustomization {
+                distanceFormatterOptions = DistanceFormatterOptions
+                    .Builder(ctx)
+                    .roundingIncrement(25)
+                    .build()
+            }
+
+            assertNotEquals(firstComponent, reloadComponent.childComponent)
+        }
+}

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/speedlimit/SpeedLimitCoordinatorTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/speedlimit/SpeedLimitCoordinatorTest.kt
@@ -58,7 +58,7 @@ class SpeedLimitCoordinatorTest {
     fun `should return default binder`() = runBlockingTest {
         coordinator.apply {
             val binders = mapboxNavigation.flowViewBinders().take(1).toList()
-            assertTrue(binders.first() is SpeedLimitViewBinder)
+            assertTrue(binders.first() is SpeedInfoViewBinder)
         }
     }
 

--- a/libnavui-speedlimit/api/current.txt
+++ b/libnavui-speedlimit/api/current.txt
@@ -2,7 +2,17 @@
 package com.mapbox.navigation.ui.speedlimit {
 
   public final class ComponentInstallerKt {
+    method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public static com.mapbox.navigation.ui.base.installer.Installation speedInfo(com.mapbox.navigation.ui.base.installer.ComponentInstaller, com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView speedInfoView, kotlin.jvm.functions.Function1<? super com.mapbox.navigation.ui.speedlimit.SpeedInfoConfig,kotlin.Unit> config = {});
     method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public static com.mapbox.navigation.ui.base.installer.Installation speedLimit(com.mapbox.navigation.ui.base.installer.ComponentInstaller, com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView speedLimitView, kotlin.jvm.functions.Function1<? super com.mapbox.navigation.ui.speedlimit.SpeedLimitConfig,kotlin.Unit> config = {});
+  }
+
+  @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class SpeedInfoConfig {
+    method public com.mapbox.navigation.base.formatter.DistanceFormatterOptions getDistanceFormatterOptions();
+    method public com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions getSpeedInfoOptions();
+    method public void setDistanceFormatterOptions(com.mapbox.navigation.base.formatter.DistanceFormatterOptions);
+    method public void setSpeedInfoOptions(com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions);
+    property public final com.mapbox.navigation.base.formatter.DistanceFormatterOptions distanceFormatterOptions;
+    property public final com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions speedInfoOptions;
   }
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class SpeedLimitConfig {
@@ -48,12 +58,14 @@ package com.mapbox.navigation.ui.speedlimit.model {
     method public boolean getShowLegend();
     method public boolean getShowSpeedWhenUnavailable();
     method public boolean getShowUnit();
+    method public com.mapbox.navigation.ui.speedlimit.model.SpeedInfoStyle getSpeedInfoStyle();
     method public com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions.Builder toBuilder();
     property public final com.mapbox.navigation.ui.speedlimit.model.CurrentSpeedDirection currentSpeedDirection;
     property public final com.mapbox.navigation.base.speed.model.SpeedLimitSign? renderWithSpeedSign;
     property public final boolean showLegend;
     property public final boolean showSpeedWhenUnavailable;
     property public final boolean showUnit;
+    property public final com.mapbox.navigation.ui.speedlimit.model.SpeedInfoStyle speedInfoStyle;
   }
 
   public static final class MapboxSpeedInfoOptions.Builder {
@@ -64,6 +76,7 @@ package com.mapbox.navigation.ui.speedlimit.model {
     method public com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions.Builder showLegend(boolean showLegend);
     method @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions.Builder showSpeedWhenUnavailable(boolean showSpeedWhenUnavailable);
     method public com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions.Builder showUnit(boolean showUnit);
+    method public com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions.Builder speedInfoStyle(com.mapbox.navigation.ui.speedlimit.model.SpeedInfoStyle speedInfoStyle);
   }
 
   public final class PostedAndCurrentSpeedFormatter implements com.mapbox.navigation.ui.base.formatter.ValueFormatter<com.mapbox.navigation.ui.speedlimit.model.SpeedData,java.lang.Integer> {
@@ -78,6 +91,40 @@ package com.mapbox.navigation.ui.speedlimit.model {
     property public final com.mapbox.navigation.base.speed.model.SpeedUnit fromUnit;
     property public final double speed;
     property public final com.mapbox.navigation.base.formatter.UnitType toUnit;
+  }
+
+  public final class SpeedInfoStyle {
+    ctor public SpeedInfoStyle();
+    method public int getCurrentSpeedMutcdTextAppearance();
+    method public int getCurrentSpeedViennaTextAppearance();
+    method public int getMutcdLayoutBackground();
+    method public int getPostedSpeedLegendTextAppearance();
+    method public int getPostedSpeedMutcdLayoutBackground();
+    method public int getPostedSpeedMutcdTextAppearance();
+    method public int getPostedSpeedUnitTextAppearance();
+    method public int getPostedSpeedViennaLayoutBackground();
+    method public int getPostedSpeedViennaTextAppearance();
+    method public int getViennaLayoutBackground();
+    method public void setCurrentSpeedMutcdTextAppearance(int);
+    method public void setCurrentSpeedViennaTextAppearance(int);
+    method public void setMutcdLayoutBackground(int);
+    method public void setPostedSpeedLegendTextAppearance(int);
+    method public void setPostedSpeedMutcdLayoutBackground(int);
+    method public void setPostedSpeedMutcdTextAppearance(int);
+    method public void setPostedSpeedUnitTextAppearance(int);
+    method public void setPostedSpeedViennaLayoutBackground(int);
+    method public void setPostedSpeedViennaTextAppearance(int);
+    method public void setViennaLayoutBackground(int);
+    property public final int currentSpeedMutcdTextAppearance;
+    property public final int currentSpeedViennaTextAppearance;
+    property public final int mutcdLayoutBackground;
+    property public final int postedSpeedLegendTextAppearance;
+    property public final int postedSpeedMutcdLayoutBackground;
+    property public final int postedSpeedMutcdTextAppearance;
+    property public final int postedSpeedUnitTextAppearance;
+    property public final int postedSpeedViennaLayoutBackground;
+    property public final int postedSpeedViennaTextAppearance;
+    property public final int viennaLayoutBackground;
   }
 
   public final class SpeedInfoValue {

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/ComponentInstaller.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/ComponentInstaller.kt
@@ -1,10 +1,15 @@
 package com.mapbox.navigation.ui.speedlimit
 
+import android.content.Context
 import androidx.annotation.StyleRes
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
 import com.mapbox.navigation.ui.base.installer.ComponentInstaller
 import com.mapbox.navigation.ui.base.installer.Installation
+import com.mapbox.navigation.ui.speedlimit.internal.SpeedInfoComponent
 import com.mapbox.navigation.ui.speedlimit.internal.SpeedLimitComponent
+import com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions
+import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView
 import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView
 
 /**
@@ -29,6 +34,27 @@ fun ComponentInstaller.speedLimit(
 }
 
 /**
+ * Install components that render [MapboxSpeedInfoView].
+ *
+ * @param speedInfoView [MapboxSpeedInfoView]
+ * @param config SpeedInfoConfig
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+fun ComponentInstaller.speedInfo(
+    speedInfoView: MapboxSpeedInfoView,
+    config: SpeedInfoConfig.() -> Unit = {}
+): Installation {
+    val componentConfig = SpeedInfoConfig(speedInfoView.context).apply(config)
+    return component(
+        SpeedInfoComponent(
+            speedInfoOptions = componentConfig.speedInfoOptions,
+            speedInfoView = speedInfoView,
+            distanceFormatterOptions = componentConfig.distanceFormatterOptions
+        )
+    )
+}
+
+/**
  * Speed limit view component configuration class.
  */
 @ExperimentalPreviewMapboxNavigationAPI
@@ -42,4 +68,21 @@ class SpeedLimitConfig internal constructor() {
      * [textAppearance] to be set to [MapboxSpeedLimitView].
      */
     @StyleRes var textAppearance: Int = 0
+}
+
+/**
+ * Speed info view component configuration class.
+ */
+@ExperimentalPreviewMapboxNavigationAPI
+class SpeedInfoConfig internal constructor(context: Context) {
+    /**
+     * [speedInfoOptions] to be set to [MapboxSpeedInfoView].
+     */
+    var speedInfoOptions: MapboxSpeedInfoOptions = MapboxSpeedInfoOptions.Builder().build()
+
+    /**
+     * [DistanceFormatterOptions] to be used by [MapboxSpeedInfoView].
+     */
+    var distanceFormatterOptions: DistanceFormatterOptions =
+        DistanceFormatterOptions.Builder(context).build()
 }

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedInfoComponent.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedInfoComponent.kt
@@ -1,0 +1,35 @@
+package com.mapbox.navigation.ui.speedlimit.internal
+
+import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.extensions.flowLocationMatcherResult
+import com.mapbox.navigation.ui.base.lifecycle.UIComponent
+import com.mapbox.navigation.ui.speedlimit.api.MapboxSpeedInfoApi
+import com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions
+import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+class SpeedInfoComponent(
+    private val speedInfoView: MapboxSpeedInfoView,
+    private val speedInfoOptions: MapboxSpeedInfoOptions,
+    private val distanceFormatterOptions: DistanceFormatterOptions,
+    private val speedInfoApi: MapboxSpeedInfoApi = MapboxSpeedInfoApi()
+) : UIComponent() {
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        super.onAttached(mapboxNavigation)
+
+        speedInfoView.applyOptions(speedInfoOptions)
+
+        coroutineScope.launch {
+            mapboxNavigation.flowLocationMatcherResult().collect { locationMatcher ->
+                val value = speedInfoApi.updatePostedAndCurrentSpeed(
+                    locationMatcher,
+                    distanceFormatterOptions,
+                )
+                speedInfoView.render(value)
+            }
+        }
+    }
+}

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedLimitComponent.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedLimitComponent.kt
@@ -10,6 +10,10 @@ import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedLimitView
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
+@Deprecated(
+    message = "The component cannot render user's current speed",
+    replaceWith = ReplaceWith("SpeedInfoComponent", imports = arrayOf("SpeedInfoComponent"))
+)
 class SpeedLimitComponent(
     @StyleRes val style: Int,
     @StyleRes val textAppearance: Int,

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/model/MapboxSpeedInfoOptions.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/model/MapboxSpeedInfoOptions.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView
  * Default value is true.
  * @param showLegend If set to true [MapboxSpeedInfoView] will render the text "Speed Limit" for
  * MUTCD convention. Default value is false.
+ * @param speedInfoStyle applies styles to [MapboxSpeedInfoView]
  * @param showSpeedWhenUnavailable If set to true [MapboxSpeedInfoView] will render the posted speed
  * with text "--". Default value is false.
  * @param renderWithSpeedSign [MapboxSpeedInfoView] will always render in Vienna convention if
@@ -28,6 +29,7 @@ import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView
 class MapboxSpeedInfoOptions private constructor(
     val showUnit: Boolean,
     val showLegend: Boolean,
+    val speedInfoStyle: SpeedInfoStyle,
     @ExperimentalPreviewMapboxNavigationAPI val showSpeedWhenUnavailable: Boolean,
     @ExperimentalPreviewMapboxNavigationAPI val renderWithSpeedSign: SpeedLimitSign?,
     val currentSpeedDirection: CurrentSpeedDirection,
@@ -41,6 +43,7 @@ class MapboxSpeedInfoOptions private constructor(
         return Builder()
             .showUnit(showUnit)
             .showLegend(showLegend)
+            .speedInfoStyle(speedInfoStyle)
             .showSpeedWhenUnavailable(showSpeedWhenUnavailable)
             .renderWithSpeedSign(renderWithSpeedSign)
             .currentSpeedDirection(currentSpeedDirection)
@@ -54,6 +57,7 @@ class MapboxSpeedInfoOptions private constructor(
         return "MapboxSpeedInfoOptions(" +
             "showUnit=$showUnit, " +
             "showLegend=$showLegend, " +
+            "speedInfoStyle=$speedInfoStyle, " +
             "showSpeedWhenUnavailable=$showSpeedWhenUnavailable, " +
             "renderWithSpeedSign=$renderWithSpeedSign, " +
             "currentSpeedDirection=$currentSpeedDirection" +
@@ -72,6 +76,7 @@ class MapboxSpeedInfoOptions private constructor(
 
         if (showUnit != other.showUnit) return false
         if (showLegend != other.showLegend) return false
+        if (speedInfoStyle != other.speedInfoStyle) return false
         if (showSpeedWhenUnavailable != other.showSpeedWhenUnavailable) return false
         if (renderWithSpeedSign != other.renderWithSpeedSign) return false
         if (currentSpeedDirection != other.currentSpeedDirection) return false
@@ -86,6 +91,7 @@ class MapboxSpeedInfoOptions private constructor(
     override fun hashCode(): Int {
         var result = showUnit.hashCode()
         result = 31 * result + showLegend.hashCode()
+        result = 31 * result + speedInfoStyle.hashCode()
         result = 31 * result + showSpeedWhenUnavailable.hashCode()
         result = 31 * result + renderWithSpeedSign.hashCode()
         result = 31 * result + currentSpeedDirection.hashCode()
@@ -98,6 +104,7 @@ class MapboxSpeedInfoOptions private constructor(
     class Builder {
         private var showUnit: Boolean = true
         private var showLegend: Boolean = false
+        private var speedInfoStyle: SpeedInfoStyle = SpeedInfoStyle()
         private var showSpeedWhenUnavailable: Boolean = false
         private var renderWithSpeedSign: SpeedLimitSign? = null
         private var currentSpeedDirection: CurrentSpeedDirection = CurrentSpeedDirection.BOTTOM
@@ -116,6 +123,14 @@ class MapboxSpeedInfoOptions private constructor(
          */
         fun showLegend(showLegend: Boolean): Builder = apply {
             this.showLegend = showLegend
+        }
+
+        /**
+         * Apply the value to apply styles to [MapboxSpeedInfoView].
+         * @param speedInfoStyle set to apply your custom styles.
+         */
+        fun speedInfoStyle(speedInfoStyle: SpeedInfoStyle): Builder = apply {
+            this.speedInfoStyle = speedInfoStyle
         }
 
         /**
@@ -159,6 +174,7 @@ class MapboxSpeedInfoOptions private constructor(
             return MapboxSpeedInfoOptions(
                 showUnit,
                 showLegend,
+                speedInfoStyle,
                 showSpeedWhenUnavailable,
                 renderWithSpeedSign,
                 currentSpeedDirection

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/model/SpeedInfoStyle.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/model/SpeedInfoStyle.kt
@@ -1,0 +1,73 @@
+package com.mapbox.navigation.ui.speedlimit.model
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StyleRes
+import com.mapbox.navigation.ui.speedlimit.R
+import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView
+
+/**
+ * A utility class that can be used to apply background and text styling to [MapboxSpeedInfoView]
+ * components.
+ */
+class SpeedInfoStyle {
+
+    /**
+     * Background resource applied to outer view for MUTCD convention.
+     */
+    @DrawableRes
+    var mutcdLayoutBackground: Int = R.drawable.background_mutcd_outer_layout
+
+    /**
+     * Background resource applied to inner view for MUTCD convention.
+     */
+    @DrawableRes
+    var postedSpeedMutcdLayoutBackground: Int = R.drawable.background_mutcd_posted_speed_limit
+
+    /**
+     * Text styling applied to posted speed legend for MUTCD convention.
+     */
+    @StyleRes
+    var postedSpeedLegendTextAppearance: Int = R.style.MapboxSpeedInfoMutcdLegendStyle
+
+    /**
+     * Text styling applied to posted speed for MUTCD convention.
+     */
+    @StyleRes
+    var postedSpeedMutcdTextAppearance: Int = R.style.MapboxSpeedInfoPostedSpeedMutcdStyle
+
+    /**
+     * Text styling applied to posted speed unit for MUTCD convention.
+     */
+    @StyleRes
+    var postedSpeedUnitTextAppearance: Int = R.style.MapboxSpeedInfoMutcdUnitStyle
+
+    /**
+     * Text styling applied to current speed for MUTCD convention.
+     */
+    @StyleRes
+    var currentSpeedMutcdTextAppearance: Int = R.style.MapboxSpeedInfoCurrentSpeedMutcdStyle
+
+    /**
+     * Background resource applied to outer view for VIENNA convention.
+     */
+    @DrawableRes
+    var viennaLayoutBackground: Int = R.drawable.background_vienna_outer_layout
+
+    /**
+     * Background resource applied to inner view for VIENNA convention.
+     */
+    @DrawableRes
+    var postedSpeedViennaLayoutBackground: Int = R.drawable.background_vienna_posted_speed_limit
+
+    /**
+     * Text styling applied to posted speed for VIENNA convention.
+     */
+    @StyleRes
+    var postedSpeedViennaTextAppearance: Int = R.style.MapboxSpeedInfoPostedSpeedViennaStyle
+
+    /**
+     * Text styling applied to current speed for VIENNA convention.
+     */
+    @StyleRes
+    var currentSpeedViennaTextAppearance: Int = R.style.MapboxSpeedInfoCurrentSpeedViennaStyle
+}

--- a/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedInfoView.kt
+++ b/libnavui-speedlimit/src/main/java/com/mapbox/navigation/ui/speedlimit/view/MapboxSpeedInfoView.kt
@@ -20,7 +20,6 @@ import androidx.core.widget.TextViewCompat
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.speed.model.SpeedLimitSign
 import com.mapbox.navigation.base.speed.model.SpeedUnit
-import com.mapbox.navigation.ui.speedlimit.R
 import com.mapbox.navigation.ui.speedlimit.api.MapboxSpeedInfoApi
 import com.mapbox.navigation.ui.speedlimit.databinding.MapboxSpeedInfoViewBinding
 import com.mapbox.navigation.ui.speedlimit.model.CurrentSpeedDirection
@@ -124,39 +123,7 @@ class MapboxSpeedInfoView : FrameLayout {
 
     init {
         applyOptions(speedInfoOptions)
-        speedInfoMutcdLayout.setBackgroundResource(R.drawable.background_mutcd_outer_layout)
-        speedInfoPostedSpeedLayoutMutcd.setBackgroundResource(
-            R.drawable.background_mutcd_posted_speed_limit
-        )
-        TextViewCompat.setTextAppearance(
-            speedInfoLegendTextMutcd,
-            R.style.MapboxSpeedInfoMutcdLegendStyle
-        )
-        TextViewCompat.setTextAppearance(
-            speedInfoPostedSpeedMutcd,
-            R.style.MapboxSpeedInfoPostedSpeedMutcdStyle
-        )
-        TextViewCompat.setTextAppearance(
-            speedInfoUnitTextMutcd,
-            R.style.MapboxSpeedInfoMutcdUnitStyle
-        )
-        TextViewCompat.setTextAppearance(
-            speedInfoCurrentSpeedMutcd,
-            R.style.MapboxSpeedInfoCurrentSpeedMutcdStyle
-        )
-
-        speedInfoViennaLayout.setBackgroundResource(R.drawable.background_vienna_outer_layout)
-        speedInfoPostedSpeedLayoutVienna.setBackgroundResource(
-            R.drawable.background_vienna_posted_speed_limit
-        )
-        TextViewCompat.setTextAppearance(
-            speedInfoPostedSpeedVienna,
-            R.style.MapboxSpeedInfoPostedSpeedViennaStyle
-        )
-        TextViewCompat.setTextAppearance(
-            speedInfoCurrentSpeedVienna,
-            R.style.MapboxSpeedInfoCurrentSpeedViennaStyle
-        )
+        updateStyles()
     }
 
     /**
@@ -200,6 +167,7 @@ class MapboxSpeedInfoView : FrameLayout {
      */
     fun applyOptions(speedInfoOptions: MapboxSpeedInfoOptions) {
         this.speedInfoOptions = speedInfoOptions
+        updateStyles()
         updateView()
     }
 
@@ -248,6 +216,46 @@ class MapboxSpeedInfoView : FrameLayout {
                 // No-op
             }
         }
+    }
+
+    private fun updateStyles() {
+        speedInfoMutcdLayout.setBackgroundResource(
+            speedInfoOptions.speedInfoStyle.mutcdLayoutBackground
+        )
+        speedInfoPostedSpeedLayoutMutcd.setBackgroundResource(
+            speedInfoOptions.speedInfoStyle.postedSpeedMutcdLayoutBackground
+        )
+        TextViewCompat.setTextAppearance(
+            speedInfoLegendTextMutcd,
+            speedInfoOptions.speedInfoStyle.postedSpeedLegendTextAppearance
+        )
+        TextViewCompat.setTextAppearance(
+            speedInfoPostedSpeedMutcd,
+            speedInfoOptions.speedInfoStyle.postedSpeedMutcdTextAppearance
+        )
+        TextViewCompat.setTextAppearance(
+            speedInfoUnitTextMutcd,
+            speedInfoOptions.speedInfoStyle.postedSpeedUnitTextAppearance
+        )
+        TextViewCompat.setTextAppearance(
+            speedInfoCurrentSpeedMutcd,
+            speedInfoOptions.speedInfoStyle.currentSpeedMutcdTextAppearance
+        )
+
+        speedInfoViennaLayout.setBackgroundResource(
+            speedInfoOptions.speedInfoStyle.viennaLayoutBackground
+        )
+        speedInfoPostedSpeedLayoutVienna.setBackgroundResource(
+            speedInfoOptions.speedInfoStyle.postedSpeedViennaLayoutBackground
+        )
+        TextViewCompat.setTextAppearance(
+            speedInfoPostedSpeedVienna,
+            speedInfoOptions.speedInfoStyle.postedSpeedViennaTextAppearance
+        )
+        TextViewCompat.setTextAppearance(
+            speedInfoCurrentSpeedVienna,
+            speedInfoOptions.speedInfoStyle.currentSpeedViennaTextAppearance
+        )
     }
 
     private fun updateView() {

--- a/libnavui-speedlimit/src/main/res/values-night/colors.xml
+++ b/libnavui-speedlimit/src/main/res/values-night/colors.xml
@@ -5,7 +5,7 @@
     <color name="mapbox_speed_limit_view_mutcd_border">@android:color/black</color>
     <color name="mapbox_speed_limit_view_vienna_border">#EE0000</color>
 
-    <color name="mapbox_speed_info_background_color">@color/colorSurface</color>
+    <color name="mapbox_speed_info_background_color">#FFFFFF</color>
     <color name="mapbox_speed_info_border_color">#CDD0D0</color>
     <color name="mapbox_current_speed_color">#BE3C30</color>
 </resources>

--- a/libnavui-speedlimit/src/main/res/values/colors.xml
+++ b/libnavui-speedlimit/src/main/res/values/colors.xml
@@ -5,7 +5,7 @@
     <color name="mapbox_speed_limit_view_mutcd_border">@android:color/black</color>
     <color name="mapbox_speed_limit_view_vienna_border">#BE3C30</color>
 
-    <color name="mapbox_speed_info_background_color">@color/colorSurface</color>
+    <color name="mapbox_speed_info_background_color">@android:color/white</color>
     <color name="mapbox_speed_info_border_color">#CDD0D0</color>
     <color name="mapbox_current_speed_color">#BE3C30</color>
 </resources>

--- a/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedInfoComponentTest.kt
+++ b/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/internal/SpeedInfoComponentTest.kt
@@ -1,0 +1,82 @@
+package com.mapbox.navigation.ui.speedlimit.internal
+
+import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.base.speed.model.SpeedLimit
+import com.mapbox.navigation.base.speed.model.SpeedLimitSign
+import com.mapbox.navigation.base.speed.model.SpeedLimitUnit
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.extensions.flowLocationMatcherResult
+import com.mapbox.navigation.core.trip.session.LocationMatcherResult
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.speedlimit.api.MapboxSpeedInfoApi
+import com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions
+import com.mapbox.navigation.ui.speedlimit.view.MapboxSpeedInfoView
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SpeedInfoComponentTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    private val speedInfoView = mockk<MapboxSpeedInfoView>(relaxed = true)
+    private val mockNavigation = mockk<MapboxNavigation> {
+        every { navigationOptions } returns mockk {
+            every { accessToken } returns "token"
+        }
+    }
+
+    @Before
+    fun setUp() {
+        mockkStatic("com.mapbox.navigation.core.internal.extensions.MapboxNavigationExtensions")
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic("com.mapbox.navigation.core.internal.extensions.MapboxNavigationExtensions")
+    }
+
+    @Test
+    fun `speed limit is rendered when location matcher results are available`() =
+        coroutineRule.runBlockingTest {
+            val locationMatcher = mockk<LocationMatcherResult> {
+                every { speedLimit } returns SpeedLimit(
+                    speedKmph = 100,
+                    speedLimitUnit = SpeedLimitUnit.KILOMETRES_PER_HOUR,
+                    speedLimitSign = SpeedLimitSign.MUTCD
+                )
+            }
+            every { mockNavigation.flowLocationMatcherResult() } returns flowOf(locationMatcher)
+            every {
+                mockNavigation.registerLocationObserver(any())
+            } answers {
+                firstArg<LocationObserver>().onNewLocationMatcherResult(locationMatcher)
+            }
+            val distanceFormatterOptions = mockk<DistanceFormatterOptions>(relaxed = true)
+            val speedInfoApi = mockk<MapboxSpeedInfoApi>(relaxed = true) {
+                every {
+                    updatePostedAndCurrentSpeed(locationMatcher, distanceFormatterOptions)
+                } returns mockk()
+            }
+            val speedInfoComponent = SpeedInfoComponent(
+                speedInfoOptions = MapboxSpeedInfoOptions.Builder().build(),
+                speedInfoView = speedInfoView,
+                distanceFormatterOptions = distanceFormatterOptions,
+                speedInfoApi = speedInfoApi
+            )
+            speedInfoComponent.onAttached(mockNavigation)
+
+            verify { speedInfoView.render(any()) }
+        }
+}

--- a/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/model/MapboxSpeedInfoOptionsTest.kt
+++ b/libnavui-speedlimit/src/test/java/com/mapbox/navigation/ui/speedlimit/model/MapboxSpeedInfoOptionsTest.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.ui.speedlimit.model
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.speed.model.SpeedLimitSign
 import com.mapbox.navigation.testing.BuilderTest
+import io.mockk.mockk
 import kotlin.reflect.KClass
 
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
@@ -16,6 +17,7 @@ class MapboxSpeedInfoOptionsTest :
             .Builder()
             .showLegend(true)
             .showUnit(false)
+            .speedInfoStyle(mockk())
             .showSpeedWhenUnavailable(true)
             .renderWithSpeedSign(SpeedLimitSign.VIENNA)
             .currentSpeedDirection(CurrentSpeedDirection.END)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/CustomizedViewModel.kt
@@ -10,6 +10,9 @@ class CustomizedViewModel : ViewModel() {
     // Activity
     val fullScreen = MutableLiveData(false)
 
+    // Speed Limit
+    val useLegacy = MutableLiveData(false)
+
     // General
     val showManeuver = MutableLiveData(true)
     val showSpeedLimit = MutableLiveData(true)

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/customnavview/MapboxNavigationViewCustomizedActivity.kt
@@ -66,6 +66,7 @@ import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRece
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRoadNameBackground
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRoadNameTextAppearance
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultRoutePreviewButtonStyle
+import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultSpeedInfoOptions
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultSpeedLimitStyle
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultSpeedLimitTextAppearance
 import com.mapbox.navigation.dropin.ViewStyleCustomization.Companion.defaultStartNavigationButtonStyle
@@ -91,6 +92,8 @@ import com.mapbox.navigation.ui.maps.NavigationStyles
 import com.mapbox.navigation.ui.maps.building.model.MapboxBuildingHighlightOptions
 import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions
 import com.mapbox.navigation.ui.maps.puck.LocationPuckOptions.Builder.Companion.regularPuck
+import com.mapbox.navigation.ui.speedlimit.model.MapboxSpeedInfoOptions
+import com.mapbox.navigation.ui.speedlimit.model.SpeedInfoStyle
 import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
 import com.mapbox.navigation.utils.internal.toPoint
 
@@ -149,6 +152,7 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
         initDebugOptions()
         initActivityOptions()
         initGeneralOptions()
+        initSpeedLimitOptions()
         initMapOptions()
         initActionsOptions()
         initInfoPanelOptions()
@@ -225,6 +229,18 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
 
     //endregion
 
+    //region Speed limit
+
+    private fun initSpeedLimitOptions() {
+        bindSwitch(
+            menuBinding.toggleLegacySpeed,
+            viewModel.useLegacy,
+            ::toggleLegacySpeedLimit
+        )
+    }
+
+    //endregion
+
     //region General Options
 
     private fun initGeneralOptions() {
@@ -270,6 +286,16 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
         )
     }
 
+    private fun toggleLegacySpeedLimit(enabled: Boolean) {
+        binding.navigationView.customizeViewBinders {
+            speedLimitBinder = if (enabled) {
+                legacySpeedLimitBinder()
+            } else {
+                defaultSpeedInfoBinder()
+            }
+        }
+    }
+
     private fun toggleShowManeuver(enabled: Boolean) {
         binding.navigationView.customizeViewOptions {
             showManeuver = enabled
@@ -301,6 +327,15 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
                 tripProgressStyle = R.style.MyCustomTripProgressStyle
                 speedLimitStyle = R.style.MyCustomSpeedLimitStyle
                 speedLimitTextAppearance = R.style.MyCustomSpeedLimitTextAppearance
+                speedInfoOptions = MapboxSpeedInfoOptions
+                    .Builder()
+                    .speedInfoStyle(
+                        SpeedInfoStyle().apply {
+                            postedSpeedMutcdTextAppearance = R.style.MyCustomPostedSpeedAppearance
+                            postedSpeedMutcdLayoutBackground = R.drawable.bg_custom_speed_info_mutcd
+                        }
+                    )
+                    .build()
                 destinationMarkerAnnotationOptions = PointAnnotationOptions().apply {
                     withIconImage(
                         ContextCompat.getDrawable(
@@ -329,6 +364,7 @@ class MapboxNavigationViewCustomizedActivity : DrawerActivity() {
                 tripProgressStyle = defaultTripProgressStyle()
                 speedLimitStyle = defaultSpeedLimitStyle()
                 speedLimitTextAppearance = defaultSpeedLimitTextAppearance()
+                speedInfoOptions = defaultSpeedInfoOptions()
                 destinationMarkerAnnotationOptions =
                     defaultDestinationMarkerAnnotationOptions(context)
                 roadNameBackground = defaultRoadNameBackground()

--- a/qa-test-app/src/main/res/drawable/bg_custom_speed_info_mutcd.xml
+++ b/qa-test-app/src/main/res/drawable/bg_custom_speed_info_mutcd.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+  <corners android:radius="10dp" />
+  <solid android:color="@color/primary" />
+  <stroke android:width="1dp" android:color="@color/onSecondary" />
+</shape>

--- a/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
+++ b/qa-test-app/src/main/res/layout/layout_drawer_menu_nav_view_custom.xml
@@ -297,6 +297,32 @@
 
             </androidx.appcompat.widget.LinearLayoutCompat>
 
+            <!-- Speed limit customization -->
+            <androidx.appcompat.widget.LinearLayoutCompat
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginTop="10dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textStyle="bold"
+                    android:gravity="center"
+                    android:paddingVertical="10dp"
+                    android:text="Speed Limit" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/toggleLegacySpeed"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:paddingVertical="10dp"
+                    android:text="Use Legacy Speed Limit"
+                    android:textAllCaps="true" />
+
+            </androidx.appcompat.widget.LinearLayoutCompat>
+
             <!-- Actions Customization -->
             <androidx.appcompat.widget.LinearLayoutCompat
                 android:layout_width="match_parent"

--- a/qa-test-app/src/main/res/values/styles_custom_nav_view.xml
+++ b/qa-test-app/src/main/res/values/styles_custom_nav_view.xml
@@ -41,6 +41,11 @@
         <item name="android:textSize">10sp</item>
     </style>
 
+    <style name="MyCustomPostedSpeedAppearance" parent="TextAppearance.AppCompat">
+        <item name="android:textSize">20sp</item>
+        <item name="android:textColor">@android:color/white</item>
+    </style>
+
     <style name="MyCustomTurnIconManeuver" parent="MapboxStyleTurnIconManeuver">
         <item name="maneuverTurnIconColor">@color/maneuver_turn_icon_color</item>
         <item name="maneuverTurnIconShadowColor">@color/maneuver_turn_icon_shadow_color</item>


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
Adds support to show the new `MapboxSpeedInfoView` to Drop-In UI

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

https://user-images.githubusercontent.com/9770186/207465086-ff8951db-3b7b-4a16-b79c-0a5686269cc2.mp4

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
