### PR TITLE
fix standalone maneuver view appearance when drop-in ui is integrated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Mapbox welcomes participation and contributions from everyone.
   ```
 - Added guarantees that route progress with `RouteProgress#currentState == OFF_ROUTE` arrives earlier than `NavigationRerouteController#reroute` is called. [#6764](https://github.com/mapbox/mapbox-navigation-android/pull/6764)
 - Fixed a rare `java.lang.NullPointerException: Attempt to read from field 'SpeechAnnouncement PlayCallback.announcement' on a null object reference` crash in `PlayCallback.getAnnouncement`. [#6760](https://github.com/mapbox/mapbox-navigation-android/pull/6760)
+- Fixed standalone `MapboxManeuverView` appearance when the app also integrates Drop-In UI. [#6774](https://github.com/mapbox/mapbox-navigation-android/pull/6774)
 
 ## Mapbox Navigation SDK 2.10.0-rc.1 - 16 December, 2022
 ### Changelog

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="description_signboard" translatable="false">Demonstrates the use of signboard API.</string>
     <string name="title_junction" translatable="false">Junction Example</string>
     <string name="description_junction" translatable="false">Demonstrates the use of junction API.</string>
-    <string name="title_trip_progress" translatable="false">TripProgess Example</string>
+    <string name="title_trip_progress" translatable="false">TripProgress Example</string>
     <string name="description_trip_progress" translatable="false">Demonstrates the use of trip progress API.</string>
     <string name="title_maneuver" translatable="false">Maneuver Example</string>
     <string name="description_maneuver" translatable="false">Demonstrates the use of maneuver API.</string>

--- a/libnavui-maneuver/src/main/res/values-night/colors.xml
+++ b/libnavui-maneuver/src/main/res/values-night/colors.xml
@@ -8,7 +8,6 @@
   <color name="mapbox_main_maneuver_background_color">@color/colorSecondary</color>
   <color name="mapbox_sub_maneuver_background_color">@color/colorSecondaryVariant</color>
   <color name="mapbox_upcoming_maneuver_background_color">@color/colorSecondaryVariant</color>
-  <color name="mapbox_exit_text_color">@android:color/black</color>
   <color name="mapbox_turn_icon_color">@color/colorOnSecondary</color>
   <color name="mapbox_turn_icon_shadow_color">#A8A8A8</color>
 </resources>

--- a/libnavui-maneuver/src/main/res/values/colors.xml
+++ b/libnavui-maneuver/src/main/res/values/colors.xml
@@ -8,7 +8,7 @@
   <color name="mapbox_main_maneuver_background_color">@color/colorSecondary</color>
   <color name="mapbox_sub_maneuver_background_color">@color/colorSecondaryVariant</color>
   <color name="mapbox_upcoming_maneuver_background_color">@color/colorSecondaryVariant</color>
-  <color name="mapbox_exit_text_color">@android:color/black</color>
+  <color name="mapbox_exit_text_color">@color/colorOnSurface</color>
   <color name="mapbox_exit_background_color">@color/colorSurface</color>
   <color name="mapbox_exit_background_border_color">@color/colorOnSurface</color>
   <color name="mapbox_exit_drawable_color">@color/colorOnSurface</color>


### PR DESCRIPTION
### Description
Drop-In UI overrides some of the resources in `libnavui-maneuver` module, but not all of them, which makes the standalone `MapboxManeuerView` draw black text on a black background when rendering exit info. This also affects Android Auto, because it uses the same `ManeuverViewOptions` as the standalone `MapboxManeuerView`. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
