### PR TITLE
NAVAND-940: fix buildings highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Fixed the `NavigationView` issue where route arrows are being rendered above navigation puck after device rotation. [#6747](https://github.com/mapbox/mapbox-navigation-android/pull/6747)
 - Fixed an issue where a refresh of the routes or a change in alternatives that occurred while user was off-route would call `RerouteController#interrupt` and interrupt the potentially ongoing reroute process without recovery. [#6719](https://github.com/mapbox/mapbox-navigation-android/pull/6719)
 - Improved OpenLR matching rate. Updates take lowest FRC to next point into account during path generation. [#6750](https://github.com/mapbox/mapbox-navigation-android/pull/6750)
+- Fixed an issue where `MapboxBuildingsApi` would fail to highlight buildings. [#6749](https://github.com/mapbox/mapbox-navigation-android/pull/6749)
 
 ## Mapbox Navigation SDK 2.9.5 - 13 December, 2022
 ### Changelog

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/building/BuildingProcessor.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/building/BuildingProcessor.kt
@@ -2,10 +2,9 @@ package com.mapbox.navigation.ui.maps.building
 
 import com.mapbox.bindgen.ExpectedFactory
 import com.mapbox.maps.RenderedQueryOptions
-import com.mapbox.navigation.base.internal.extensions.isLegWaypoint
-import com.mapbox.navigation.base.internal.utils.internalWaypoints
 import com.mapbox.navigation.ui.maps.building.model.BuildingError
 import com.mapbox.navigation.ui.maps.building.model.BuildingValue
+import com.mapbox.navigation.utils.internal.ifNonNull
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -48,18 +47,25 @@ internal object BuildingProcessor {
     fun queryBuildingOnWaypoint(
         action: BuildingAction.QueryBuildingOnWaypoint
     ): BuildingResult.GetDestination {
-        val waypoints = action.progress.navigationRoute.internalWaypoints()
-        val waypointIndex = action.progress.currentLegProgress?.legIndex!! + 1
-        val waypoint = waypoints.filter { it.isLegWaypoint() }.getOrNull(waypointIndex)
-        return BuildingResult.GetDestination(waypoint?.target ?: waypoint?.location)
+        val routeOptions = action.progress.route.routeOptions()
+        val coordinatesList = routeOptions?.coordinatesList()
+        val waypointTargets = routeOptions?.waypointTargetsList()
+        val coordinateIndex = action.progress.currentLegProgress?.legIndex!! + 1
+        val routablePoint = coordinatesList?.getOrNull(coordinateIndex)
+        val locationPoint = waypointTargets?.getOrNull(coordinateIndex)
+        return ifNonNull(locationPoint) { point ->
+            BuildingResult.GetDestination(point)
+        } ?: BuildingResult.GetDestination(routablePoint)
     }
 
     fun queryBuildingOnFinalDestination(
         action: BuildingAction.QueryBuildingOnFinalDestination
     ): BuildingResult.GetDestination {
-        val lastWaypoint = action.progress.navigationRoute
-            .internalWaypoints()
-            .lastOrNull()
-        return BuildingResult.GetDestination(lastWaypoint?.target ?: lastWaypoint?.location)
+        val routeOptions = action.progress.route.routeOptions()
+        val lastCoordinate = routeOptions?.coordinatesList()?.lastOrNull()
+        val lastWaypointTarget = routeOptions?.waypointTargetsList()?.lastOrNull()
+        return ifNonNull(lastWaypointTarget) { point ->
+            BuildingResult.GetDestination(point)
+        } ?: BuildingResult.GetDestination(lastCoordinate)
     }
 }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/building/BuildingProcessorTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/building/BuildingProcessorTest.kt
@@ -8,9 +8,6 @@ import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.QueryFeaturesCallback
 import com.mapbox.maps.RenderedQueryOptions
 import com.mapbox.maps.ScreenCoordinate
-import com.mapbox.navigation.base.internal.route.Waypoint
-import com.mapbox.navigation.base.internal.utils.WaypointFactory
-import com.mapbox.navigation.base.internal.utils.internalWaypoints
 import com.mapbox.navigation.base.trip.model.RouteLegProgress
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import io.mockk.every
@@ -26,111 +23,107 @@ class BuildingProcessorTest {
 
     @Test
     fun `map query on waypoint arrival with waypoint targets`() {
-        val waypoints = listOf(
-            provideWaypoint(
-                Point.fromLngLat(-122.4192, 37.7627),
-                Waypoint.REGULAR,
-                "",
-                Point.fromLngLat(-122.4192, 37.7627),
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4182, 37.7651),
-                Waypoint.REGULAR,
-                "",
-                Point.fromLngLat(-122.4183, 37.7653),
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4145, 37.7653),
-                Waypoint.REGULAR,
-                "",
-                Point.fromLngLat(-122.4146, 37.7655),
-            ),
-        )
+        val mockOriginForWaypointTarget = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForWaypointTarget = Point.fromLngLat(-122.4183, 37.7653)
+        val mockFinalForWaypointTarget = Point.fromLngLat(-122.4146, 37.7655)
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
+        val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns listOf(
+                mockOriginForWaypointTarget,
+                mockWaypointForWaypointTarget,
+                mockFinalForWaypointTarget
+            )
+        }
+        val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
+            every { routeOptions() } returns mockRouteOptions
+        }
         val mockRouteLegProgress = mockk<RouteLegProgress>(relaxed = true) {
             every { legIndex } returns 0
         }
         val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
             every { currentLegProgress } returns mockRouteLegProgress
-            every { navigationRoute.internalWaypoints() } returns waypoints
+            every { route } returns mockRoute
         }
         val mockAction = BuildingAction.QueryBuildingOnWaypoint(mockRouteProgress)
 
         val result = BuildingProcessor.queryBuildingOnWaypoint(mockAction)
 
-        assertEquals(waypoints[1].target!!, result.point)
+        assertEquals(result.point, mockWaypointForWaypointTarget)
     }
 
     @Test
     fun `map query on waypoint arrival with some waypoint targets`() {
-        val waypoints = listOf(
-            provideWaypoint(
-                Point.fromLngLat(-122.4192, 37.7627),
-                Waypoint.REGULAR,
-                "",
-                Point.fromLngLat(-122.4192, 37.7627),
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4182, 37.7651),
-                Waypoint.REGULAR,
-                "",
-                null,
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4145, 37.7653),
-                Waypoint.REGULAR,
-                "",
-                Point.fromLngLat(-122.4146, 37.7655),
-            ),
-        )
+        val mockOriginForWaypointTarget = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForWaypointTarget = null
+        val mockFinalForWaypointTarget = Point.fromLngLat(-122.4146, 37.7655)
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
+        val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns listOf(
+                mockOriginForWaypointTarget,
+                mockWaypointForWaypointTarget,
+                mockFinalForWaypointTarget
+            )
+        }
+        val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
+            every { routeOptions() } returns mockRouteOptions
+        }
         val mockRouteLegProgress = mockk<RouteLegProgress>(relaxed = true) {
             every { legIndex } returns 0
         }
         val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
             every { currentLegProgress } returns mockRouteLegProgress
-            every { navigationRoute.internalWaypoints() } returns waypoints
+            every { route } returns mockRoute
         }
 
         val mockAction = BuildingAction.QueryBuildingOnWaypoint(mockRouteProgress)
 
         val result = BuildingProcessor.queryBuildingOnWaypoint(mockAction)
 
-        assertEquals(waypoints[1].location, result.point)
+        assertEquals(result.point, mockWaypointForCoordinates)
     }
 
     @Test
     fun `map query on waypoint arrival without waypoint targets`() {
-        val waypoints = listOf(
-            provideWaypoint(
-                Point.fromLngLat(-122.4192, 37.7627),
-                Waypoint.REGULAR,
-                "",
-                null,
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4182, 37.7651),
-                Waypoint.REGULAR,
-                "",
-                null,
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4145, 37.7653),
-                Waypoint.REGULAR,
-                "",
-                null,
-            ),
-        )
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
+        val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns null
+        }
+        val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
+            every { routeOptions() } returns mockRouteOptions
+        }
         val mockRouteLegProgress = mockk<RouteLegProgress>(relaxed = true) {
             every { legIndex } returns 0
         }
         val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
             every { currentLegProgress } returns mockRouteLegProgress
-            every { navigationRoute.internalWaypoints() } returns waypoints
+            every { route } returns mockRoute
         }
         val mockAction = BuildingAction.QueryBuildingOnWaypoint(mockRouteProgress)
 
         val result = BuildingProcessor.queryBuildingOnWaypoint(mockAction)
 
-        assertEquals(waypoints[1].location, result.point)
+        assertEquals(result.point, mockWaypointForCoordinates)
     }
 
     @Test
@@ -158,74 +151,69 @@ class BuildingProcessorTest {
 
     @Test
     fun `map query on final destination arrival with waypoint targets`() {
-        val waypoints = listOf(
-            provideWaypoint(
-                Point.fromLngLat(-122.4192, 37.7627),
-                Waypoint.REGULAR,
-                "",
-                Point.fromLngLat(-122.4192, 37.7627),
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4182, 37.7651),
-                Waypoint.REGULAR,
-                "",
-                Point.fromLngLat(-122.4183, 37.7653),
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4145, 37.7653),
-                Waypoint.REGULAR,
-                "",
-                Point.fromLngLat(-122.4146, 37.7655),
-            ),
-        )
+        val mockOriginForWaypointTarget = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForWaypointTarget = Point.fromLngLat(-122.4183, 37.7653)
+        val mockFinalForWaypointTarget = Point.fromLngLat(-122.4146, 37.7655)
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
+        val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns listOf(
+                mockOriginForWaypointTarget,
+                mockWaypointForWaypointTarget,
+                mockFinalForWaypointTarget
+            )
+        }
+        val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
+            every { routeOptions() } returns mockRouteOptions
+        }
         val mockRouteLegProgress = mockk<RouteLegProgress>(relaxed = true) {
             every { legIndex } returns 0
         }
         val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
             every { currentLegProgress } returns mockRouteLegProgress
-            every { navigationRoute.internalWaypoints() } returns waypoints
+            every { route } returns mockRoute
         }
         val mockAction = BuildingAction.QueryBuildingOnFinalDestination(mockRouteProgress)
 
         val result = BuildingProcessor.queryBuildingOnFinalDestination(mockAction)
 
-        assertEquals(waypoints.last().target!!, result.point)
+        assertEquals(result.point, mockFinalForWaypointTarget)
     }
 
     @Test
     fun `map query on final destination arrival without waypoint targets`() {
-        val waypoints = listOf(
-            provideWaypoint(
-                Point.fromLngLat(-122.4192, 37.7627),
-                Waypoint.REGULAR,
-                "",
-                null,
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4182, 37.7651),
-                Waypoint.REGULAR,
-                "",
-                null,
-            ),
-            provideWaypoint(
-                Point.fromLngLat(-122.4145, 37.7653),
-                Waypoint.REGULAR,
-                "",
-                null,
-            ),
-        )
+        val mockOriginForCoordinates = Point.fromLngLat(-122.4192, 37.7627)
+        val mockWaypointForCoordinates = Point.fromLngLat(-122.4182, 37.7651)
+        val mockFinalForCoordinates = Point.fromLngLat(-122.4145, 37.7653)
+        val mockRouteOptions = mockk<RouteOptions>(relaxed = true) {
+            every { coordinatesList() } returns listOf(
+                mockOriginForCoordinates,
+                mockWaypointForCoordinates,
+                mockFinalForCoordinates
+            )
+            every { waypointTargetsList() } returns null
+        }
+        val mockRoute = mockk<DirectionsRoute>(relaxed = true) {
+            every { routeOptions() } returns mockRouteOptions
+        }
         val mockRouteLegProgress = mockk<RouteLegProgress>(relaxed = true) {
             every { legIndex } returns 0
         }
         val mockRouteProgress = mockk<RouteProgress>(relaxed = true) {
             every { currentLegProgress } returns mockRouteLegProgress
-            every { navigationRoute.internalWaypoints() } returns waypoints
+            every { route } returns mockRoute
         }
         val mockAction = BuildingAction.QueryBuildingOnFinalDestination(mockRouteProgress)
 
         val result = BuildingProcessor.queryBuildingOnFinalDestination(mockAction)
 
-        assertEquals(waypoints.last().location, result.point)
+        assertEquals(result.point, mockFinalForCoordinates)
     }
 
     @Test
@@ -253,16 +241,4 @@ class BuildingProcessorTest {
         assertTrue(optionsSlot.captured.layerIds!!.contains("building"))
         assertTrue(optionsSlot.captured.layerIds!!.contains("building-extrusion"))
     }
-
-    private fun provideWaypoint(
-        location: Point,
-        @Waypoint.Type type: Int,
-        name: String,
-        target: Point?,
-    ): Waypoint = WaypointFactory.provideWaypoint(
-        location,
-        name,
-        target,
-        type
-    )
 }


### PR DESCRIPTION
I basically reverted building related changed from [#6005](https://github.com/mapbox/mapbox-navigation-android/pull/6005). We don't really deal with waypoints there, only waypoint targets (that have the same size as`RoutesOptions#coordinatesList`). And for these things we use leg index. So nothing waypoint related. All the indices and lists stay valid even after introducing EV waypoints.
The question is whether we want to highlight EV chargers. If yes, I think we can do it separately. For now let's fix old behaviour.