### PR TITLE
Backport #6834 to `release-v2.10`

### DIFF
--- a/changelog/unreleased/bugfixes/6834.md
+++ b/changelog/unreleased/bugfixes/6834.md
@@ -1,0 +1,1 @@
+- Ensure map-matching considers HOV-only roads as auto accessible.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,7 +13,7 @@ ext {
   // version which we should use in this build
   def mapboxNavigatorVersion = System.getenv("FORCE_MAPBOX_NAVIGATION_NATIVE_VERSION")
   if (mapboxNavigatorVersion == null || mapboxNavigatorVersion == '') {
-      mapboxNavigatorVersion = '123.1.0'
+      mapboxNavigatorVersion = '123.2.0'
   }
   println("Navigation Native version: " + mapboxNavigatorVersion)
 


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
- Backports #6834 to `release-v2.10`