### PR TITLE
Prototype of the custom looper for the Navigation SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ workflows:
               only:
                 - main
                 - release-v.*
+                - vv-NAVAND-779-let-sdk-work-on-backroud-thread-2
       - release:
           filters:
             tags:

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -52,6 +52,6 @@ def getSnapshotVersion(String version) {
         if (!isPreRelease) {
             minor += 1
         }
-        return "${major}.${minor}.0-SNAPSHOT"
+        return "${major}.${minor}.0-sdk-background-2-SNAPSHOT"
     }
 }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/HandlerThreadTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/HandlerThreadTest.kt
@@ -1,0 +1,90 @@
+package com.mapbox.navigation.instrumentation_tests.core
+
+import android.location.Location
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.util.Log
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.internal.extensions.flowOnFinalDestinationArrival
+import com.mapbox.navigation.instrumentation_tests.activity.EmptyTestActivity
+import com.mapbox.navigation.instrumentation_tests.utils.MapboxNavigationRule
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.sdkTest
+import com.mapbox.navigation.instrumentation_tests.utils.coroutines.setNavigationRoutesAsync
+import com.mapbox.navigation.instrumentation_tests.utils.location.MockLocationReplayerRule
+import com.mapbox.navigation.instrumentation_tests.utils.routes.RoutesProvider
+import com.mapbox.navigation.instrumentation_tests.utils.routes.RoutesProvider.toNavigationRoutes
+import com.mapbox.navigation.testing.ui.BaseTest
+import com.mapbox.navigation.testing.ui.utils.getMapboxAccessTokenFromResources
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.android.asCoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class HandlerThreadTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.java) {
+
+    override fun setupMockLocation(): Location = mockLocationUpdatesRule.generateLocationUpdate {
+        latitude = 38.894721
+        longitude = -77.031991
+    }
+
+    @get:Rule
+    val mockLocationReplayerRule = MockLocationReplayerRule(mockLocationUpdatesRule)
+
+    private lateinit var mapboxNavigation: MapboxNavigation
+    private lateinit var sdkThread: HandlerThread
+    private lateinit var handler: Handler
+    private lateinit var sdkDispatcher: CoroutineDispatcher
+
+    @Before
+    fun setUp() {
+        sdkThread = HandlerThread("test sdk thread")
+        sdkThread.start()
+        handler = Handler(sdkThread.looper)
+        sdkDispatcher = handler.asCoroutineDispatcher()
+
+        mapboxNavigation = MapboxNavigationProvider.create(
+            NavigationOptions.Builder(activity)
+                .accessToken(getMapboxAccessTokenFromResources(activity))
+                .looper(sdkThread.looper)
+                .build()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        mapboxNavigation.onDestroy()
+        sdkThread.quitSafely()
+    }
+
+    private fun assertSDKThread() {
+        assertEquals(sdkThread.looper, Looper.myLooper())
+    }
+
+    @Test
+    fun set_navigation_routes_successfully() = sdkTest {
+        val routes = RoutesProvider.dc_very_short(activity).toNavigationRoutes()
+        mapboxNavigation.setNavigationRoutesAsync(routes)
+        assertEquals(routes, mapboxNavigation.getNavigationRoutes())
+        mapboxNavigation.startTripSession()
+        mockLocationReplayerRule.playRoute(routes.first().directionsRoute)
+        var routeProgressEventsCount = 0
+        mapboxNavigation.registerRouteProgressObserver {
+            assertSDKThread()
+            routeProgressEventsCount++
+            assertEquals(routes, mapboxNavigation.getNavigationRoutes())
+        }
+
+        mapboxNavigation.flowOnFinalDestinationArrival().first()
+        assertNotEquals(0, routeProgressEventsCount)
+    }
+}

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/TestUtils.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/coroutines/TestUtils.kt
@@ -7,6 +7,7 @@ import com.mapbox.navigation.core.RoutesSetCallback
 import com.mapbox.navigation.core.directions.session.RoutesExtra
 import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.directions.session.RoutesUpdatedResult
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -26,9 +27,10 @@ private const val DEFAULT_TIMEOUT_FOR_SDK_TEST = 30_000L
 
 fun sdkTest(
     timeout: Long = DEFAULT_TIMEOUT_FOR_SDK_TEST,
-    block: suspend CoroutineScope.() -> Unit
+    dispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
+    block: suspend CoroutineScope.() -> Unit,
 ) {
-    runBlocking(Dispatchers.Main.immediate) {
+    runBlocking(dispatcher) {
         withTimeout(timeout) {
             block()
         }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -223,7 +223,7 @@ private constructor(
 
         @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
         private var copilotOptions: CopilotOptions = CopilotOptions.Builder().build()
-        private var looper: Looper = Looper.getMainLooper()
+        private var looper: Looper? = null
 
         /**
          * Defines [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
@@ -370,7 +370,7 @@ private constructor(
                 eventsAppMetadata = eventsAppMetadata,
                 enableSensors = enableSensors,
                 copilotOptions = copilotOptions,
-                looper = looper,
+                looper = looper ?: Looper.getMainLooper(),
             )
         }
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.base.options
 
 import android.content.Context
+import android.os.Looper
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineProvider
 import com.mapbox.android.core.location.LocationEngineRequest
@@ -67,6 +68,7 @@ private constructor(
     val enableSensors: Boolean,
     @ExperimentalPreviewMapboxNavigationAPI
     val copilotOptions: CopilotOptions,
+    val looper: Looper,
 ) {
 
     /**
@@ -216,6 +218,7 @@ private constructor(
 
         @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
         private var copilotOptions: CopilotOptions = CopilotOptions.Builder().build()
+        private var looper: Looper = Looper.getMainLooper()
 
         /**
          * Defines [Mapbox Access Token](https://docs.mapbox.com/help/glossary/access-token/)
@@ -329,6 +332,10 @@ private constructor(
         fun copilotOptions(copilotOptions: CopilotOptions): Builder =
             apply { this.copilotOptions = copilotOptions }
 
+        @ExperimentalPreviewMapboxNavigationAPI
+        fun looper(looper: Looper): Builder =
+            apply { this.looper = looper }
+
         /**
          * Build a new instance of [NavigationOptions]
          * @return NavigationOptions
@@ -355,6 +362,7 @@ private constructor(
                 eventsAppMetadata = eventsAppMetadata,
                 enableSensors = enableSensors,
                 copilotOptions = copilotOptions,
+                looper = looper,
             )
         }
     }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -44,6 +44,7 @@ const val DEFAULT_NAVIGATOR_PREDICTION_MILLIS = 1000L
  * @param eventsAppMetadata [EventsAppMetadata] information (optional)
  * @param enableSensors enables sensors for current position calculation (optional)
  * @param copilotOptions defines options for Copilot
+ * @param looper defines a looper for callbacks and internal work
  */
 class NavigationOptions
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
@@ -332,6 +333,9 @@ private constructor(
         fun copilotOptions(copilotOptions: CopilotOptions): Builder =
             apply { this.copilotOptions = copilotOptions }
 
+        /**
+         * Defines custom lopper for callbacks and internal work
+         */
         @ExperimentalPreviewMapboxNavigationAPI
         fun looper(looper: Looper): Builder =
             apply { this.looper = looper }

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/options/NavigationOptions.kt
@@ -95,6 +95,7 @@ private constructor(
         eventsAppMetadata(eventsAppMetadata)
         enableSensors(enableSensors)
         copilotOptions(copilotOptions)
+        looper(looper)
     }
 
     /**
@@ -126,6 +127,7 @@ private constructor(
         if (eventsAppMetadata != other.eventsAppMetadata) return false
         if (enableSensors != other.enableSensors) return false
         if (copilotOptions != other.copilotOptions) return false
+        if (looper != other.looper) return false
 
         return true
     }
@@ -154,6 +156,7 @@ private constructor(
         result = 31 * result + eventsAppMetadata.hashCode()
         result = 31 * result + enableSensors.hashCode()
         result = 31 * result + copilotOptions.hashCode()
+        result = 31 * result + looper.hashCode()
         return result
     }
 
@@ -181,7 +184,8 @@ private constructor(
             "historyRecorderOptions=$historyRecorderOptions, " +
             "eventsAppMetadata=$eventsAppMetadata, " +
             "enableSensors=$enableSensors, " +
-            "copilotOptions=$copilotOptions" +
+            "copilotOptions=$copilotOptions," +
+            "looper=$looper" +
             ")"
     }
 

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/options/NavigationOptionsTest.kt
@@ -84,6 +84,7 @@ class NavigationOptionsTest : BuilderTest<NavigationOptions, NavigationOptions.B
             .copilotOptions(
                 CopilotOptions.Builder().shouldSendHistoryOnlyWithFeedback(true).build()
             )
+            .looper(mockk())
     }
 
     @Test

--- a/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/tests/activity/TripServiceActivity.kt
+++ b/libnavigation-core/src/androidTest/java/com/mapbox/navigation/core/tests/activity/TripServiceActivity.kt
@@ -15,7 +15,7 @@ import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
 import com.mapbox.navigation.core.test.R
 import com.mapbox.navigation.core.trip.service.MapboxTripService
-import com.mapbox.navigation.utils.internal.ThreadController
+import com.mapbox.navigation.utils.internal.AndroidThreadController
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -23,8 +23,8 @@ import kotlinx.coroutines.launch
 
 internal class TripServiceActivity : AppCompatActivity() {
 
-    private val threadController = ThreadController()
-    private var mainJobController = threadController.getMainScopeAndRootJob()
+    private val threadController = AndroidThreadController()
+    private var mainJobController = threadController.getSDKScopeAndRootJob()
     private lateinit var tripNotification: TripNotification
     private lateinit var mapboxTripService: MapboxTripService
     private var textUpdateJob: Job = Job()
@@ -87,8 +87,7 @@ internal class TripServiceActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         stopService()
-        threadController.cancelAllNonUICoroutines()
-        threadController.cancelAllUICoroutines()
+        threadController.cancelSDKScope()
     }
 
     private fun changeText() {

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt
@@ -41,7 +41,7 @@ internal class MapboxRerouteController @VisibleForTesting constructor(
 
     private val observers = CopyOnWriteArraySet<RerouteController.RerouteStateObserver>()
 
-    private val mainJobController: JobControl = threadController.getMainScopeAndRootJob()
+    private val mainJobController: JobControl = threadController.getSDKScopeAndRootJob()
 
     private var rerouteJob: Job? = null
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesController.kt
@@ -30,7 +30,7 @@ internal class RouteAlternativesController constructor(
 
     private var lastUpdateOrigin: RouterOrigin = RouterOrigin.Onboard
 
-    private val mainJobControl by lazy { threadController.getMainScopeAndRootJob() }
+    private val mainJobControl by lazy { threadController.getSDKScopeAndRootJob() }
 
     private var observerProcessingJob: Job? = null
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/MapboxTripService.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/service/MapboxTripService.kt
@@ -96,7 +96,7 @@ internal class MapboxTripService(
 
     private val serviceStarted = AtomicBoolean(false)
 
-    private val mainJobController = threadController.getMainScopeAndRootJob()
+    private val mainJobController = threadController.getSDKScopeAndRootJob()
     private var allowedNotificationTime = 0L
     private var notificationJob: Job? = null
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionLocationEngine.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/TripSessionLocationEngine.kt
@@ -49,7 +49,7 @@ internal class TripSessionLocationEngine constructor(
         locationEngine.requestLocationUpdates(
             navigationOptions.locationEngineRequest,
             locationEngineCallback,
-            Looper.getMainLooper()
+            Looper.myLooper()
         )
         locationEngine.getLastLocation(locationEngineCallback)
     }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/eh/EHorizonSubscriptionManagerImpl.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/eh/EHorizonSubscriptionManagerImpl.kt
@@ -16,7 +16,7 @@ internal class EHorizonSubscriptionManagerImpl(
     threadController: ThreadController,
 ) : EHorizonSubscriptionManager {
 
-    private val mainJobController = threadController.getMainScopeAndRootJob()
+    private val mainJobController = threadController.getSDKScopeAndRootJob()
     private val eHorizonObservers = CopyOnWriteArraySet<EHorizonObserver>()
     private var currentPosition: EHorizonPosition? = null
     private var currentDistances: List<RoadObjectDistanceInfo>? = null

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationBaseTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationBaseTest.kt
@@ -44,9 +44,8 @@ import com.mapbox.navigation.navigator.internal.NavigatorLoader
 import com.mapbox.navigation.testing.LoggingFrontendTestRule
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.testing.NativeRouteParserRule
-import com.mapbox.navigation.utils.internal.JobControl
+import com.mapbox.navigation.testing.TestThreadController
 import com.mapbox.navigation.utils.internal.LoggerProvider
-import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigator.CacheHandle
 import io.mockk.coEvery
 import io.mockk.every
@@ -99,7 +98,9 @@ internal open class MapboxNavigationBaseTest {
     val arrivalProgressObserver: ArrivalProgressObserver = mockk(relaxUnitFun = true)
     val historyRecordingStateHandler: HistoryRecordingStateHandler = mockk(relaxed = true)
     val developerMetadataAggregator: DeveloperMetadataAggregator = mockk(relaxUnitFun = true)
-    val threadController = mockk<ThreadController>(relaxed = true)
+    val threadController = TestThreadController(
+        dispatcher = coroutineRule.testDispatcher
+    )
     val routeProgressDataProvider = mockk<RouteProgressDataProvider>(relaxed = true)
     val routesPreviewController = mockk<RoutesPreviewController>(relaxed = true)
     val routesCacheClearer = mockk<RoutesCacheClearer>(relaxed = true)
@@ -129,9 +130,6 @@ internal open class MapboxNavigationBaseTest {
 
     @Before
     open fun setUp() {
-        every { threadController.getMainScopeAndRootJob() } answers {
-            JobControl(mockk(), coroutineRule.createTestScope())
-        }
         mockkObject(LoggerProvider)
         mockkObject(NavigatorLoader)
         every {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -181,7 +181,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     fun init_registerOffRouteObserver_MapboxNavigation_recreated() {
         createMapboxNavigation()
         mapboxNavigation.onDestroy()
-        threadController.cancelAllUICoroutines()
+        threadController.cancelSDKScope()
         val navigationOptions = provideNavigationOptions().build()
 
         mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
@@ -193,7 +193,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     fun destroy_unregisterAllOffRouteObservers_MapboxNavigation_recreated() {
         createMapboxNavigation()
         mapboxNavigation.onDestroy()
-        threadController.cancelAllUICoroutines()
+        threadController.cancelSDKScope()
         val navigationOptions = provideNavigationOptions().build()
         mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
 
@@ -784,7 +784,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `verify tile config path`() {
-        threadController.cancelAllUICoroutines()
+        threadController.cancelSDKScope()
         val slot = slot<TilesConfig>()
         every {
             NavigationComponentProvider.createNativeNavigator(
@@ -806,7 +806,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `verify tile config dataset`() {
-        threadController.cancelAllUICoroutines()
+        threadController.cancelSDKScope()
         val slot = slot<TilesConfig>()
         every {
             NavigationComponentProvider.createNativeNavigator(
@@ -833,7 +833,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `verify incidents options null when no params set`() {
-        threadController.cancelAllUICoroutines()
+        threadController.cancelSDKScope()
         val slot = slot<NavigatorConfig>()
         every { NavigatorLoader.createConfig(any(), capture(slot)) } returns mockk()
 
@@ -844,7 +844,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `verify incidents options non-null when graph set`() {
-        threadController.cancelAllUICoroutines()
+        threadController.cancelSDKScope()
         val slot = slot<NavigatorConfig>()
         every { NavigatorLoader.createConfig(any(), capture(slot)) } returns mockk()
         val options = navigationOptions.toBuilder()
@@ -863,7 +863,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `verify incidents options non-null when apiUrl set`() {
-        threadController.cancelAllUICoroutines()
+        threadController.cancelSDKScope()
         val slot = slot<NavigatorConfig>()
         every { NavigatorLoader.createConfig(any(), capture(slot)) } returns mockk()
         val options = navigationOptions.toBuilder()
@@ -1055,7 +1055,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `verify tile config tilesVersion and isFallback on init`() {
-        threadController.cancelAllUICoroutines()
+        threadController.cancelSDKScope()
         val slot = slot<TilesConfig>()
         every {
             NavigationComponentProvider.createNativeNavigator(
@@ -1083,8 +1083,6 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `verify tile config tilesVersion and isFallback on fallback`() {
-        threadController.cancelAllUICoroutines()
-
         val fallbackObserverSlot = slot<FallbackVersionsObserver>()
         every {
             tripSession.registerFallbackVersionsObserver(capture(fallbackObserverSlot))
@@ -1117,8 +1115,6 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `verify tile config tilesVersion and isFallback on return to latest tiles version`() = runBlocking {
-        threadController.cancelAllUICoroutines()
-
         val fallbackObserverSlot = slot<FallbackVersionsObserver>()
         every {
             tripSession.registerFallbackVersionsObserver(capture(fallbackObserverSlot))
@@ -1160,8 +1156,6 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `verify route and routeProgress are set after navigator recreation`() = runBlocking {
-        threadController.cancelAllUICoroutines()
-
         val fallbackObserverSlot = slot<FallbackVersionsObserver>()
         every {
             tripSession.registerFallbackVersionsObserver(capture(fallbackObserverSlot))

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
@@ -93,7 +93,7 @@ class MapboxRerouteControllerTest {
     @Before
     fun setup() {
         MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
-        every { threadController.getMainScopeAndRootJob() } answers {
+        every { threadController.getSDKScopeAndRootJob(any()) } answers {
             JobControl(mockk(), coroutineRule.createTestScope())
         }
         every {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/reroute/MapboxRerouteControllerTest.kt
@@ -18,6 +18,7 @@ import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.testing.MapboxJavaObjectsFactory
 import com.mapbox.navigation.utils.internal.JobControl
 import com.mapbox.navigation.utils.internal.ThreadController
+import com.mapbox.navigation.testing.TestThreadController
 import io.mockk.MockKAnnotations
 import io.mockk.clearMocks
 import io.mockk.coVerify

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/routealternatives/RouteAlternativesControllerTest.kt
@@ -13,6 +13,7 @@ import com.mapbox.navigation.testing.FileUtils
 import com.mapbox.navigation.testing.LoggingFrontendTestRule
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.testing.NativeRouteParserRule
+import com.mapbox.navigation.testing.TestThreadController
 import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigator.RouteAlternative
 import com.mapbox.navigator.RouteAlternativesControllerInterface
@@ -67,7 +68,7 @@ class RouteAlternativesControllerTest {
         options,
         navigator,
         tripSession,
-        ThreadController(),
+        TestThreadController(),
     )
 
     @Before

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/service/MapboxTripServiceTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/service/MapboxTripServiceTest.kt
@@ -7,8 +7,8 @@ import com.mapbox.navigation.base.trip.model.TripNotificationState
 import com.mapbox.navigation.base.trip.notification.TripNotification
 import com.mapbox.navigation.testing.LoggingFrontendTestRule
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.testing.TestThreadController
 import com.mapbox.navigation.utils.internal.LoggerFrontend
-import com.mapbox.navigation.utils.internal.ThreadController
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -41,7 +41,9 @@ class MapboxTripServiceTest {
             tripNotification,
             initializeLambda,
             terminateLambda,
-            ThreadController(),
+            TestThreadController(
+                dispatcher = coroutineRule.testDispatcher
+            ),
         )
         every { tripNotification.getNotificationId() } answers { NOTIFICATION_ID }
         every { tripNotification.getNotification() } answers { notification }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/EHorizonSubscriptionManagerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/EHorizonSubscriptionManagerTest.kt
@@ -7,7 +7,7 @@ import com.mapbox.navigation.core.trip.session.eh.EHorizonSubscriptionManager
 import com.mapbox.navigation.core.trip.session.eh.EHorizonSubscriptionManagerImpl
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.testing.MainCoroutineRule
-import com.mapbox.navigation.utils.internal.ThreadController
+import com.mapbox.navigation.testing.TestThreadController
 import com.mapbox.navigator.ElectronicHorizonObserver
 import com.mapbox.navigator.ElectronicHorizonPosition
 import com.mapbox.navigator.RoadObjectDistance
@@ -48,7 +48,7 @@ class EHorizonSubscriptionManagerTest {
     private val subscriptionManager: EHorizonSubscriptionManager =
         EHorizonSubscriptionManagerImpl(
             navigator,
-            ThreadController(),
+            TestThreadController(),
         )
 
     @Before

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionNoSetupTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionNoSetupTest.kt
@@ -5,6 +5,7 @@ import android.location.Location
 import com.mapbox.android.core.location.LocationEngine
 import com.mapbox.android.core.location.LocationEngineCallback
 import com.mapbox.android.core.location.LocationEngineResult
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.internal.extensions.inferDeviceLocale
 import com.mapbox.navigation.base.internal.factory.RoadObjectFactory
 import com.mapbox.navigation.base.internal.factory.RoadObjectFactory.toUpcomingRoadObjects
@@ -585,6 +586,7 @@ class MapboxTripSessionNoSetupTest {
         }
 }
 
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 private fun buildTripSession(
     nativeNavigator: MapboxNativeNavigator = createNativeNavigatorMock(),
     locationEngine: LocationEngine = TestLocationEngine.create(),
@@ -592,6 +594,7 @@ private fun buildTripSession(
 ): MapboxTripSession {
     val navigationOptions = NavigationOptions.Builder(context)
         .locationEngine(locationEngine)
+        .looper(mockk())
         .build()
 
     val tripService: TripService = mockk(relaxUnitFun = true) {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionNoSetupTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionNoSetupTest.kt
@@ -601,7 +601,7 @@ private fun buildTripSession(
     val parentJob = SupervisorJob()
     val testScope = CoroutineScope(parentJob + TestCoroutineDispatcher())
     val threadController = spyk<ThreadController>()
-    every { threadController.getMainScopeAndRootJob() } returns JobControl(parentJob, testScope)
+    every { threadController.getSDKScopeAndRootJob() } returns JobControl(parentJob, testScope)
 
     return MapboxTripSession(
         tripService,

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -156,8 +156,8 @@ class MapboxTripSessionTest {
         every { location.toFixLocation() } returns fixLocation
         every { fixLocation.toLocation() } returns location
         every { keyFixPoints.toLocations() } returns keyPoints
-        every { threadController.getMainScopeAndRootJob() } returns JobControl(parentJob, testScope)
         every { BannerInstructionEvent.invoke() } returns bannerInstructionEvent
+        every { threadController.getSDKScopeAndRootJob() } returns JobControl(parentJob, testScope)
         navigationOptions = NavigationOptions.Builder(context).build()
         tripSession = buildTripSession()
 

--- a/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
+++ b/libnavigation-router/src/main/java/com/mapbox/navigation/route/internal/RouterWrapper.kt
@@ -52,7 +52,7 @@ class RouterWrapper(
     private val threadController: ThreadController,
 ) : NavigationRouterV2, InternalRouter {
 
-    private val mainJobControl by lazy { threadController.getMainScopeAndRootJob() }
+    private val mainJobControl by lazy { threadController.getSDKScopeAndRootJob() }
 
     override fun getRoute(routeOptions: RouteOptions, callback: NavigationRouterCallback): Long {
         val routeUrl = routeOptions.toUrl(accessToken).toString()

--- a/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/RouterWrapperTests.kt
+++ b/libnavigation-router/src/test/java/com/mapbox/navigation/route/internal/RouterWrapperTests.kt
@@ -24,6 +24,7 @@ import com.mapbox.navigation.route.internal.util.TestRouteFixtures
 import com.mapbox.navigation.route.internal.util.redactQueryParam
 import com.mapbox.navigation.testing.LoggingFrontendTestRule
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.testing.TestThreadController
 import com.mapbox.navigation.testing.factories.createDirectionsRoute
 import com.mapbox.navigation.testing.factories.createNavigationRoute
 import com.mapbox.navigation.testing.factories.createRouteInterfacesFromDirectionRequestResponse
@@ -150,7 +151,7 @@ class RouterWrapperTests {
         routerWrapper = RouterWrapper(
             accessToken,
             mapboxNativeNavigator.router,
-            ThreadController(),
+            TestThreadController(),
         )
     }
 

--- a/libtesting-navigation-util/src/main/java/com/mapbox/navigation/testing/TestThreadController.kt
+++ b/libtesting-navigation-util/src/main/java/com/mapbox/navigation/testing/TestThreadController.kt
@@ -1,0 +1,43 @@
+package com.mapbox.navigation.testing
+
+import com.mapbox.navigation.utils.internal.JobControl
+import com.mapbox.navigation.utils.internal.ThreadController
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+
+class TestThreadController(
+    private val dispatcher: CoroutineDispatcher = TestCoroutineDispatcher(),
+    private val scope: CoroutineScope = TestCoroutineScope(dispatcher + SupervisorJob())
+) : ThreadController {
+
+    override fun assertSDKThread() {
+    }
+
+    override fun getSDKScopeAndRootJob(immediate: Boolean): JobControl {
+        val childScope = createChildSDKScope(immediate)
+        return JobControl(childScope.coroutineContext.job, childScope)
+    }
+
+    override fun createChildSDKScope(immediate: Boolean): CoroutineScope {
+        val job = SupervisorJob(scope.coroutineContext.job)
+        return CoroutineScope(job + dispatcher)
+    }
+
+    override fun cancelSDKScope() {
+        scope.cancel()
+    }
+
+    override fun getIODispatcher(): CoroutineDispatcher {
+        return dispatcher
+    }
+
+    override fun getComputationDispatcher(): CoroutineDispatcher {
+        return dispatcher
+    }
+}

--- a/libtesting-utils/src/main/java/com/mapbox/navigation/testing/MainCoroutineRule.kt
+++ b/libtesting-utils/src/main/java/com/mapbox/navigation/testing/MainCoroutineRule.kt
@@ -1,5 +1,9 @@
 package com.mapbox.navigation.testing
 
+import android.os.Looper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
@@ -29,7 +33,6 @@ class MainCoroutineRule : TestRule {
         @Throws(Throwable::class)
         override fun evaluate() {
             Dispatchers.setMain(testDispatcher)
-
             base.evaluate()
 
             Dispatchers.resetMain() // Restore original main dispatcher

--- a/qa-test-app/src/main/AndroidManifest.xml
+++ b/qa-test-app/src/main/AndroidManifest.xml
@@ -77,6 +77,9 @@
         <activity android:name=".view.DropInButtonsActivity" />
 
         <activity android:name=".view.RoutesPreviewActivity" />
+
+        <activity android:name=".view.HandlerThreadActivity" />
+
         <activity android:name=".view.SpeedInfoActivity"
             android:theme="@style/Theme.Fullscreen" />
         <activity

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/domain/TestActivitySuite.kt
@@ -9,6 +9,7 @@ import com.mapbox.navigation.qa_test_app.view.AppLifecycleActivity
 import com.mapbox.navigation.qa_test_app.view.CustomAlternativeRouteColoringActivity
 import com.mapbox.navigation.qa_test_app.view.DropInButtonsActivity
 import com.mapbox.navigation.qa_test_app.view.FeedbackActivity
+import com.mapbox.navigation.qa_test_app.view.HandlerThreadActivity
 import com.mapbox.navigation.qa_test_app.view.IconsPreviewActivity
 import com.mapbox.navigation.qa_test_app.view.InactiveRouteStylingActivity
 import com.mapbox.navigation.qa_test_app.view.InactiveRouteStylingWithRestrictionsActivity
@@ -241,6 +242,12 @@ object TestActivitySuite {
             category = CATEGORY_COMPONENTS
         ) { activity ->
             activity.startActivity<RestAreaActivity>()
+        },
+        TestActivityDescription(
+            "Handler Thread",
+            R.string.handler_thread_description
+        ) { activity ->
+            activity.startActivity<HandlerThreadActivity>()
         },
     )
 

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/HandlerThreadActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/HandlerThreadActivity.kt
@@ -24,6 +24,7 @@ import com.mapbox.maps.plugin.LocationPuck2D
 import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.gestures.gestures
 import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.TimeFormat
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
@@ -80,6 +81,7 @@ import kotlinx.coroutines.launch
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
 
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class HandlerThreadActivity : AppCompatActivity() {
 
     /* ----- Layout binding reference ----- */
@@ -306,14 +308,13 @@ class HandlerThreadActivity : AppCompatActivity() {
             enabled = true
         }
 
-        val waitForCreation = CountDownLatch(1)
-
         sdkThread = HandlerThread("handler thread")
         sdkThread.start()
 
         mapboxNavigation = MapboxNavigation(
             NavigationOptions.Builder(this)
                 .accessToken(getMapboxAccessTokenFromResources())
+                .looper(sdkThread.looper)
                 .build()
         )
         // initialize Mapbox Navigation

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/HandlerThreadActivity.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/view/HandlerThreadActivity.kt
@@ -1,0 +1,560 @@
+package com.mapbox.navigation.qa_test_app.view
+
+import android.annotation.SuppressLint
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.location.Location
+import android.os.Bundle
+import android.os.Handler
+import android.os.HandlerThread
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.bindgen.Expected
+import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraOptions
+import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.MapboxMap
+import com.mapbox.maps.Style.Companion.MAPBOX_STREETS
+import com.mapbox.maps.plugin.LocationPuck2D
+import com.mapbox.maps.plugin.animation.camera
+import com.mapbox.maps.plugin.gestures.gestures
+import com.mapbox.maps.plugin.locationcomponent.location
+import com.mapbox.navigation.base.TimeFormat
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
+import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.base.options.EventsAppMetadata
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.NavigationRouterCallback
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.formatter.MapboxDistanceFormatter
+import com.mapbox.navigation.core.trip.session.LocationMatcherResult
+import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.core.trip.session.NavigationSessionStateObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
+import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver
+import com.mapbox.navigation.qa_test_app.R
+import com.mapbox.navigation.qa_test_app.databinding.LayoutActivityHandlerThreadBinding
+import com.mapbox.navigation.qa_test_app.utils.Utils
+import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
+import com.mapbox.navigation.ui.maneuver.api.MapboxManeuverApi
+import com.mapbox.navigation.ui.maps.camera.NavigationCamera
+import com.mapbox.navigation.ui.maps.camera.data.MapboxNavigationViewportDataSource
+import com.mapbox.navigation.ui.maps.camera.lifecycle.NavigationBasicGesturesHandler
+import com.mapbox.navigation.ui.maps.camera.state.NavigationCameraState
+import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowApi
+import com.mapbox.navigation.ui.maps.route.arrow.api.MapboxRouteArrowView
+import com.mapbox.navigation.ui.maps.route.arrow.model.RouteArrowOptions
+import com.mapbox.navigation.ui.maps.route.line.MapboxRouteLineApiExtensions.setRoutes
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineApi
+import com.mapbox.navigation.ui.maps.route.line.api.MapboxRouteLineView
+import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
+import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
+import com.mapbox.navigation.ui.tripprogress.api.MapboxTripProgressApi
+import com.mapbox.navigation.ui.tripprogress.model.DistanceRemainingFormatter
+import com.mapbox.navigation.ui.tripprogress.model.EstimatedTimeToArrivalFormatter
+import com.mapbox.navigation.ui.tripprogress.model.PercentDistanceTraveledFormatter
+import com.mapbox.navigation.ui.tripprogress.model.TimeRemainingFormatter
+import com.mapbox.navigation.ui.tripprogress.model.TripProgressUpdateFormatter
+import com.mapbox.navigation.ui.voice.api.MapboxSpeechApi
+import com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer
+import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
+import com.mapbox.navigation.ui.voice.model.SpeechError
+import com.mapbox.navigation.ui.voice.model.SpeechValue
+import com.mapbox.navigation.ui.voice.model.SpeechVolume
+import com.mapbox.navigation.utils.internal.logD
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.Locale
+import java.util.concurrent.CountDownLatch
+
+class HandlerThreadActivity : AppCompatActivity() {
+
+    /* ----- Layout binding reference ----- */
+    private lateinit var binding: LayoutActivityHandlerThreadBinding
+
+    /* ----- Mapbox Maps components ----- */
+    private lateinit var mapboxMap: MapboxMap
+
+    /* ----- Mapbox Navigation components ----- */
+    private lateinit var mapboxNavigation: MapboxNavigation
+
+    // location puck integration
+    private val navigationLocationProvider = NavigationLocationProvider()
+
+    // camera
+    private lateinit var navigationCamera: NavigationCamera
+    private lateinit var viewportDataSource: MapboxNavigationViewportDataSource
+    private val pixelDensity = Resources.getSystem().displayMetrics.density
+    private val overviewPadding: EdgeInsets by lazy {
+        EdgeInsets(
+            140.0 * pixelDensity,
+            40.0 * pixelDensity,
+            120.0 * pixelDensity,
+            40.0 * pixelDensity
+        )
+    }
+    private val landscapeOverviewPadding: EdgeInsets by lazy {
+        EdgeInsets(
+            30.0 * pixelDensity,
+            380.0 * pixelDensity,
+            20.0 * pixelDensity,
+            20.0 * pixelDensity
+        )
+    }
+    private val followingPadding: EdgeInsets by lazy {
+        EdgeInsets(
+            180.0 * pixelDensity,
+            40.0 * pixelDensity,
+            150.0 * pixelDensity,
+            40.0 * pixelDensity
+        )
+    }
+    private val landscapeFollowingPadding: EdgeInsets by lazy {
+        EdgeInsets(
+            30.0 * pixelDensity,
+            380.0 * pixelDensity,
+            110.0 * pixelDensity,
+            40.0 * pixelDensity
+        )
+    }
+
+    // trip progress bottom view
+    private lateinit var tripProgressApi: MapboxTripProgressApi
+
+    // voice instructions
+    private var isVoiceInstructionsMuted = false
+    private lateinit var maneuverApi: MapboxManeuverApi
+    private lateinit var speechAPI: MapboxSpeechApi
+    private lateinit var voiceInstructionsPlayer: MapboxVoiceInstructionsPlayer
+
+    // route line
+    private lateinit var routeLineAPI: MapboxRouteLineApi
+    private lateinit var routeLineView: MapboxRouteLineView
+    private lateinit var routeArrowView: MapboxRouteArrowView
+    private val routeArrowAPI: MapboxRouteArrowApi = MapboxRouteArrowApi()
+
+    /* ----- Voice instruction callbacks ----- */
+    private val voiceInstructionsObserver =
+        VoiceInstructionsObserver { voiceInstructions ->
+            runOnUiThread {
+                speechAPI.generate(
+                    voiceInstructions,
+                    speechCallback
+                )
+            }
+        }
+
+    private val voiceInstructionsPlayerCallback =
+        MapboxNavigationConsumer<SpeechAnnouncement> { value ->
+            runOnUiThread {
+                // remove already consumed file to free-up space
+                speechAPI.clean(value)
+            }
+        }
+
+    private val speechCallback =
+        MapboxNavigationConsumer<Expected<SpeechError, SpeechValue>> { expected ->
+            runOnUiThread {
+                expected.fold(
+                    { error ->
+                        // play the instruction via fallback text-to-speech engine
+                        voiceInstructionsPlayer.play(
+                            error.fallback,
+                            voiceInstructionsPlayerCallback
+                        )
+                    },
+                    { value ->
+                        // play the sound file from the external generator
+                        voiceInstructionsPlayer.play(
+                            value.announcement,
+                            voiceInstructionsPlayerCallback
+                        )
+                    }
+                )
+            }
+        }
+
+    /* ----- Location and route progress callbacks ----- */
+    private val locationObserver = object : LocationObserver {
+        override fun onNewRawLocation(rawLocation: Location) {
+            // not handled
+        }
+
+        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+            runOnUiThread {
+                // update location puck's position on the map
+                navigationLocationProvider.changePosition(
+                    location = locationMatcherResult.enhancedLocation,
+                    keyPoints = locationMatcherResult.keyPoints,
+                )
+
+                // update camera position to account for new location
+                viewportDataSource.onLocationChanged(locationMatcherResult.enhancedLocation)
+                viewportDataSource.evaluate()
+            }
+        }
+    }
+
+    private val routeProgressObserver =
+        RouteProgressObserver { routeProgress ->
+            runOnUiThread {
+                // update the camera position to account for the progressed fragment of the route
+                viewportDataSource.onRouteProgressChanged(routeProgress)
+                viewportDataSource.evaluate()
+
+                // show arrow on the route line with the next maneuver
+                val maneuverArrowResult = routeArrowAPI.addUpcomingManeuverArrow(routeProgress)
+                val style = mapboxMap.getStyle()
+                if (style != null) {
+                    routeArrowView.renderManeuverUpdate(style, maneuverArrowResult)
+                }
+
+                // update top maneuver instructions
+                val maneuvers = maneuverApi.getManeuvers(routeProgress)
+                maneuvers.fold(
+                    { error ->
+                        Toast.makeText(
+                            this@HandlerThreadActivity,
+                            error.errorMessage,
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    },
+                    {
+                        binding.maneuverView.visibility = VISIBLE
+                        binding.maneuverView.renderManeuvers(maneuvers)
+                    }
+                )
+
+                // update bottom trip progress summary
+                binding.tripProgressView.render(tripProgressApi.getTripProgress(routeProgress))
+            }
+        }
+
+    private val routesObserver = RoutesObserver { result ->
+        runOnUiThread {
+            if (result.routes.isNotEmpty()) {
+                // generate route geometries asynchronously and render them
+                lifecycleScope.launch {
+                    val result = routeLineAPI.setRoutes(
+                        listOf(RouteLine(result.routes.first(), null))
+                    )
+                    val style = mapboxMap.getStyle()
+                    if (style != null) {
+                        routeLineView.renderRouteDrawData(style, result)
+                    }
+                }
+
+                // update the camera position to account for the new route
+                viewportDataSource.onRouteChanged(result.routes.first())
+                viewportDataSource.evaluate()
+            } else {
+                // remove the route line and route arrow from the map
+                val style = mapboxMap.getStyle()
+                if (style != null) {
+                    routeLineAPI.clearRouteLine { value ->
+                        routeLineView.renderClearRouteLineValue(
+                            style,
+                            value
+                        )
+                    }
+                    routeArrowView.render(style, routeArrowAPI.clearArrows())
+                }
+
+                // remove the route reference to change camera position
+                viewportDataSource.clearRouteData()
+                viewportDataSource.evaluate()
+            }
+        }
+    }
+
+    private val navigationSessionStateObserver = NavigationSessionStateObserver {
+        logD("NavigationSessionState=$it", LOG_CATEGORY)
+        logD("sessionId=${mapboxNavigation.getNavigationSessionState().sessionId}", LOG_CATEGORY)
+    }
+
+    private lateinit var sdkThread: HandlerThread
+
+    @SuppressLint("MissingPermission")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = LayoutActivityHandlerThreadBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        mapboxMap = binding.mapView.getMapboxMap()
+
+        // initialize the location puck
+        binding.mapView.location.apply {
+            this.locationPuck = LocationPuck2D(
+                bearingImage = ContextCompat.getDrawable(
+                    this@HandlerThreadActivity,
+                    R.drawable.mapbox_navigation_puck_icon
+                )
+            )
+            setLocationProvider(navigationLocationProvider)
+            enabled = true
+        }
+
+        val waitForCreation = CountDownLatch(1)
+
+        sdkThread = HandlerThread("handler thread")
+        sdkThread.start()
+
+        mapboxNavigation = MapboxNavigation(
+            NavigationOptions.Builder(this)
+                .accessToken(getMapboxAccessTokenFromResources())
+                .build()
+        )
+        // initialize Mapbox Navigation
+
+
+            // move the camera to current location on the first update
+        mapboxNavigation.registerLocationObserver(object : LocationObserver {
+            override fun onNewRawLocation(rawLocation: Location) {
+                runOnUiThread {
+                    val point = Point.fromLngLat(rawLocation.longitude, rawLocation.latitude)
+                    val cameraOptions = CameraOptions.Builder()
+                        .center(point)
+                        .zoom(13.0)
+                        .build()
+                    mapboxMap.setCamera(cameraOptions)
+                    mapboxNavigation.unregisterLocationObserver(this)
+                }
+            }
+
+            override fun onNewLocationMatcherResult(
+                locationMatcherResult: LocationMatcherResult,
+            ) {
+                // not handled
+            }
+        })
+
+
+        // initialize Navigation Camera
+        viewportDataSource = MapboxNavigationViewportDataSource(
+            binding.mapView.getMapboxMap()
+        )
+        navigationCamera = NavigationCamera(
+            binding.mapView.getMapboxMap(),
+            binding.mapView.camera,
+            viewportDataSource
+        )
+        binding.mapView.camera.addCameraAnimationsLifecycleListener(
+            NavigationBasicGesturesHandler(navigationCamera)
+        )
+        navigationCamera.registerNavigationCameraStateChangeObserver { navigationCameraState ->
+            // shows/hide the recenter button depending on the camera state
+            when (navigationCameraState) {
+                NavigationCameraState.TRANSITION_TO_FOLLOWING,
+                NavigationCameraState.FOLLOWING -> binding.recenter.visibility = INVISIBLE
+
+                NavigationCameraState.TRANSITION_TO_OVERVIEW,
+                NavigationCameraState.OVERVIEW,
+                NavigationCameraState.IDLE -> binding.recenter.visibility = VISIBLE
+            }
+        }
+        if (this.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            viewportDataSource.overviewPadding = landscapeOverviewPadding
+        } else {
+            viewportDataSource.overviewPadding = overviewPadding
+        }
+        if (this.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            viewportDataSource.followingPadding = landscapeFollowingPadding
+        } else {
+            viewportDataSource.followingPadding = followingPadding
+        }
+
+        // initialize top maneuver view
+        maneuverApi = MapboxManeuverApi(
+            MapboxDistanceFormatter(DistanceFormatterOptions.Builder(this).build())
+        )
+
+        // initialize bottom progress view
+        tripProgressApi = MapboxTripProgressApi(
+            TripProgressUpdateFormatter.Builder(this)
+                .distanceRemainingFormatter(
+                    DistanceRemainingFormatter(
+                        mapboxNavigation.navigationOptions.distanceFormatterOptions
+                    )
+                )
+                .timeRemainingFormatter(TimeRemainingFormatter(this))
+                .percentRouteTraveledFormatter(PercentDistanceTraveledFormatter())
+                .estimatedTimeToArrivalFormatter(
+                    EstimatedTimeToArrivalFormatter(this, TimeFormat.NONE_SPECIFIED)
+                )
+                .build()
+        )
+
+        // initialize voice instructions
+        speechAPI = MapboxSpeechApi(
+            this,
+            getMapboxAccessTokenFromResources(),
+            Locale.US.language
+        )
+        voiceInstructionsPlayer = MapboxVoiceInstructionsPlayer(
+            this,
+            Locale.US.language
+        )
+
+        // initialize route line
+        val mapboxRouteLineOptions = MapboxRouteLineOptions.Builder(this)
+            .withRouteLineBelowLayerId("road-label")
+            .build()
+        routeLineAPI = MapboxRouteLineApi(mapboxRouteLineOptions)
+        routeLineView = MapboxRouteLineView(mapboxRouteLineOptions)
+        val routeArrowOptions = RouteArrowOptions.Builder(this).build()
+        routeArrowView = MapboxRouteArrowView(routeArrowOptions)
+
+        // load map style
+        mapboxMap.loadStyleUri(MAPBOX_STREETS) { style ->
+            routeLineView.initializeLayers(style)
+            // add long click listener that search for a route to the clicked destination
+            binding.mapView.gestures.addOnMapLongClickListener { point ->
+                findRoute(point)
+                true
+            }
+        }
+
+        // initialize view interactions
+        binding.stop.setOnClickListener {
+            clearRouteAndStopNavigation()
+        }
+        binding.recenter.setOnClickListener {
+            navigationCamera.requestNavigationCameraToFollowing()
+        }
+        binding.routeOverview.setOnClickListener {
+            navigationCamera.requestNavigationCameraToOverview()
+            binding.recenter.showTextAndExtend(2000L)
+        }
+        binding.soundButton.setOnClickListener {
+            // mute/unmute voice instructions
+            isVoiceInstructionsMuted = !isVoiceInstructionsMuted
+            if (isVoiceInstructionsMuted) {
+                binding.soundButton.muteAndExtend(2000L)
+                voiceInstructionsPlayer.volume(SpeechVolume(0f))
+            } else {
+                binding.soundButton.unmuteAndExtend(2000L)
+                voiceInstructionsPlayer.volume(SpeechVolume(1f))
+            }
+        }
+
+        // start the trip session to being receiving location updates in free drive
+        // and later when a route is set, also receiving route progress updates
+        mapboxNavigation.startTripSession()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        mapboxNavigation.registerRoutesObserver(routesObserver)
+        mapboxNavigation.registerNavigationSessionStateObserver(navigationSessionStateObserver)
+        mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+        mapboxNavigation.registerLocationObserver(locationObserver)
+        mapboxNavigation.registerVoiceInstructionsObserver(voiceInstructionsObserver)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        mapboxNavigation.unregisterRoutesObserver(routesObserver)
+        mapboxNavigation.unregisterNavigationSessionStateObserver(navigationSessionStateObserver)
+        mapboxNavigation.unregisterRouteProgressObserver(routeProgressObserver)
+        mapboxNavigation.unregisterLocationObserver(locationObserver)
+        mapboxNavigation.unregisterVoiceInstructionsObserver(voiceInstructionsObserver)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        routeLineAPI.cancel()
+        routeLineView.cancel()
+        mapboxNavigation.onDestroy()
+        maneuverApi.cancel()
+        speechAPI.cancel()
+        voiceInstructionsPlayer.shutdown()
+        sdkThread.quitSafely()
+    }
+
+    private fun findRoute(destination: Point) {
+        val origin = navigationLocationProvider.lastLocation?.let {
+            Point.fromLngLat(it.longitude, it.latitude)
+        } ?: return
+
+
+        mapboxNavigation.requestRoutes(
+            RouteOptions.builder()
+                .applyDefaultNavigationOptions()
+                .applyLanguageAndVoiceUnitOptions(this)
+                .coordinatesList(listOf(origin, destination))
+                .layersList(listOf(mapboxNavigation.getZLevel(), null))
+                .build(),
+            object : NavigationRouterCallback {
+                override fun onRoutesReady(
+                    routes: List<NavigationRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
+                    setRouteAndStartNavigation(routes)
+                }
+
+                override fun onFailure(
+                    reasons: List<RouterFailure>,
+                    routeOptions: RouteOptions
+                ) {
+                    // no impl
+                }
+
+                override fun onCanceled(
+                    routeOptions: RouteOptions,
+                    routerOrigin: RouterOrigin
+                ) {
+                    // no impl
+                }
+            }
+        )
+
+    }
+
+    private fun setRouteAndStartNavigation(route: List<NavigationRoute>) {
+        // set route
+        mapboxNavigation.setNavigationRoutes(route)
+        runOnUiThread {
+            // show UI elements
+            binding.soundButton.visibility = VISIBLE
+            binding.routeOverview.visibility = VISIBLE
+            binding.tripProgressCard.visibility = VISIBLE
+            binding.routeOverview.showTextAndExtend(2000L)
+            binding.soundButton.unmuteAndExtend(2000L)
+
+            // move the camera to overview when new route is available
+            navigationCamera.requestNavigationCameraToOverview()
+        }
+    }
+
+    private fun clearRouteAndStopNavigation() {
+        // clear
+        mapboxNavigation.setRoutes(listOf())
+
+
+        // hide UI elements
+        binding.soundButton.visibility = INVISIBLE
+        binding.maneuverView.visibility = INVISIBLE
+        binding.routeOverview.visibility = INVISIBLE
+        binding.tripProgressCard.visibility = INVISIBLE
+    }
+
+    private fun getMapboxAccessTokenFromResources(): String {
+        return Utils.getMapboxAccessToken(this)
+    }
+
+    private companion object {
+        private const val LOG_CATEGORY = "MapboxNavigationActivity"
+    }
+}

--- a/qa-test-app/src/main/res/layout/layout_activity_handler_thread.xml
+++ b/qa-test-app/src/main/res/layout/layout_activity_handler_thread.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.mapbox.maps.MapView
+        android:id="@+id/mapView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/tripProgressCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:visibility="invisible"
+        app:cardElevation="8dp"
+        app:cardUseCompatPadding="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <com.mapbox.navigation.ui.tripprogress.view.MapboxTripProgressView
+            android:id="@+id/tripProgressView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <Button
+            android:id="@+id/stop"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="end|center_vertical"
+            android:layout_marginEnd="12dp"
+            android:text="X" />
+    </androidx.cardview.widget.CardView>
+
+    <com.mapbox.navigation.ui.maneuver.view.MapboxManeuverView
+        android:id="@+id/maneuverView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:visibility="invisible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.mapbox.navigation.ui.voice.view.MapboxSoundButton
+        android:id="@+id/soundButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:visibility="invisible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/maneuverView" />
+
+    <com.mapbox.navigation.ui.maps.camera.view.MapboxRouteOverviewButton
+        android:id="@+id/routeOverview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:visibility="invisible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/soundButton" />
+
+    <com.mapbox.navigation.ui.maps.camera.view.MapboxRecenterButton
+        android:id="@+id/recenter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/routeOverview" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/qa-test-app/src/main/res/values/strings.xml
+++ b/qa-test-app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="drop_in_buttons_activity_description" translatable="false">Screen for viewing SDK buttons.</string>
     <string name="speed_info_activity_description" translatable="false">Example of how to use Mapbox SpeedInfo View</string>
     <string name="rest_area_activity_description" translatable="false">Demonstrates the use of Rest Area API</string>
+    <string name="handler_thread_description" translatable="false">Navigation activity where SDK\'s core works on a handler thread instead of the main.</string>
 
     <string-array name="drop_in_info_panel_overrides" translatable="false">
         <item>--</item>


### PR DESCRIPTION
The second iteration of https://github.com/mapbox/mapbox-navigation-android/pull/6575

https://mapbox.atlassian.net/browse/NAVAND-779

## The goal

Let customers configure the Navigation SDK in a way where navigation core works without touching the main thread. At the same time SDK's core could be accessed from any thread.

## The implementation

`MapboxNavigaiton` reschedules all the calls to the SDK thread using the looper it receives via navigation options. I.e. internally it works only with 1 tread, so the change isn't very dangerous. 

There was a challenging case: what to do with methods that return result immediately, for example `MapboxNavigation#getZLevel` or `MapboxNavigation#requestRoutes`? I decided to execute calls immediately if the SDK is accessed from the SDK thread and block caller thread until the SDK thread calculates result otherwise. In the tradeoff of efficiency vs simplicity I picked simplicity. Anyway if the SDK is access from the SDK thread, not blocking happens.

## Notes for reviewers

This is a draft PR. I'm not sure if that makes sense at all, I'm still waiting for the feedback from the customer. I opened the PR to ask you if you see any red flags in this approach. Try not to care about implementation details too much, the are not important at this stage. 
