### PR TITLE
increased instrumentation tests timeout to 25 minutes per device

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ commands:
               --device model=oriole,version=33,locale=it,orientation=landscape \
               --use-orchestrator \
               --directories-to-pull=/sdcard/Download/mapbox_test \
-              --timeout 15m
+              --timeout 25m
 
   run-firebase-robo:
     parameters:


### PR DESCRIPTION
As our test suite grows we started to hit the limit on slower devices.