### PR TITLE
Remove stopTripSession from ReplayRouteSession

### DIFF
--- a/changelog/unreleased/bugfixes/6817.md
+++ b/changelog/unreleased/bugfixes/6817.md
@@ -1,0 +1,1 @@
+- Improved `MapboxNavigation#startReplayTripSession` and `ReplayRouteSession` so that the previous trip session does not need to be stopped. :warning: `ReplayRouteSession#onDetached` removed the call to `stopTripSession`.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/replay/route/ReplayRouteSession.kt
@@ -106,7 +106,6 @@ class ReplayRouteSession : MapboxNavigationObserver {
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         this.replayRouteMapper = ReplayRouteMapper(options.replayRouteOptions)
         this.mapboxNavigation = mapboxNavigation
-        mapboxNavigation.stopTripSession()
         mapboxNavigation.startReplayTripSession()
         mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
         mapboxNavigation.registerRoutesObserver(routesObserver)
@@ -139,7 +138,6 @@ class ReplayRouteSession : MapboxNavigationObserver {
         mapboxNavigation.mapboxReplayer.unregisterObserver(replayEventsObserver)
         mapboxNavigation.mapboxReplayer.stop()
         mapboxNavigation.mapboxReplayer.clearEvents()
-        mapboxNavigation.stopTripSession()
         this.mapboxNavigation = null
         this.currentRoute = null
     }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteSessionTest.kt
@@ -85,17 +85,6 @@ class ReplayRouteSessionTest {
     }
 
     @Test
-    fun `onAttached - should stop trip session and start replay session`() {
-        sut.onAttached(mapboxNavigation)
-
-        verifyOrder {
-            mapboxNavigation.stopTripSession()
-            mapboxNavigation.startReplayTripSession()
-            replayer.play()
-        }
-    }
-
-    @Test
     fun `onAttached - should reset trip session and replayer when navigation routes are cleared`() {
         val routesObserver = slot<RoutesObserver>()
         every { mapboxNavigation.registerRoutesObserver(capture(routesObserver)) } returns Unit
@@ -139,13 +128,13 @@ class ReplayRouteSessionTest {
     }
 
     @Test
-    fun `onDetached - should stop trip session and replayer`() {
+    fun `onDetached - should stop and clear the replayer`() {
         sut.onDetached(mapboxNavigation)
 
         verifyOrder {
+            replayer.unregisterObserver(any())
             replayer.stop()
             replayer.clearEvents()
-            mapboxNavigation.stopTripSession()
         }
     }
 
@@ -251,7 +240,6 @@ class ReplayRouteSessionTest {
         )
 
         verifyOrder {
-            mapboxNavigation.stopTripSession()
             mapboxNavigation.startReplayTripSession()
             replayer.play()
             replayer.pushEvents(any())

--- a/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/TripSessionStarterStateController.kt
+++ b/libnavui-app/src/main/java/com/mapbox/navigation/ui/app/internal/controller/TripSessionStarterStateController.kt
@@ -1,7 +1,6 @@
 package com.mapbox.navigation.ui.app.internal.controller
 
 import android.annotation.SuppressLint
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.ui.app.internal.Action
 import com.mapbox.navigation.ui.app.internal.State
 import com.mapbox.navigation.ui.app.internal.Store
@@ -12,7 +11,6 @@ import com.mapbox.navigation.ui.app.internal.tripsession.TripSessionStarterState
  * The class is responsible to start and stop the `TripSession` for NavigationView.
  * @param store defines the current screen state
  */
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 @SuppressLint("MissingPermission")
 class TripSessionStarterStateController(store: Store) : StateController() {
     init {

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/tripsession/TripSessionComponent.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/tripsession/TripSessionComponent.kt
@@ -79,19 +79,13 @@ internal class TripSessionComponent(
     private fun startTripSession(mapboxNavigation: MapboxNavigation) {
         replayRouteTripSession?.onDetached(mapboxNavigation)
         replayRouteTripSession = null
-        mapboxNavigation.ensureTripSessionStarted()
+        mapboxNavigation.startTripSession()
     }
 
     private fun startReplayTripSession(mapboxNavigation: MapboxNavigation) {
         replayRouteTripSession?.onDetached(mapboxNavigation)
         replayRouteTripSession = ReplayRouteSession()
         replayRouteTripSession?.onAttached(mapboxNavigation)
-    }
-
-    private fun MapboxNavigation.ensureTripSessionStarted() {
-        if (getTripSessionState() != TripSessionState.STARTED) {
-            startTripSession()
-        }
     }
 
     private fun MapboxNavigation.ensureTripSessionStopped() {

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/tripsession/TripSessionComponentTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/tripsession/TripSessionComponentTest.kt
@@ -114,7 +114,7 @@ class TripSessionComponentTest {
         }
 
     @Test
-    fun `EnableTripSession will restart a trip session when replay is enabled`() =
+    fun `EnableTripSession will not stopTripSession`() =
         runBlockingTest {
             testStore.setState(
                 State(
@@ -139,9 +139,9 @@ class TripSessionComponentTest {
 
             verifyOrder {
                 mapboxNavigation.startReplayTripSession()
-                mapboxNavigation.stopTripSession()
                 mapboxNavigation.startTripSession()
             }
+            verify(exactly = 0) { mapboxNavigation.stopTripSession() }
         }
 
     @Test

--- a/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
+++ b/qa-test-app/src/main/java/com/mapbox/navigation/qa_test_app/QaTestApplication.kt
@@ -1,5 +1,12 @@
 package com.mapbox.navigation.qa_test_app
 
 import android.app.Application
+import com.mapbox.common.LogConfiguration
+import com.mapbox.common.LoggingLevel
 
-class QaTestApplication : Application()
+class QaTestApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        LogConfiguration.setLoggingLevel(LoggingLevel.DEBUG)
+    }
+}


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Resolves https://mapbox.atlassian.net/browse/NAVAND-320
Resolves https://github.com/mapbox/mapbox-navigation-android/issues/6056

There is an internal requirement to first call `stopTripSession` before you can call `startReplayTripSession`. This pull request is fixing that. This will make it so the caller can convert a regular trip session into a replay session.

I'm finding that this issue needs to be resolved before resolving this issue https://github.com/mapbox/mapbox-navigation-android/pull/6794. Anything that observes the trip session state receives rapid changes when enabling replay. 
