### PR TITLE
[Drop-In UI] Fix: Route Arrows are rendered above Nav Puck after device rotation. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed approaches list update in `RouteOptionsUpdater`(uses for reroute). It was putting to the origin approach corresponding approach from legacy approach list. [#6540](https://github.com/mapbox/mapbox-navigation-android/pull/6540)
 - Updated the `MapboxRestAreaApi` logic to load a SAPA map only if the upcoming rest stop is at the current step of the route leg. [#6695](https://github.com/mapbox/mapbox-navigation-android/pull/6695)
 - Fixed an issue where `MapboxRerouteController` could deliver a delayed interruption state notifications. Now, the interruption state is always delivered synchronously, as soon as it's available. [#6718](https://github.com/mapbox/mapbox-navigation-android/pull/6718)
+- Fixed the `NavigationView` issue where route arrows are being rendered above navigation puck after device rotation. [#6747](https://github.com/mapbox/mapbox-navigation-android/pull/6747)
 
 ## Mapbox Navigation SDK 2.9.5 - 13 December, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/ui/RouteLineComponent.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/ui/RouteLineComponent.kt
@@ -90,6 +90,12 @@ class RouteLineComponent(
         mapPlugins.gestures.addOnMapClickListener(onMapClickListener)
         mapPlugins.location.addOnIndicatorPositionChangedListener(onPositionChangedListener)
 
+        mapboxMap.getStyle {
+            // initialize route line layers to ensure they exist before
+            // both RouteLineComponent and RouteArrowComponent start rendering
+            routeLineView.initializeLayers(it)
+        }
+
         coroutineScope.launch {
             mapboxNavigation.flowRouteProgress().collect { routeProgress ->
                 ifNonNull(mapboxMap.getStyle()) { style ->

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/RouteLineComponentTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/internal/ui/RouteLineComponentTest.kt
@@ -413,6 +413,21 @@ class RouteLineComponentTest {
     }
 
     @Test
+    fun `onAttached should initialize route line layers on mapStyle load`() {
+        val lineApi = mockk<MapboxRouteLineApi>(relaxed = true)
+        val lineView = mockk<MapboxRouteLineView>(relaxed = true)
+        val onStyleLoadedCallback = slot<Style.OnStyleLoaded>()
+        val mapStyle = mockk<Style>()
+        val sut = RouteLineComponent(mockMap, mapPluginProvider, options, lineApi, lineView)
+        every { mockMap.getStyle(capture(onStyleLoadedCallback)) } returns Unit
+
+        sut.onAttached(mockMapboxNavigation)
+        onStyleLoadedCallback.captured.onStyleLoaded(mapStyle)
+
+        verify { lineView.initializeLayers(mapStyle) }
+    }
+
+    @Test
     fun `onDetached cancels route line API`() {
         val mockApi = mockk<MapboxRouteLineApi>(relaxed = true)
         val component = RouteLineComponent(mockMap, mapPluginProvider, options, mockApi)


### PR DESCRIPTION
Closes NAVAND-1007

### Description
- Fixed by Initializing Route Line Layer on map style load
