### PR TITLE
Cherry-pick #6638: [Drop-In UI] Move `fetchRouteIfNeeded` to `RoutePreviewStateController`

### DIFF
--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/SharedApp.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/SharedApp.kt
@@ -1,6 +1,5 @@
 package com.mapbox.navigation.ui.app.internal
 
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.internal.extensions.attachCreated
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
@@ -14,39 +13,29 @@ import com.mapbox.navigation.ui.app.internal.controller.RoutePreviewStateControl
 import com.mapbox.navigation.ui.app.internal.controller.RouteStateController
 import com.mapbox.navigation.ui.app.internal.controller.StateResetController
 import com.mapbox.navigation.ui.app.internal.controller.TripSessionStarterStateController
+import com.mapbox.navigation.ui.app.internal.routefetch.RouteOptionsProvider
 import com.mapbox.navigation.ui.maps.internal.ui.RouteAlternativeComponent
 import com.mapbox.navigation.ui.maps.internal.ui.RouteAlternativeContract
 import java.util.concurrent.atomic.AtomicBoolean
 
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 object SharedApp {
     private var isSetup = false
 
     val store = Store()
     val state get() = store.state.value
+    val routeOptionsProvider: RouteOptionsProvider = RouteOptionsProvider()
 
     private val ignoreTripSessionUpdates = AtomicBoolean(false)
 
-    /**
-     * These classes are accessible through MapboxNavigationApp.getObserver(..)
-     */
-    val navigationStateController = NavigationStateController(store)
-    val locationStateController = LocationStateController(store)
-    val tripSessionStarterStateController = TripSessionStarterStateController(store)
-    val audioGuidanceStateController = AudioGuidanceStateController(store)
-    val cameraStateController = CameraStateController(store)
-    val destinationStateController = DestinationStateController(store)
-    val routeStateController = RouteStateController(store)
-    val routePreviewStateController = RoutePreviewStateController(store)
     private val navigationObservers: Array<MapboxNavigationObserver> = arrayOf(
-        routeStateController,
-        cameraStateController,
-        locationStateController,
-        navigationStateController,
-        destinationStateController,
-        routePreviewStateController,
-        audioGuidanceStateController,
-        tripSessionStarterStateController,
+        RouteStateController(store),
+        CameraStateController(store),
+        LocationStateController(store),
+        NavigationStateController(store),
+        DestinationStateController(store),
+        RoutePreviewStateController(store, routeOptionsProvider),
+        AudioGuidanceStateController(store),
+        TripSessionStarterStateController(store),
     )
 
     @JvmOverloads

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/extension/MapboxNavigationExtensions.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/extension/MapboxNavigationExtensions.kt
@@ -1,0 +1,56 @@
+package com.mapbox.navigation.ui.app.internal.extension
+
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.base.route.NavigationRouterCallback
+import com.mapbox.navigation.base.route.RouterFailure
+import com.mapbox.navigation.base.route.RouterOrigin
+import com.mapbox.navigation.core.MapboxNavigation
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal suspend fun MapboxNavigation.fetchRoute(
+    routeOptions: RouteOptions,
+    fetchStarted: (requestId: Long) -> Unit = {}
+): List<NavigationRoute> {
+    return suspendCancellableCoroutine { cont ->
+        val requestId = requestRoutes(
+            routeOptions,
+            object : NavigationRouterCallback {
+                override fun onRoutesReady(
+                    routes: List<NavigationRoute>,
+                    routerOrigin: RouterOrigin
+                ) {
+                    cont.resume(routes)
+                }
+
+                override fun onFailure(
+                    reasons: List<RouterFailure>,
+                    routeOptions: RouteOptions
+                ) {
+                    cont.resumeWithException(FetchRouteError(reasons, routeOptions))
+                }
+
+                override fun onCanceled(
+                    routeOptions: RouteOptions,
+                    routerOrigin: RouterOrigin
+                ) {
+                    cont.cancel(FetchRouteCancelled(routeOptions, routerOrigin))
+                }
+            }
+        )
+        fetchStarted(requestId)
+        cont.invokeOnCancellation { cancelRouteRequest(requestId) }
+    }
+}
+
+internal class FetchRouteError(
+    val reasons: List<RouterFailure>,
+    val routeOptions: RouteOptions
+) : Error()
+
+internal class FetchRouteCancelled(
+    val routeOptions: RouteOptions,
+    val routerOrigin: RouterOrigin
+) : Error()

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutePreviewAction.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/routefetch/RoutePreviewAction.kt
@@ -5,14 +5,24 @@ import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.ui.app.internal.Action
+import com.mapbox.navigation.ui.app.internal.State
 
 sealed class RoutePreviewAction : Action {
 
     /**
-     * The action is used to request and set routes based on [RouteOptions].
-     * @param options
+     * The action for fetching a route from the [State.location] to the [State.destination].
      */
-    data class FetchOptions(val options: RouteOptions) : RoutePreviewAction()
+    object FetchRoute : RoutePreviewAction()
+
+    /**
+     * Fetch Route and Show Route Preview.
+     */
+    object FetchRouteAndShowRoutePreview : RoutePreviewAction()
+
+    /**
+     * Fetch Route and Start Active Navigation.
+     */
+    object FetchRouteAndStartActiveNavigation : RoutePreviewAction()
 
     /**
      * The action informs that route request was successful and routes are ready to be used.

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/RoutePreviewStateControllerTest.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/internal/controller/RoutePreviewStateControllerTest.kt
@@ -1,19 +1,31 @@
 package com.mapbox.navigation.ui.app.internal.controller
 
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
 import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.geojson.Point
+import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.NavigationRouterCallback
 import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.core.directions.session.RoutesObserver
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.testing.LoggingFrontendTestRule
 import com.mapbox.navigation.testing.MainCoroutineRule
+import com.mapbox.navigation.ui.app.internal.Action
+import com.mapbox.navigation.ui.app.internal.State
+import com.mapbox.navigation.ui.app.internal.destination.Destination
 import com.mapbox.navigation.ui.app.internal.destination.DestinationAction
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
+import com.mapbox.navigation.ui.app.internal.navigation.NavigationStateAction
+import com.mapbox.navigation.ui.app.internal.routefetch.RouteOptionsProvider
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutesAction
 import com.mapbox.navigation.ui.app.testing.TestStore
+import com.mapbox.navigation.ui.app.testing.TestingUtil.makeLocationMatcherResult
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -24,13 +36,19 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [Build.VERSION_CODES.LOLLIPOP])
 internal class RoutePreviewStateControllerTest {
 
     @get:Rule
@@ -39,12 +57,23 @@ internal class RoutePreviewStateControllerTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
-    private val store = spyk(TestStore())
-    private val sut = RoutePreviewStateController(store)
+    private lateinit var store: TestStore
+    private lateinit var mapboxNavigation: MapboxNavigation
+    private lateinit var sut: RoutePreviewStateController
 
     @Before
     fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
         mockkObject(MapboxNavigationApp)
+        mapboxNavigation = mockMapboxNavigation(context)
+        store = spyk(TestStore())
+        store.setState(
+            State(
+                destination = Destination(Point.fromLngLat(11.0, 22.0)),
+                location = makeLocationMatcherResult(33.0, 44.0, 0f)
+            )
+        )
+        sut = RoutePreviewStateController(store, RouteOptionsProvider())
     }
 
     @After
@@ -54,15 +83,13 @@ internal class RoutePreviewStateControllerTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `onAttached should cancel previous route requests when SetDestination action is dispatched`() {
-        val options = mockk<RouteOptions>()
-        val mapboxNavigation = mockMapboxNavigation()
+    fun `fetchRouteSaga - should cancel previous route requests when SetDestination action is dispatched`() {
         every {
-            mapboxNavigation.requestRoutes(options, ofType(NavigationRouterCallback::class))
+            mapboxNavigation.requestRoutes(any(), ofType(NavigationRouterCallback::class))
         } returnsMany listOf(1L, 2L, 3L)
 
         sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchOptions(options))
+        store.dispatch(RoutePreviewAction.FetchRoute)
         store.dispatch(DestinationAction.SetDestination(null))
 
         verify { mapboxNavigation.cancelRouteRequest(1L) }
@@ -70,95 +97,48 @@ internal class RoutePreviewStateControllerTest {
 
     @Test
     @Suppress("MaxLineLength")
-    fun `onAttached should cancel previous route requests when FetchOptions action is dispatched`() {
-        val mapboxNavigation = mockMapboxNavigation()
+    fun `fetchRouteSaga - should cancel previous route requests when another FetchRoute action is dispatched`() {
         every {
             mapboxNavigation.requestRoutes(any(), ofType(NavigationRouterCallback::class))
         } returnsMany listOf(1L, 2L, 3L)
 
         sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchOptions(mockk()))
-        store.dispatch(RoutePreviewAction.FetchOptions(mockk()))
+        store.dispatch(RoutePreviewAction.FetchRoute)
+        store.dispatch(RoutePreviewAction.FetchRoute)
 
         verify { mapboxNavigation.cancelRouteRequest(1L) }
     }
 
     @Test
-    fun `should dispatch StartedFetchRequest when fetching routes`() {
-        val mapboxNavigation = mockMapboxNavigation()
+    fun `fetchRouteSaga - should dispatch StartedFetchRequest when fetching routes`() {
         every {
             mapboxNavigation.requestRoutes(any(), ofType(NavigationRouterCallback::class))
         } returns 1L
 
         sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchOptions(mockk()))
+        store.dispatch(RoutePreviewAction.FetchRoute)
 
-        verify { store.dispatch(RoutePreviewAction.StartedFetchRequest(1L)) }
+        assertActionDispatched(RoutePreviewAction.StartedFetchRequest(1L))
     }
 
     @Test
-    fun `RoutePreviewAction StartedFetchRequest should save requestId in the store`() {
-        val mapboxNavigation = mockMapboxNavigation()
+    @Suppress("MaxLineLength")
+    fun `fetchRouteSaga - should use MapboxNavigation to fetch routes and set Fetching state`() {
         sut.onAttached(mapboxNavigation)
-
-        store.dispatch(RoutePreviewAction.StartedFetchRequest(1L))
-
-        val requestId = (store.state.value.previewRoutes as RoutePreviewState.Fetching).requestId
-        assertEquals(1L, requestId)
-    }
-
-    @Test
-    fun `RoutePreviewAction Ready with an empty list should result in Empty state`() {
-        val mapboxNavigation = mockMapboxNavigation()
-        every { mapboxNavigation.registerRoutesObserver(any()) } answers {
-            firstArg<RoutesObserver>().onRoutesChanged(
-                mockk {
-                    every { navigationRoutes } returns emptyList()
-                }
-            )
-        }
-
-        sut.onAttached(mapboxNavigation)
-
-        assertTrue(store.state.value.previewRoutes is RoutePreviewState.Empty)
-    }
-
-    @Test
-    fun `RoutePreviewAction FetchOptions will request routes with the options`() {
-        val mapboxNavigation = mockMapboxNavigation()
-        val routeOptions = mockk<RouteOptions>()
-
-        sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchOptions(routeOptions))
+        store.dispatch(RoutePreviewAction.FetchRoute)
 
         assertTrue(store.state.value.previewRoutes is RoutePreviewState.Fetching)
-        verify { mapboxNavigation.requestRoutes(routeOptions, any<NavigationRouterCallback>()) }
+        verify { mapboxNavigation.requestRoutes(any(), any<NavigationRouterCallback>()) }
     }
 
     @Test
-    fun `RoutePreviewAction FetchOptions is canceled when onDetached is called`() {
-        val mapboxNavigation = mockMapboxNavigation()
-        every { mapboxNavigation.requestRoutes(any(), any<NavigationRouterCallback>()) } answers {
-            123L
-        }
-
-        sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchOptions(mockk()))
-        sut.onDetached(mapboxNavigation)
-
-        verify { mapboxNavigation.cancelRouteRequest(123L) }
-    }
-
-    @Test
-    fun `RoutePreviewAction FetchOptions will go to Ready state when onRoutesReady`() {
-        val mapboxNavigation = mockMapboxNavigation()
+    fun `fetchRouteSaga - after requestRoutes success should update to Ready`() {
         val routes = listOf<NavigationRoute>(mockk())
         val callbackSlot = slot<NavigationRouterCallback>()
         every { mapboxNavigation.requestRoutes(any(), capture(callbackSlot)) } returns 123L
-        val routeOptions = mockk<RouteOptions>()
 
         sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchOptions(routeOptions))
+        store.dispatch(RoutePreviewAction.FetchRoute)
         callbackSlot.captured.onRoutesReady(routes, mockk())
 
         val readyState = store.state.value.previewRoutes as? RoutePreviewState.Ready
@@ -167,15 +147,14 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutePreviewAction FetchOptions will go to Failed state when onFailure`() {
-        val mapboxNavigation = mockMapboxNavigation()
+    fun `fetchRouteSaga - will result in Failed state on fetch routes failure`() {
         val reasons = listOf<RouterFailure>(mockk())
         val routeOptions = mockk<RouteOptions>()
         val callbackSlot = slot<NavigationRouterCallback>()
         every { mapboxNavigation.requestRoutes(any(), capture(callbackSlot)) } returns 123L
 
         sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchOptions(routeOptions))
+        store.dispatch(RoutePreviewAction.FetchRoute)
         callbackSlot.captured.onFailure(reasons, routeOptions)
 
         val readyState = store.state.value.previewRoutes as? RoutePreviewState.Failed
@@ -185,15 +164,14 @@ internal class RoutePreviewStateControllerTest {
     }
 
     @Test
-    fun `RoutePreviewAction FetchOptions will go to Canceled state when onCanceled`() {
-        val mapboxNavigation = mockMapboxNavigation()
+    fun `fetchRouteSaga - will result in Canceled state on fetch request cancellation`() {
         val routeOptions = mockk<RouteOptions>()
         val routerOrigin = mockk<RouterOrigin>()
         val callbackSlot = slot<NavigationRouterCallback>()
         every { mapboxNavigation.requestRoutes(any(), capture(callbackSlot)) } returns 123L
 
         sut.onAttached(mapboxNavigation)
-        store.dispatch(RoutePreviewAction.FetchOptions(routeOptions))
+        store.dispatch(RoutePreviewAction.FetchRoute)
         callbackSlot.captured.onCanceled(routeOptions, routerOrigin)
 
         val readyState = store.state.value.previewRoutes as? RoutePreviewState.Canceled
@@ -202,9 +180,152 @@ internal class RoutePreviewStateControllerTest {
         assertEquals(readyState?.routerOrigin, routerOrigin)
     }
 
-    private fun mockMapboxNavigation(): MapboxNavigation {
-        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true)
+    @Test
+    fun `process - StartedFetchRequest action should save requestId in the store`() {
+        sut.onAttached(mapboxNavigation)
+
+        store.dispatch(RoutePreviewAction.StartedFetchRequest(1L))
+
+        val requestId = (store.state.value.previewRoutes as RoutePreviewState.Fetching).requestId
+        assertEquals(1L, requestId)
+    }
+
+    @Test
+    fun `onDetached should canceled fetch request`() {
+        every { mapboxNavigation.requestRoutes(any(), any<NavigationRouterCallback>()) } answers {
+            123L
+        }
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchRoute)
+        sut.onDetached(mapboxNavigation)
+
+        verify { mapboxNavigation.cancelRouteRequest(123L) }
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `fetchRouteAndMoveToNavigationStateSaga - on FetchRouteAndShowRoutePreview should dispatch FetchRoute and update NavigationState on RoutePreviewState_Ready`() {
+        val routes = listOf<NavigationRoute>(mockk())
+        val callbackSlot = slot<NavigationRouterCallback>()
+        every { mapboxNavigation.requestRoutes(any(), capture(callbackSlot)) } returns 123L
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchRouteAndShowRoutePreview)
+        callbackSlot.captured.onRoutesReady(routes, mockk())
+
+        assertTrue(store.state.value.previewRoutes is RoutePreviewState.Ready)
+        assertActionDispatched(RoutePreviewAction.FetchRoute)
+        assertActionDispatched(NavigationStateAction.Update(NavigationState.RoutePreview))
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `fetchRouteAndMoveToNavigationStateSaga - on FetchRouteAndShowRoutePreview should NOT dispatch FetchRoute when already in RoutePreviewState_Ready state`() {
+        val routes = listOf<NavigationRoute>(mockk())
+        store.updateState {
+            it.copy(previewRoutes = RoutePreviewState.Ready(routes))
+        }
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchRouteAndShowRoutePreview)
+
+        assertActionNotDispatched(RoutePreviewAction.FetchRoute)
+        assertActionDispatched(NavigationStateAction.Update(NavigationState.RoutePreview))
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `fetchRouteAndMoveToNavigationStateSaga - on FetchRouteAndShowRoutePreview should ABORT when in RoutePreviewState_Fetching state`() {
+        store.updateState {
+            it.copy(previewRoutes = RoutePreviewState.Fetching(123))
+        }
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchRouteAndShowRoutePreview)
+
+        assertActionNotDispatched(RoutePreviewAction.FetchRoute)
+        assertActionNotDispatched(NavigationStateAction.Update(NavigationState.RoutePreview))
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `fetchRouteAndMoveToNavigationStateSaga - on FetchRouteAndStartActiveNavigation should dispatch FetchRoute and update NavigationState on RoutePreviewState_Ready`() {
+        val routes = listOf<NavigationRoute>(mockk())
+        val callbackSlot = slot<NavigationRouterCallback>()
+        every { mapboxNavigation.requestRoutes(any(), capture(callbackSlot)) } returns 123L
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchRouteAndStartActiveNavigation)
+        callbackSlot.captured.onRoutesReady(routes, mockk())
+
+        assertTrue(store.state.value.previewRoutes is RoutePreviewState.Ready)
+        assertActionDispatched(RoutePreviewAction.FetchRoute)
+        assertActionDispatched(RoutesAction.SetRoutes(routes))
+        assertActionDispatched(NavigationStateAction.Update(NavigationState.ActiveNavigation))
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `fetchRouteAndMoveToNavigationStateSaga - on FetchRouteAndStartActiveNavigation should NOT dispatch FetchRoute when already in RoutePreviewState_Ready state`() {
+        val routes = listOf<NavigationRoute>(mockk())
+        store.updateState {
+            it.copy(previewRoutes = RoutePreviewState.Ready(routes))
+        }
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchRouteAndStartActiveNavigation)
+
+        assertActionNotDispatched(RoutePreviewAction.FetchRoute)
+        assertActionDispatched(RoutesAction.SetRoutes(routes))
+        assertActionDispatched(NavigationStateAction.Update(NavigationState.ActiveNavigation))
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `fetchRouteAndMoveToNavigationStateSaga - on FetchRouteAndStartActiveNavigation should ABORT when in RoutePreviewState_Fetching state`() {
+        store.updateState {
+            it.copy(previewRoutes = RoutePreviewState.Fetching(123))
+        }
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchRouteAndStartActiveNavigation)
+
+        assertActionNotDispatched(RoutePreviewAction.FetchRoute)
+        assertActionNotDispatched(NavigationStateAction.Update(NavigationState.ActiveNavigation))
+    }
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun `fetchRouteAndMoveToNavigationStateSaga - on should ABORT previous work when NavigationStateAction_Update is dispatched`() {
+        val routes = listOf<NavigationRoute>(mockk())
+        val callbackSlot = slot<NavigationRouterCallback>()
+        every { mapboxNavigation.requestRoutes(any(), capture(callbackSlot)) } returns 123L
+
+        sut.onAttached(mapboxNavigation)
+        store.dispatch(RoutePreviewAction.FetchRouteAndStartActiveNavigation)
+        assertActionDispatched(RoutePreviewAction.FetchRoute)
+
+        // simulate NavigationState update while fetch request is in-flight
+        store.dispatch(NavigationStateAction.Update(NavigationState.FreeDrive))
+        // finish route request
+        callbackSlot.captured.onRoutesReady(routes, mockk())
+        assertActionNotDispatched(NavigationStateAction.Update(NavigationState.ActiveNavigation))
+    }
+
+    private fun mockMapboxNavigation(context: Context): MapboxNavigation {
+        val mapboxNavigation = mockk<MapboxNavigation>(relaxed = true) {
+            every { navigationOptions } returns NavigationOptions.Builder(context)
+                .locationEngine(mockk())
+                .build()
+        }
         every { MapboxNavigationApp.current() } returns mapboxNavigation
         return mapboxNavigation
     }
+
+    private fun assertActionDispatched(action: Action) =
+        assertTrue("expected $action action to be dispatched", store.didDispatchAction(action))
+
+    private fun assertActionNotDispatched(action: Action) =
+        assertFalse("unexpected $action action was dispatched", store.didDispatchAction(action))
 }

--- a/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/testing/TestStore.kt
+++ b/libnavui-app/src/test/java/com/mapbox/navigation/ui/app/testing/TestStore.kt
@@ -1,9 +1,22 @@
 package com.mapbox.navigation.ui.app.testing
 
+import com.mapbox.navigation.ui.app.internal.Action
+import com.mapbox.navigation.ui.app.internal.Middleware
 import com.mapbox.navigation.ui.app.internal.State
 import com.mapbox.navigation.ui.app.internal.Store
 
 internal class TestStore : Store() {
+
+    val actions = mutableListOf<Action>()
+
+    init {
+        registerMiddleware(object : Middleware {
+            override fun onDispatch(state: State, action: Action): Boolean {
+                actions.add(action)
+                return false
+            }
+        })
+    }
 
     fun setState(state: State) {
         _state.value = state
@@ -12,4 +25,6 @@ internal class TestStore : Store() {
     fun updateState(update: (State) -> State) {
         setState(update(_state.value))
     }
+
+    fun <T : Action> didDispatchAction(action: T) = actions.contains(action)
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/extendablebutton/RoutePreviewButtonComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/extendablebutton/RoutePreviewButtonComponent.kt
@@ -3,15 +3,12 @@ package com.mapbox.navigation.dropin.extendablebutton
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.internal.extensions.onClick
 import com.mapbox.navigation.ui.app.internal.Store
-import com.mapbox.navigation.ui.app.internal.extension.dispatch
-import com.mapbox.navigation.ui.app.internal.fetchRouteAndShowRoutePreview
-import com.mapbox.navigation.ui.app.internal.routefetch.RouteOptionsProvider
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction.FetchRouteAndShowRoutePreview
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import com.mapbox.navigation.ui.base.view.MapboxExtendableButton
 
 internal class RoutePreviewButtonComponent(
     private val store: Store,
-    private val routeOptionsProvider: RouteOptionsProvider,
     private val button: MapboxExtendableButton
 ) : UIComponent() {
 
@@ -19,9 +16,7 @@ internal class RoutePreviewButtonComponent(
         super.onAttached(mapboxNavigation)
 
         button.onClick(coroutineScope) {
-            store.dispatch(
-                fetchRouteAndShowRoutePreview(routeOptionsProvider, mapboxNavigation),
-            )
+            store.dispatch(FetchRouteAndShowRoutePreview)
         }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/extendablebutton/StartNavigationButtonComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/extendablebutton/StartNavigationButtonComponent.kt
@@ -3,15 +3,12 @@ package com.mapbox.navigation.dropin.extendablebutton
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.internal.extensions.onClick
 import com.mapbox.navigation.ui.app.internal.Store
-import com.mapbox.navigation.ui.app.internal.extension.dispatch
-import com.mapbox.navigation.ui.app.internal.fetchRouteAndStartActiveNavigation
-import com.mapbox.navigation.ui.app.internal.routefetch.RouteOptionsProvider
+import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction.FetchRouteAndStartActiveNavigation
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import com.mapbox.navigation.ui.base.view.MapboxExtendableButton
 
 internal class StartNavigationButtonComponent(
     private val store: Store,
-    private val routeOptionsProvider: RouteOptionsProvider,
     private val button: MapboxExtendableButton
 ) : UIComponent() {
 
@@ -19,9 +16,7 @@ internal class StartNavigationButtonComponent(
         super.onAttached(mapboxNavigation)
 
         button.onClick(coroutineScope) {
-            store.dispatch(
-                fetchRouteAndStartActiveNavigation(routeOptionsProvider, mapboxNavigation)
-            )
+            store.dispatch(FetchRouteAndStartActiveNavigation)
         }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelRoutePreviewButtonBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelRoutePreviewButtonBinder.kt
@@ -23,7 +23,7 @@ internal class InfoPanelRoutePreviewButtonBinder(
                 right = button.resources.getDimensionPixelSize(R.dimen.mapbox_infoPanel_paddingEnd)
             )
 
-            RoutePreviewButtonComponent(context.store, context.routeOptionsProvider, button)
+            RoutePreviewButtonComponent(context.store, button)
         }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelStartNavigationButtonBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/infopanel/InfoPanelStartNavigationButtonBinder.kt
@@ -23,7 +23,7 @@ internal class InfoPanelStartNavigationButtonBinder(
                 right = button.resources.getDimensionPixelSize(R.dimen.mapbox_infoPanel_paddingEnd)
             )
 
-            StartNavigationButtonComponent(context.store, context.routeOptionsProvider, button)
+            StartNavigationButtonComponent(context.store, button)
         }
     }
 }

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewContext.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/navigationview/NavigationViewContext.kt
@@ -18,7 +18,6 @@ import com.mapbox.navigation.dropin.util.BitmapMemoryCache
 import com.mapbox.navigation.dropin.util.BitmapMemoryCache.Companion.MB_IN_BYTES
 import com.mapbox.navigation.ui.app.internal.SharedApp
 import com.mapbox.navigation.ui.app.internal.Store
-import com.mapbox.navigation.ui.app.internal.routefetch.RouteOptionsProvider
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 import com.mapbox.navigation.ui.utils.internal.Provider
 import com.mapbox.navigation.ui.utils.internal.getValue
@@ -36,7 +35,7 @@ internal class NavigationViewContext(
     val context: Context,
     val lifecycleOwner: LifecycleOwner,
     val viewModel: NavigationViewModel,
-    storeProvider: Provider<Store> = Provider { SharedApp.store }
+    storeProvider: Provider<Store> = Provider { SharedApp.store },
 ) {
     val store by storeProvider
 
@@ -60,7 +59,7 @@ internal class NavigationViewContext(
         )
     }
     val locationProvider = NavigationLocationProvider()
-    val routeOptionsProvider = RouteOptionsProvider()
+    val routeOptionsProvider = SharedApp.routeOptionsProvider
 
     fun mapAnnotationFactory() = MapMarkerFactory(
         context,

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/extendablebutton/RoutePreviewButtonComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/extendablebutton/RoutePreviewButtonComponentTest.kt
@@ -2,20 +2,11 @@ package com.mapbox.navigation.dropin.extendablebutton
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import com.mapbox.api.directions.v5.models.RouteOptions
-import com.mapbox.geojson.Point
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.util.TestStore
-import com.mapbox.navigation.dropin.util.TestingUtil
 import com.mapbox.navigation.testing.MainCoroutineRule
-import com.mapbox.navigation.ui.app.internal.State
-import com.mapbox.navigation.ui.app.internal.destination.Destination
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
-import com.mapbox.navigation.ui.app.internal.routefetch.RouteOptionsProvider
 import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewAction
-import com.mapbox.navigation.ui.app.internal.routefetch.RoutePreviewState
 import com.mapbox.navigation.ui.base.view.MapboxExtendableButton
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
@@ -36,7 +27,6 @@ class RoutePreviewButtonComponentTest {
 
     private lateinit var store: TestStore
     private lateinit var mapboxNavigation: MapboxNavigation
-    private lateinit var routeOptionsProvider: RouteOptionsProvider
     private lateinit var button: MapboxExtendableButton
     private lateinit var sut: RoutePreviewButtonComponent
 
@@ -45,66 +35,19 @@ class RoutePreviewButtonComponentTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         store = spyk(TestStore())
         mapboxNavigation = mockk(relaxed = true)
-        routeOptionsProvider = mockk()
         button = spyk(MapboxExtendableButton(context))
 
-        sut = RoutePreviewButtonComponent(store, routeOptionsProvider, button)
+        sut = RoutePreviewButtonComponent(store, button)
     }
 
     @Test
-    fun `onClick routePreview should FetchOptions`() = runBlockingTest {
-        val origPoint = Point.fromLngLat(1.0, 2.0)
-        val destPoint = Point.fromLngLat(2.0, 3.0)
-        val options = mockk<RouteOptions>()
-        every {
-            routeOptionsProvider.getOptions(mapboxNavigation, origPoint, destPoint)
-        } returns options
-        store.setState(
-            State(
-                location = TestingUtil.makeLocationMatcherResult(
-                    origPoint.longitude(),
-                    origPoint.latitude(),
-                    0f
-                ),
-                destination = Destination(destPoint),
-                navigation = NavigationState.DestinationPreview,
-                previewRoutes = RoutePreviewState.Empty
-            )
-        )
-
+    @Suppress("MaxLineLength")
+    fun `onClick routePreview should dispatch FetchRouteAndShowRoutePreview action`() = runBlockingTest {
         sut.onAttached(mapboxNavigation)
         button.performClick()
 
         verify(exactly = 1) {
-            store.dispatch(RoutePreviewAction.FetchOptions(options))
+            store.dispatch(RoutePreviewAction.FetchRouteAndShowRoutePreview)
         }
     }
-
-    @Test
-    fun `onClick routePreview should NOT FetchOptions when already in Ready state`() =
-        runBlockingTest {
-            val origPoint = Point.fromLngLat(1.0, 2.0)
-            val destPoint = Point.fromLngLat(2.0, 3.0)
-            store.setState(
-                State(
-                    location = TestingUtil.makeLocationMatcherResult(
-                        origPoint.longitude(),
-                        origPoint.latitude(),
-                        0f
-                    ),
-                    destination = Destination(destPoint),
-                    navigation = NavigationState.DestinationPreview,
-                    previewRoutes = mockk<RoutePreviewState.Ready> {
-                        every { routes } returns mockk()
-                    }
-                )
-            )
-
-            sut.onAttached(mockk())
-            button.performClick()
-
-            verify(exactly = 0) {
-                store.dispatch(ofType<RoutePreviewAction.FetchOptions>())
-            }
-        }
 }


### PR DESCRIPTION
Cherry pick of #6638 - [Drop-In UI] Move `fetchRouteIfNeeded` to `RoutePreviewStateController`