### PR TITLE
Fix Copilot `unrecognized` fields serialization

### DIFF
--- a/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilotImpl.kt
+++ b/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/MapboxCopilotImpl.kt
@@ -4,8 +4,11 @@ import android.content.pm.ApplicationInfo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
-import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.mapbox.api.directions.v5.DirectionsAdapterFactory
 import com.mapbox.common.UploadOptions
+import com.mapbox.geojson.Point
+import com.mapbox.geojson.PointAsCoordinatesTypeAdapter
 import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.copilot.HistoryAttachmentsUtils.copyToAndRemove
@@ -397,7 +400,10 @@ internal class MapboxCopilotImpl(
 
     internal companion object {
 
-        internal val gson = Gson()
+        internal val gson = GsonBuilder()
+            .registerTypeAdapterFactory(DirectionsAdapterFactory.create())
+            .registerTypeAdapter(Point::class.java, PointAsCoordinatesTypeAdapter())
+            .create()
         internal const val GZ = "gz"
         internal const val ZIP = "zip"
         internal const val MEDIA_TYPE_ZIP = "application/zip"


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
While testing we found that `DirectionsResponse` fields from Copilot History files were not properly serialized:
- field names were incorrect (camelCase vs snake_case)
- `unrecognized` fields not serialized (also obfuscated if Proguard was enabled)

E.g. 👀 

```json
"incidents": [
                {
                  "affectedRoadNames": [
                    "A-3/E 901/Autovía del Este",
                    "A-3/E 901"
                  ],
                  "alertcCodes": [
                    703
                  ],
                  "congestion": {
                    "value": 101
                  },
                  "countryCodeAlpha2": "ES",
                  "countryCodeAlpha3": "ESP",
                  "creationTime": "2023-01-12T13:40:30Z",
                  "description": "A-3: obras de mantenimiento entre 68 M-328 y 111 CUV-3131",
                  "endTime": "2023-01-12T19:40:00Z",
                  "geometryIndexEnd": 273,
                  "geometryIndexStart": 76,
                  "id": "8907455158012201",
                  "impact": "low",
                  "lanesBlocked": [],
                  "longDescription": "Obras de mantenimiento en la ambos sentidos A-3 entre 68 M-328 y 111 CUV-3131.",
                  "startTime": "2023-01-11T22:40:00Z",
                  "type": "construction",
                  "unrecognized": {
                    "length": {
                      "a": 39194
                    },
                    "south": {
                      "a": 39.904338
                    },
                    "west": {
                      "a": -3.086498
                    },
                    "north": {
                      "a": 40.068935
                    },
                    "east": {
                      "a": -2.717774
                    }
                  }
                }
]
```

This PR fixes it 👀 

```json
"incidents": [
                {
                  "length": 39194,
                  "south": 39.904338,
                  "west": -3.086498,
                  "north": 40.068935,
                  "east": -2.717774,
                  "id": "8907455158012201",
                  "type": "construction",
                  "congestion": {
                    "value": 101
                  },
                  "description": "A-3: obras de mantenimiento entre 68 M-328 y 111 CUV-3131",
                  "long_description": "Obras de mantenimiento en la ambos sentidos A-3 entre 68 M-328 y 111 CUV-3131.",
                  "impact": "low",
                  "alertc_codes": [
                    703
                  ],
                  "geometry_index_start": 914,
                  "geometry_index_end": 972,
                  "creation_time": "2023-01-12T14:25:31Z",
                  "start_time": "2023-01-11T22:40:00Z",
                  "end_time": "2023-01-12T19:40:00Z",
                  "iso_3166_1_alpha2": "ES",
                  "iso_3166_1_alpha3": "ESP",
                  "lanes_blocked": [],
                  "affected_road_names": [
                    "A-3/E 901/Autovía del Este",
                    "A-3/E 901"
                  ]
                }
]
```