### PR TITLE
Fix: Same first voice instruction is played in Offline and Online player.

### DIFF
--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidance.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxAudioGuidance.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
@@ -147,7 +148,8 @@ internal constructor(
                         .filter { it.voiceInstructions != lastPlayedInstructions }
                         .flatMapConcat {
                             lastPlayedInstructions = it.voiceInstructions
-                            audioGuidance.speak(it.voiceInstructions)
+                            val announcement = audioGuidance.speak(it.voiceInstructions)
+                            flowOf(announcement)
                         }
                         .map { speechAnnouncement ->
                             internalStateFlow.updateAndGet {

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/MapboxAudioGuidanceVoice.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/internal/MapboxAudioGuidanceVoice.kt
@@ -1,20 +1,13 @@
 package com.mapbox.navigation.ui.voice.internal
 
 import com.mapbox.api.directions.v5.models.VoiceInstructions
-import com.mapbox.bindgen.Expected
-import com.mapbox.navigation.ui.base.util.MapboxNavigationConsumer
 import com.mapbox.navigation.ui.voice.api.MapboxSpeechApi
 import com.mapbox.navigation.ui.voice.api.MapboxVoiceInstructionsPlayer
 import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
-import com.mapbox.navigation.ui.voice.model.SpeechError
-import com.mapbox.navigation.ui.voice.model.SpeechValue
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.channels.onFailure
-import kotlinx.coroutines.channels.onSuccess
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
 
 /**
  * Controls voice guidance for the car.
@@ -26,35 +19,44 @@ class MapboxAudioGuidanceVoice(
     private val mapboxSpeechApi: MapboxSpeechApi,
     private val mapboxVoiceInstructionsPlayer: MapboxVoiceInstructionsPlayer
 ) {
-    fun speak(voiceInstructions: VoiceInstructions?): Flow<SpeechAnnouncement?> {
+    /**
+     * Load and play [SpeechAnnouncement].
+     * This method will suspend until announcement finishes playback.
+     */
+    suspend fun speak(voiceInstructions: VoiceInstructions?): SpeechAnnouncement? {
         return if (voiceInstructions != null) {
-            speechFlow(voiceInstructions)
+            val announcement = mapboxSpeechApi.generate(voiceInstructions)
+            try {
+                mapboxVoiceInstructionsPlayer.play(announcement)
+                announcement
+            } finally {
+                withContext(NonCancellable) {
+                    mapboxSpeechApi.clean(announcement)
+                }
+            }
         } else {
             mapboxSpeechApi.cancel()
             mapboxVoiceInstructionsPlayer.clear()
-            flowOf(null)
+            null
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    private fun speechFlow(voiceInstructions: VoiceInstructions): Flow<SpeechAnnouncement> =
-        callbackFlow {
-            val speechCallback =
-                MapboxNavigationConsumer<Expected<SpeechError, SpeechValue>> { value ->
-                    val speechAnnouncement = value.value?.announcement ?: value.error!!.fallback
-                    mapboxVoiceInstructionsPlayer.play(speechAnnouncement) {
-                        mapboxSpeechApi.clean(it)
-                        trySend(speechAnnouncement).onSuccess {
-                            close()
-                        }.onFailure {
-                            close()
-                        }
-                    }
-                }
-            mapboxSpeechApi.generate(voiceInstructions, speechCallback)
-            awaitClose {
-                mapboxSpeechApi.cancel()
-                mapboxVoiceInstructionsPlayer.clear()
-            }
+    private suspend fun MapboxSpeechApi.generate(
+        instructions: VoiceInstructions
+    ): SpeechAnnouncement = suspendCancellableCoroutine { cont ->
+        generate(instructions) { value ->
+            val announcement = value.value?.announcement ?: value.error!!.fallback
+            cont.resume(announcement)
         }
+        cont.invokeOnCancellation { cancel() }
+    }
+
+    private suspend fun MapboxVoiceInstructionsPlayer.play(
+        announcement: SpeechAnnouncement
+    ): SpeechAnnouncement = suspendCancellableCoroutine { cont ->
+        play(announcement) {
+            cont.resume(announcement)
+        }
+        cont.invokeOnCancellation { clear() }
+    }
 }

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/TestMapboxAudioGuidanceServices.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/TestMapboxAudioGuidanceServices.kt
@@ -8,13 +8,13 @@ import com.mapbox.navigation.ui.voice.internal.MapboxVoiceInstructionsState
 import com.mapbox.navigation.ui.voice.internal.impl.MapboxAudioGuidanceServices
 import com.mapbox.navigation.ui.voice.model.SpeechAnnouncement
 import io.mockk.Runs
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.onEach
 
 class TestMapboxAudioGuidanceServices(
     private val deviceLanguage: String = "en"
@@ -34,7 +34,7 @@ class TestMapboxAudioGuidanceServices(
     }
 
     private val mapboxAudioGuidanceVoice = mockk<MapboxAudioGuidanceVoice> {
-        every { speak(any()) } answers {
+        coEvery { speak(any()) } coAnswers {
             val voiceInstructions = firstArg<VoiceInstructions?>()
             val speechAnnouncement: SpeechAnnouncement? = voiceInstructions?.let {
                 mockk {
@@ -42,12 +42,11 @@ class TestMapboxAudioGuidanceServices(
                     every { ssmlAnnouncement } returns it.ssmlAnnouncement()
                 }
             }
-            flowOf(speechAnnouncement).onEach {
-                if (it != null) {
-                    // Simulate a real speech announcement by delaying the TestCoroutineScope
-                    delay(SPEECH_ANNOUNCEMENT_DELAY_MS)
-                }
+            if (speechAnnouncement != null) {
+                // Simulate a real speech announcement by delaying the TestCoroutineScope
+                delay(SPEECH_ANNOUNCEMENT_DELAY_MS)
             }
+            speechAnnouncement
         }
     }
 


### PR DESCRIPTION
Closes NAVAND-1001

### Description

Updated `MapboxAudioGuidanceVoice` to use coroutines to synchronize calls to both `MapboxSpeechApi` and `MapboxVoiceInstructionsPlayer`. As a result, `MapboxAudioGuidanceVoice` will wait until the player finishes playing the previous announcement before attempting to play the next one. Using coroutines also allows API and Player cancellation alongside the parent `Job`.
