### PR TITLE
Explicitly guarantee the order or route progress during reroute 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Mapbox welcomes participation and contributions from everyone.
           .build()
   }
   ```
+- Added guarantees that route progress with `RouteProgress#currentState == OFF_ROUTE` arrives earlier than `NavigationRerouteController#reroute` is called. [#6764](https://github.com/mapbox/mapbox-navigation-android/pull/6764)
 
 ## Mapbox Navigation SDK 2.10.0-rc.1 - 16 December, 2022
 ### Changelog

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/CoreRerouteTest.kt
@@ -16,10 +16,13 @@ import com.mapbox.navigation.base.route.RouteRefreshOptions
 import com.mapbox.navigation.base.route.RouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
 import com.mapbox.navigation.core.directions.session.RoutesExtra
+import com.mapbox.navigation.core.reroute.NavigationRerouteController
+import com.mapbox.navigation.core.reroute.RerouteController
 import com.mapbox.navigation.core.reroute.RerouteState
 import com.mapbox.navigation.instrumentation_tests.R
 import com.mapbox.navigation.instrumentation_tests.activity.EmptyTestActivity
@@ -48,6 +51,7 @@ import com.mapbox.navigation.testing.ui.BaseTest
 import com.mapbox.navigation.testing.ui.utils.getMapboxAccessTokenFromResources
 import com.mapbox.navigation.testing.ui.utils.runOnMainSync
 import com.mapbox.navigation.utils.internal.logE
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNot
@@ -449,6 +453,56 @@ class CoreRerouteTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::class.jav
             routesUpdate.navigationRoutes
         )
     }
+
+    @Test
+    fun events_order_are_guaranteed_during_reroute_to_alternative_with_custom_reroute_controller() =
+        sdkTest {
+            val mapboxNavigation = createMapboxNavigation()
+            val routes = RoutesProvider.dc_short_with_alternative(activity).toNavigationRoutes()
+            var latestRouteProgress: RouteProgress? = null
+            mapboxNavigation.registerRouteProgressObserver {
+                latestRouteProgress = it
+            }
+            val alternativeIdFromTheLatestRouteProgressDuringReroute =
+                CompletableDeferred<String?>()
+            mapboxNavigation.setRerouteController(object : NavigationRerouteController {
+                override fun reroute(callback: NavigationRerouteController.RoutesCallback) {
+                    alternativeIdFromTheLatestRouteProgressDuringReroute
+                        .complete(latestRouteProgress?.routeAlternativeId)
+                }
+
+                override fun reroute(routesCallback: RerouteController.RoutesCallback) {
+                }
+                override val state: RerouteState = RerouteState.Idle
+                override fun interrupt() {
+                }
+                override fun registerRerouteStateObserver(
+                    rerouteStateObserver: RerouteController.RerouteStateObserver
+                ): Boolean {
+                    return false
+                }
+                override fun unregisterRerouteStateObserver(
+                    rerouteStateObserver: RerouteController.RerouteStateObserver
+                ): Boolean {
+                    return false
+                }
+            })
+            val origin = routes.first().routeOptions.coordinatesList().first()
+            mockLocationUpdatesRule.pushLocationUpdate {
+                latitude = origin.latitude()
+                longitude = origin.longitude()
+            }
+            mapboxNavigation.startTripSession()
+            mapboxNavigation.setNavigationRoutes(routes)
+            mapboxNavigation.routesUpdates().first { it.navigationRoutes == routes }
+
+            mockLocationReplayerRule.playRoute(routes[1].directionsRoute)
+
+            assertEquals(
+                routes[1].id,
+                alternativeIdFromTheLatestRouteProgressDuringReroute.await()
+            )
+        }
 
     private fun createMapboxNavigation(customRefreshInterval: Long? = null): MapboxNavigation {
         var mapboxNavigation: MapboxNavigation? = null

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/NavigationRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/NavigationRerouteController.kt
@@ -3,8 +3,10 @@ package com.mapbox.navigation.core.reroute
 import androidx.annotation.UiThread
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
+import com.mapbox.navigation.core.trip.session.RouteProgressObserver
 
 /**
  * Reroute controller allows changing the reroute logic externally. Use [MapboxNavigation.rerouteController]
@@ -16,6 +18,9 @@ interface NavigationRerouteController : RerouteController {
     /**
      * Invoked whenever re-route is needed. For instance when a driver is off-route. Called just after
      * an off-route event.
+     *
+     * In case you need the latest [RouteProgress] in your reroute logic,
+     * the SDK guarantees that [RouteProgressObserver.onRouteProgressChanged] is called before [reroute].
      *
      * @see [OffRouteObserver]
      */

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/NavigationRerouteController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/NavigationRerouteController.kt
@@ -4,6 +4,7 @@ import androidx.annotation.UiThread
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
+import com.mapbox.navigation.base.trip.model.RouteProgressState
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.session.OffRouteObserver
 import com.mapbox.navigation.core.trip.session.RouteProgressObserver
@@ -20,7 +21,8 @@ interface NavigationRerouteController : RerouteController {
      * an off-route event.
      *
      * In case you need the latest [RouteProgress] in your reroute logic,
-     * the SDK guarantees that [RouteProgressObserver.onRouteProgressChanged] is called before [reroute].
+     * the SDK guarantees that [RouteProgress] with [RouteProgressState.OFF_ROUTE] arrives earlier at [RouteProgressObserver.onRouteProgressChanged]
+     * than [reroute] is called.
      *
      * @see [OffRouteObserver]
      */


### PR DESCRIPTION
It not so easy to implement switching to an alternative route during reroute in a way the [SDK does it internally](https://github.com/mapbox/mapbox-navigation-android/blob/4032da4432d8de3bf851195f847fbbfa59458e83/libnavigation-core/src/main/java/com/mapbox/navigation/core/reroute/MapboxRerouteController.kt#L122). Internally we access the latest route progress from the trip session, but external users can't do it, they have to combine route progress and reroute events. It would be easier to combine SDK can provide some guarantees about the order. 

See more details in NAVAND-1027

Alternative approach to solve the problem could be found here: https://github.com/mapbox/mapbox-navigation-android/pull/6765