### PR TITLE
[copilot] Add Proguard rule to prevent obfuscation of route properties

### DIFF
--- a/libnavigation-copilot/proguard-rules.pro
+++ b/libnavigation-copilot/proguard-rules.pro
@@ -1,0 +1,1 @@
+-keepnames class com.mapbox.api.directions.v5.models.** {*;}


### PR DESCRIPTION
### Description
Adds Proguard rule to prevent obfuscation of `route` (`DirectionsRoute`) properties

cc @ikryvanos 