### PR TITLE
NAVAND-979: represent imperial distances in miles down to 0.1 miles in miles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Mapbox welcomes participation and contributions from everyone.
 - Introduced `NavigationViewListener.onSpeedInfoClicked` that would be triggered when `MapboxSpeedInfoView` is clicked upon. [#6770](https://github.com/mapbox/mapbox-navigation-android/pull/6770)
 - Each newly instantiated MapboxRouteArrowView class will initialize the layers with the provided options on the first render call. Previously this would only be done if the layers hadn't already been initialized.  [#6466](https://github.com/mapbox/mapbox-navigation-android/pull/6466)
 - Fixed an issue where the first voice instruction might have been played twice. [#6766](https://github.com/mapbox/mapbox-navigation-android/pull/6766)
+- Changed distance formatting: now all the imperial distances down to 0.1 miles will be represented in miles, while the smaller ones - in feet. [#6775](https://github.com/mapbox/mapbox-navigation-android/pull/6775)
 
 ## Mapbox Navigation SDK 2.10.0-rc.1 - 16 December, 2022
 ### Changelog

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/formatter/MapboxDistanceUtilTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/formatter/MapboxDistanceUtilTest.kt
@@ -57,6 +57,22 @@ class MapboxDistanceUtilTest {
 
     @Config(qualifiers = "en")
     @Test
+    fun `formatDistance large value metric that is medium for imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            11000.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("11", result.distanceAsString)
+        assertEquals("km", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(11.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
     fun `formatDistance small value metric with default locale`() {
         val result = MapboxDistanceUtil.formatDistance(
             55.3,
@@ -73,6 +89,22 @@ class MapboxDistanceUtilTest {
 
     @Config(qualifiers = "en")
     @Test
+    fun `formatDistance small value metric that is medium for imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            390.0,
+            Rounding.INCREMENT_FIVE,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("390", result.distanceAsString)
+        assertEquals("m", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(390.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
     fun `formatDistance small value imperial with default locale`() {
         val result = MapboxDistanceUtil.formatDistance(
             10.0,
@@ -85,6 +117,22 @@ class MapboxDistanceUtilTest {
         assertEquals("ft", result.distanceSuffix)
         assertEquals(UnitType.IMPERIAL, result.unitType)
         assertEquals(30.0, result.distance, 0.1)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance small value close to upper bound imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            150.0,
+            Rounding.INCREMENT_FIVE,
+            UnitType.IMPERIAL,
+            ctx
+        )
+
+        assertEquals("490", result.distanceAsString)
+        assertEquals("ft", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(490.0, result.distance, 0.1)
     }
 
     @Config(qualifiers = "en")
@@ -138,18 +186,162 @@ class MapboxDistanceUtilTest {
 
     @Config(qualifiers = "en")
     @Test
-    fun `formatDistance medium value imperial with default locale`() {
+    fun `formatDistance medium value close to upper bound imperial with default locale`() {
         val result = MapboxDistanceUtil.formatDistance(
-            1000.0,
+            15000.0,
             Rounding.INCREMENT_FIFTY,
             UnitType.IMPERIAL,
             ctx
         )
 
-        assertEquals("0.6", result.distanceAsString)
+        assertEquals("9.3", result.distanceAsString)
         assertEquals("mi", result.distanceSuffix)
         assertEquals(UnitType.IMPERIAL, result.unitType)
-        assertEquals(0.6213714106386318, result.distance, 0.0)
+        assertEquals(9.3205679, result.distance, 0.00001)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance medium value close to lower bound imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            350.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL,
+            ctx
+        )
+
+        assertEquals("0.2", result.distanceAsString)
+        assertEquals("mi", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(0.21748, result.distance, 0.00001)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance invalid large value imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -19312.1,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL,
+            ctx
+        )
+
+        assertEquals("50", result.distanceAsString)
+        assertEquals("ft", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(50.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance invalid medium value imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -353.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL,
+            ctx
+        )
+
+        assertEquals("50", result.distanceAsString)
+        assertEquals("ft", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(50.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance invalid small value imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -54.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL,
+            ctx
+        )
+
+        assertEquals("50", result.distanceAsString)
+        assertEquals("ft", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(50.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance zero value imperial with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            0.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL,
+            ctx
+        )
+
+        assertEquals("50", result.distanceAsString)
+        assertEquals("ft", result.distanceSuffix)
+        assertEquals(UnitType.IMPERIAL, result.unitType)
+        assertEquals(50.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance zero value metric with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            0.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("50", result.distanceAsString)
+        assertEquals("m", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(50.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance invalid large value metric with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -19312.1,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("50", result.distanceAsString)
+        assertEquals("m", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(50.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance invalid medium value metric with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -353.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("50", result.distanceAsString)
+        assertEquals("m", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(50.0, result.distance, 0.0)
+    }
+
+    @Config(qualifiers = "en")
+    @Test
+    fun `formatDistance invalid small value metric with default locale`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -54.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC,
+            ctx
+        )
+
+        assertEquals("50", result.distanceAsString)
+        assertEquals("m", result.distanceSuffix)
+        assertEquals(UnitType.METRIC, result.unitType)
+        assertEquals(50.0, result.distance, 0.0)
     }
 
     @Test
@@ -164,6 +356,17 @@ class MapboxDistanceUtilTest {
     }
 
     @Test
+    fun `formatDistance return small distance only close to upper bound`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            150.0,
+            Rounding.INCREMENT_TEN,
+            UnitType.IMPERIAL
+        )
+
+        assertEquals(490.0, result, 0.0)
+    }
+
+    @Test
     fun `formatDistance return small distance only when input negative`() {
         val result = MapboxDistanceUtil.formatDistance(
             -10.0,
@@ -175,6 +378,28 @@ class MapboxDistanceUtilTest {
     }
 
     @Test
+    fun `formatDistance imperial return medium distance only close to lower bound`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            350.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL
+        )
+
+        assertEquals(0.21748, result, 0.000001)
+    }
+
+    @Test
+    fun `formatDistance imperial return medium distance only close to upper bound`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            15000.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL
+        )
+
+        assertEquals(9.3205679, result, 0.00001)
+    }
+
+    @Test
     fun `formatDistance return large distance only`() {
         val result = MapboxDistanceUtil.formatDistance(
             1000.0,
@@ -183,5 +408,71 @@ class MapboxDistanceUtilTest {
         )
 
         assertEquals(0.6213714106386318, result, 0.0)
+    }
+
+    @Test
+    fun `formatDistance invalid large metric returns zero`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -15000.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC
+        )
+
+        assertEquals(0.0, result, 0.0)
+    }
+
+    @Test
+    fun `formatDistance invalid large imperial returns zero`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -15000.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL
+        )
+
+        assertEquals(0.0, result, 0.0)
+    }
+
+    @Test
+    fun `formatDistance invalid medium metric returns zero`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -1500.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC
+        )
+
+        assertEquals(0.0, result, 0.0)
+    }
+
+    @Test
+    fun `formatDistance invalid medium imperial returns zero`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -1500.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL
+        )
+
+        assertEquals(0.0, result, 0.0)
+    }
+
+    @Test
+    fun `formatDistance invalid small metric returns zero`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -150.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.METRIC
+        )
+
+        assertEquals(0.0, result, 0.0)
+    }
+
+    @Test
+    fun `formatDistance invalid small imperial returns zero`() {
+        val result = MapboxDistanceUtil.formatDistance(
+            -150.0,
+            Rounding.INCREMENT_FIFTY,
+            UnitType.IMPERIAL
+        )
+
+        assertEquals(0.0, result, 0.0)
     }
 }


### PR DESCRIPTION
I'm not really sure what we've decided to do with British yards but this PR fixes the part with too large distances being displayed in feet.