### PR TITLE
NAVAND-1025: fix the crash in MapboxVoiceInstructionsPlayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Mapbox welcomes participation and contributions from everyone.
   }
   ```
 - Added guarantees that route progress with `RouteProgress#currentState == OFF_ROUTE` arrives earlier than `NavigationRerouteController#reroute` is called. [#6764](https://github.com/mapbox/mapbox-navigation-android/pull/6764)
+- Fixed a rare `java.lang.NullPointerException: Attempt to read from field 'SpeechAnnouncement PlayCallback.announcement' on a null object reference` crash in `PlayCallback.getAnnouncement`. [#6760](https://github.com/mapbox/mapbox-navigation-android/pull/6760)
 
 ## Mapbox Navigation SDK 2.10.0-rc.1 - 16 December, 2022
 ### Changelog

--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxVoiceInstructionsPlayer.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/MapboxVoiceInstructionsPlayer.kt
@@ -92,9 +92,11 @@ class MapboxVoiceInstructionsPlayer @JvmOverloads constructor(
                 abandonFocus()
             }
 
-            val currentAnnouncement = currentPlayCallback.announcement
-            val currentClientCallback = currentPlayCallback.consumer
-            currentClientCallback.accept(currentAnnouncement)
+            if (currentPlayCallback != null) {
+                val currentAnnouncement = currentPlayCallback.announcement
+                val currentClientCallback = currentPlayCallback.consumer
+                currentClientCallback.accept(currentAnnouncement)
+            }
             play()
         }
 

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/MapboxVoiceInstructionsPlayerTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/MapboxVoiceInstructionsPlayerTest.kt
@@ -633,6 +633,32 @@ class MapboxVoiceInstructionsPlayerTest {
         }
     }
 
+    @Test
+    fun `play is done after clear`() {
+        val anyLanguage = Locale.US.language
+        val mockedAnnouncement: SpeechAnnouncement = mockk(relaxed = true)
+        val mapboxVoiceInstructionsPlayer =
+            MapboxVoiceInstructionsPlayer(
+                aMockedContext,
+                anyLanguage,
+                mockedPlayerOptions
+            )
+        val mockedPlay: SpeechAnnouncement = mockedAnnouncement
+        val voiceInstructionsPlayerConsumer =
+            mockk<MapboxNavigationConsumer<SpeechAnnouncement>>(relaxed = true)
+
+        val requestSlotCallback = slot<AudioFocusRequestCallback>()
+        every {
+            mockedAudioFocusDelegate.requestFocus(any(), capture(requestSlotCallback))
+        } just Runs
+        mapboxVoiceInstructionsPlayer.play(mockedPlay, voiceInstructionsPlayerConsumer)
+        mapboxVoiceInstructionsPlayer.clear()
+
+        requestSlotCallback.captured.invoke(false)
+
+        verify(exactly = 0) { voiceInstructionsPlayerConsumer.accept(any()) }
+    }
+
     private fun given(
         audioFocusResult: Boolean,
         filePlayerCallbackAnswer: (VoiceInstructionsPlayerCallback) -> Unit,


### PR DESCRIPTION
### Description
This PR fixes the possible crash. The reproduce steps are unknown, I guess there is a race between calls to `clear` and focus callback calls.