### PR TITLE
ignore ime insets in navigation view

### DIFF
--- a/changelog/unreleased/bugfixes/6845.md
+++ b/changelog/unreleased/bugfixes/6845.md
@@ -1,0 +1,1 @@
+- Improved `NavigationView` camera behavior to ignore keyboard insets.

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/NavigationView.kt
@@ -134,7 +134,7 @@ class NavigationView @JvmOverloads constructor(
                 backPressedComponent(activity),
                 scalebarPlaceholderCoordinator(binding.scalebarLayout),
                 maneuverCoordinator(binding.guidanceLayout),
-                infoPanelCoordinator(binding.infoPanelLayout, binding.guidelineBottom),
+                infoPanelCoordinator(binding),
                 actionButtonsCoordinator(binding.actionListLayout),
                 speedLimitCoordinator(binding.speedLimitLayout),
                 roadNameCoordinator(binding.roadNameLayout),

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/camera/CameraLayoutObserver.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/camera/CameraLayoutObserver.kt
@@ -2,17 +2,17 @@ package com.mapbox.navigation.dropin.camera
 
 import android.content.res.Configuration
 import android.view.View
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxNavigationViewLayoutBinding
-import com.mapbox.navigation.ui.app.internal.Store
+import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
 import com.mapbox.navigation.ui.app.internal.camera.CameraAction
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 
 internal class CameraLayoutObserver(
-    private val store: Store,
+    private val context: NavigationViewContext,
     private val mapView: View,
     private val binding: MapboxNavigationViewLayoutBinding,
 ) : UIComponent() {
@@ -21,22 +21,15 @@ internal class CameraLayoutObserver(
         .getDimensionPixelSize(R.dimen.mapbox_camera_overview_padding_v).toDouble()
     private val hPadding = binding.root.resources
         .getDimensionPixelSize(R.dimen.mapbox_camera_overview_padding_h).toDouble()
-    private val vPaddingLandscape = binding.root.resources
-        .getDimensionPixelSize(R.dimen.mapbox_camera_overview_padding_landscape_v).toDouble()
-    private val hPaddingLandscape = binding.root.resources
-        .getDimensionPixelSize(R.dimen.mapbox_camera_overview_padding_landscape_h).toDouble()
 
     private val layoutListener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-        val edgeInsets = when (deviceOrientation()) {
-            Configuration.ORIENTATION_LANDSCAPE -> getLandscapePadding()
-            else -> getPortraitPadding()
-        }
-        store.dispatch(CameraAction.UpdatePadding(edgeInsets))
+        updateCameraPadding()
     }
 
     override fun onAttached(mapboxNavigation: MapboxNavigation) {
         super.onAttached(mapboxNavigation)
         binding.coordinatorLayout.addOnLayoutChangeListener(layoutListener)
+        context.behavior.infoPanelBehavior.bottomSheetState.observe { updateCameraPadding() }
     }
 
     override fun onDetached(mapboxNavigation: MapboxNavigation) {
@@ -44,40 +37,27 @@ internal class CameraLayoutObserver(
         binding.coordinatorLayout.removeOnLayoutChangeListener(layoutListener)
     }
 
-    private fun getPortraitPadding(): EdgeInsets {
-        val top = binding.guidanceLayout.height.toDouble()
-        val bottom = mapView.height.toDouble() - binding.roadNameLayout.top.toDouble()
-        return when (store.state.value.navigation) {
-            is NavigationState.DestinationPreview,
-            is NavigationState.FreeDrive,
-            is NavigationState.RoutePreview -> {
-                EdgeInsets(vPadding, hPadding, bottom, hPadding)
-            }
-            is NavigationState.ActiveNavigation,
-            is NavigationState.Arrival -> {
-                EdgeInsets(vPadding + top, hPadding, bottom, hPadding)
-            }
+    private fun updateCameraPadding() {
+        val edgeInsets = when (deviceOrientation()) {
+            Configuration.ORIENTATION_LANDSCAPE -> getLandscapePadding()
+            else -> getPortraitPadding()
         }
+        context.store.dispatch(CameraAction.UpdatePadding(edgeInsets))
+    }
+
+    private fun getPortraitPadding(): EdgeInsets {
+        val top = binding.guidanceLayout.bottom
+        val bottom = mapView.height - binding.roadNameLayout.top
+        return EdgeInsets(vPadding + top, hPadding, vPadding + bottom, hPadding)
     }
 
     private fun getLandscapePadding(): EdgeInsets {
-        val bottom = mapView.height.toDouble() - binding.roadNameLayout.top.toDouble()
-        return when (store.state.value.navigation) {
-            is NavigationState.FreeDrive -> {
-                EdgeInsets(vPaddingLandscape, hPaddingLandscape, bottom, hPaddingLandscape)
-            }
-            is NavigationState.DestinationPreview,
-            is NavigationState.RoutePreview,
-            is NavigationState.ActiveNavigation,
-            is NavigationState.Arrival -> {
-                EdgeInsets(
-                    vPaddingLandscape,
-                    hPaddingLandscape + binding.infoPanelLayout.right.toDouble(),
-                    bottom,
-                    hPaddingLandscape
-                )
-            }
-        }
+        val bottomSheetState = context.behavior.infoPanelBehavior.bottomSheetState.value
+        val isBottomSheetVisible =
+            bottomSheetState != null && bottomSheetState != BottomSheetBehavior.STATE_HIDDEN
+        val bottomSheetWidth = if (isBottomSheetVisible) binding.infoPanelLayout.right else 0
+        val bottom = mapView.height - binding.roadNameLayout.top
+        return EdgeInsets(vPadding, hPadding + bottomSheetWidth, vPadding + bottom, hPadding)
     }
 
     private fun deviceOrientation() = binding.root.resources.configuration.orientation

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/extensions/NavigationViewContextEx.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/internal/extensions/NavigationViewContextEx.kt
@@ -5,7 +5,6 @@ package com.mapbox.navigation.dropin.internal.extensions
 import android.view.ViewGroup
 import androidx.activity.ComponentActivity
 import androidx.annotation.Px
-import androidx.constraintlayout.widget.Guideline
 import com.mapbox.maps.MapView
 import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.core.MapboxNavigation
@@ -269,9 +268,8 @@ internal fun NavigationViewContext.maneuverCoordinator(guidanceLayout: ViewGroup
     ManeuverCoordinator(this, guidanceLayout)
 
 internal fun NavigationViewContext.infoPanelCoordinator(
-    infoPanelLayout: ViewGroup,
-    guidelineBottom: Guideline
-) = InfoPanelCoordinator(this, infoPanelLayout, guidelineBottom)
+    binding: MapboxNavigationViewLayoutBinding,
+) = InfoPanelCoordinator(this, binding)
 
 internal fun NavigationViewContext.actionButtonsCoordinator(actionListLayout: ViewGroup) =
     ActionButtonsCoordinator(this, actionListLayout)

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/map/MapViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/map/MapViewBinder.kt
@@ -67,7 +67,7 @@ abstract class MapViewBinder : UIBinder {
         val store = context.store
         val navigationState = store.select { it.navigation }
         return navigationListOf(
-            CameraLayoutObserver(store, mapView, navigationViewBinding),
+            CameraLayoutObserver(context, mapView, navigationViewBinding),
             LocationComponent(context.locationProvider),
             context.locationPuckComponent(mapView),
             LogoAttributionComponent(mapView, context.systemBarsInsets),

--- a/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout-land/mapbox_navigation_view_layout.xml
@@ -13,131 +13,121 @@
         tools:background="#00ccff" />
 
     <!--
-        Using outer CoordinatorLayout to adjust inner CoordinatorLayout layout based on system
-        windows such as the status bar and the navigation bar.
         CoordinatorLayout allows customization of navigation bar color using android:statusBarColor
         theme attribute, while FrameLayout doesn't.
     -->
     <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinatorLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.coordinatorlayout.widget.CoordinatorLayout
-            android:id="@+id/coordinatorLayout"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fitsSystemWindows="true">
+            android:layout_height="match_parent">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/container"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guidelineBottom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:layout_constraintGuide_end="0dp"
+                tools:layout_constraintGuide_end="100dp" />
 
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guidelineBottom"
-                    android:orientation="horizontal"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintGuide_end="0dp"
-                    tools:layout_constraintGuide_end="100dp" />
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guidelineBegin"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="375dp"
+                tools:layout_constraintGuide_begin="375dp" />
 
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guidelineBegin"
-                    android:orientation="vertical"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintGuide_begin="375dp"
-                    tools:layout_constraintGuide_begin="375dp" />
+            <FrameLayout
+                android:id="@+id/guidanceLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:background="@color/mapbox_main_maneuver_background_color"
+                tools:layout_height="120dp" />
 
-                <FrameLayout
-                    android:id="@+id/guidanceLayout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    tools:layout_height="120dp"
-                    tools:background="@color/mapbox_main_maneuver_background_color" />
+            <FrameLayout
+                android:id="@+id/scalebarLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="@id/guidanceLayout"
+                app:layout_constraintTop_toTopOf="parent" />
 
-                <FrameLayout
-                    android:id="@+id/scalebarLayout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="@id/guidanceLayout"
-                    />
+            <FrameLayout
+                android:id="@+id/speedLimitLayout"
+                android:layout_width="75dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start|top"
+                android:layout_marginStart="4dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintStart_toEndOf="@id/guidanceLayout"
+                app:layout_constraintTop_toBottomOf="@id/scalebarLayout"
+                tools:background="#eee"
+                tools:layout_height="60dp"
+                tools:layout_width="50dp" />
 
-                <FrameLayout
-                    android:id="@+id/speedLimitLayout"
-                    android:layout_width="75dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="4dp"
-                    android:layout_marginTop="8dp"
-                    app:layout_constraintStart_toEndOf="@id/guidanceLayout"
-                    app:layout_constraintTop_toBottomOf="@id/scalebarLayout"
-                    tools:background="#eee"
-                    tools:layout_height="60dp"
-                    tools:layout_width="50dp"
-                    android:layout_gravity="start|top" />
+            <FrameLayout
+                android:id="@+id/emptyLeftContainer"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_gravity="start|top"
+                android:layout_marginStart="4dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintBottom_toTopOf="@id/guidelineBottom"
+                app:layout_constraintEnd_toStartOf="@id/guidelineBegin"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
+                tools:background="#F6A1A1" />
 
-                <FrameLayout
-                    android:id="@+id/emptyLeftContainer"
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_marginStart="4dp"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="8dp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
-                    app:layout_constraintBottom_toTopOf="@id/guidelineBottom"
-                    app:layout_constraintEnd_toStartOf="@id/guidelineBegin"
-                    tools:background="#F6A1A1"
-                    android:layout_gravity="start|top" />
+            <FrameLayout
+                android:id="@+id/emptyRightContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start|top"
+                android:layout_marginStart="4dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="4dp"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/actionListLayout"
+                tools:background="#F6A1A1"
+                tools:layout_height="130dp"
+                tools:layout_width="76dp" />
 
-                <FrameLayout
-                    android:id="@+id/emptyRightContainer"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="4dp"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="8dp"
-                    android:layout_marginStart="4dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/actionListLayout"
-                    app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
-                    tools:background="#F6A1A1"
-                    tools:layout_height="130dp"
-                    tools:layout_width="76dp"
-                    android:layout_gravity="start|top" />
+            <FrameLayout
+                android:id="@+id/actionListLayout"
+                android:layout_width="@dimen/mapbox_actionList_width"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="8dp"
+                android:gravity="top|right"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:background="#eee"
+                tools:layout_height="200dp" />
 
-                <FrameLayout
-                    android:id="@+id/actionListLayout"
-                    android:layout_width="@dimen/mapbox_actionList_width"
-                    android:layout_height="wrap_content"
-                    android:gravity="top|right"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginTop="5dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    tools:layout_height="200dp"
-                    tools:background="#eee" />
+            <FrameLayout
+                android:id="@+id/roadNameLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_gravity="center"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHeight_max="62dp"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:background="#eee"
+                tools:layout_height="52dp"
+                tools:layout_width="140dp" />
 
-                <FrameLayout
-                    android:id="@+id/roadNameLayout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    tools:background="#eee"
-                    tools:layout_height="52dp"
-                    tools:layout_width="140dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    android:layout_marginBottom="8dp"
-                    app:layout_constraintHeight_max="62dp" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-        </androidx.coordinatorlayout.widget.CoordinatorLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <FrameLayout
             android:id="@+id/infoPanelLayout"

--- a/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
+++ b/libnavui-dropin/src/main/res/layout/mapbox_navigation_view_layout.xml
@@ -13,124 +13,114 @@
         tools:background="#00ccff" />
 
     <!--
-        Using outer CoordinatorLayout to adjust inner CoordinatorLayout layout based on system
-        windows such as the status bar and the navigation bar.
         CoordinatorLayout allows customization of navigation bar color using android:statusBarColor
         theme attribute, while FrameLayout doesn't.
     -->
     <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinatorLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.coordinatorlayout.widget.CoordinatorLayout
-            android:id="@+id/coordinatorLayout"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fitsSystemWindows="true">
+            android:layout_height="match_parent">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/container"
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guidelineBottom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:layout_constraintGuide_end="0dp"
+                tools:layout_constraintGuide_end="100dp" />
+
+            <FrameLayout
+                android:id="@+id/guidanceLayout"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHeight_max="350dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:background="@color/mapbox_main_maneuver_background_color"
+                tools:layout_height="120dp" />
 
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guidelineBottom"
-                    android:orientation="horizontal"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintGuide_end="0dp"
-                    tools:layout_constraintGuide_end="100dp" />
+            <FrameLayout
+                android:id="@+id/scalebarLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/guidanceLayout" />
 
-                <FrameLayout
-                    android:id="@+id/guidanceLayout"
-                    android:layout_width="match_parent"
-                    android:layout_height="0dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    tools:layout_height="120dp"
-                    app:layout_constraintHeight_max="350dp"
-                    tools:background="@color/mapbox_main_maneuver_background_color" />
+            <FrameLayout
+                android:id="@+id/speedLimitLayout"
+                android:layout_width="75dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start|top"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/scalebarLayout"
+                tools:background="#eee"
+                tools:layout_height="60dp"
+                tools:layout_width="50dp" />
 
-                <FrameLayout
-                    android:id="@+id/scalebarLayout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
-                    app:layout_constraintStart_toStartOf="parent"
-                    />
+            <FrameLayout
+                android:id="@+id/emptyLeftContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start|top"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
+                tools:background="#F6A1A1"
+                tools:layout_height="350dp"
+                tools:layout_width="50dp" />
 
-                <FrameLayout
-                    android:id="@+id/speedLimitLayout"
-                    android:layout_width="75dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:layout_marginTop="8dp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/scalebarLayout"
-                    tools:background="#eee"
-                    tools:layout_height="60dp"
-                    tools:layout_width="50dp"
-                    android:layout_gravity="start|top" />
+            <FrameLayout
+                android:id="@+id/emptyRightContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start|top"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginBottom="8dp"
+                app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/actionListLayout"
+                tools:background="#F6A1A1"
+                tools:layout_height="220dp"
+                tools:layout_width="76dp" />
 
-                <FrameLayout
-                    android:id="@+id/emptyLeftContainer"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:layout_marginTop="8dp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/speedLimitLayout"
-                    app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
-                    tools:background="#F6A1A1"
-                    tools:layout_height="350dp"
-                    tools:layout_width="50dp"
-                    android:layout_gravity="start|top" />
+            <FrameLayout
+                android:id="@+id/actionListLayout"
+                android:layout_width="@dimen/mapbox_actionList_width"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:layout_marginEnd="8dp"
+                android:gravity="top|right"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
+                tools:background="#eee"
+                tools:layout_height="200dp" />
 
-                <FrameLayout
-                    android:id="@+id/emptyRightContainer"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="8dp"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="8dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/actionListLayout"
-                    app:layout_constraintBottom_toTopOf="@id/roadNameLayout"
-                    tools:background="#F6A1A1"
-                    tools:layout_height="220dp"
-                    tools:layout_width="76dp"
-                    android:layout_gravity="start|top" />
+            <FrameLayout
+                android:id="@+id/roadNameLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_gravity="center"
+                android:layout_marginBottom="15dp"
+                app:layout_constraintBottom_toTopOf="@+id/guidelineBottom"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHeight_max="62dp"
+                app:layout_constraintStart_toStartOf="parent"
+                tools:background="#eee"
+                tools:layout_height="52dp"
+                tools:layout_width="140dp" />
 
-                <FrameLayout
-                    android:id="@+id/actionListLayout"
-                    android:layout_width="@dimen/mapbox_actionList_width"
-                    android:layout_height="wrap_content"
-                    android:gravity="top|right"
-                    android:layout_marginTop="5dp"
-                    android:layout_marginEnd="8dp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/guidanceLayout"
-                    tools:background="#eee"
-                    tools:layout_height="200dp" />
-
-                <FrameLayout
-                    android:id="@+id/roadNameLayout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    tools:background="#eee"
-                    tools:layout_height="52dp"
-                    tools:layout_width="140dp"
-                    app:layout_constraintBottom_toTopOf="@+id/guidelineBottom"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    android:layout_marginBottom="15dp"
-                    app:layout_constraintHeight_max="62dp" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-        </androidx.coordinatorlayout.widget.CoordinatorLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <FrameLayout
             android:id="@+id/infoPanelLayout"

--- a/libnavui-dropin/src/main/res/values-land/dimens.xml
+++ b/libnavui-dropin/src/main/res/values-land/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Overview camera padding to ensure location puck and target pin are not clipped -->
+    <dimen name="mapbox_camera_overview_padding_v">30dp</dimen>
+    <dimen name="mapbox_camera_overview_padding_h">35dp</dimen>
+</resources>

--- a/libnavui-dropin/src/main/res/values/dimens.xml
+++ b/libnavui-dropin/src/main/res/values/dimens.xml
@@ -25,10 +25,8 @@
     <dimen name="mapbox_maneuver_view_padding">4dp</dimen>
 
     <!-- Overview camera padding to ensure location puck and target pin are not clipped -->
-    <dimen name="mapbox_camera_overview_padding_v">50dp</dimen>
-    <dimen name="mapbox_camera_overview_padding_landscape_v">35dp</dimen>
+    <dimen name="mapbox_camera_overview_padding_v">30dp</dimen>
     <dimen name="mapbox_camera_overview_padding_h">50dp</dimen>
-    <dimen name="mapbox_camera_overview_padding_landscape_h">35dp</dimen>
 
     <dimen name="mapbox_extendable_button_width">72dp</dimen>
     <dimen name="mapbox_extendable_button_height">52dp</dimen>

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/CameraLayoutObserverTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/camera/CameraLayoutObserverTest.kt
@@ -1,27 +1,29 @@
-@file:Suppress("PrivatePropertyName", "MaxLineLength")
-
 package com.mapbox.navigation.dropin.camera
 
 import android.app.Service
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
-import android.view.View.OnLayoutChangeListener
 import android.widget.FrameLayout
+import androidx.core.view.doOnNextLayout
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxNavigationViewLayoutBinding
+import com.mapbox.navigation.dropin.infopanel.InfoPanelBehavior
+import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
+import com.mapbox.navigation.dropin.navigationview.NavigationViewModel
+import com.mapbox.navigation.dropin.testutil.TestLifecycleOwner
 import com.mapbox.navigation.dropin.util.TestStore
+import com.mapbox.navigation.testing.LoggingFrontendTestRule
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.ui.app.internal.camera.CameraAction
-import com.mapbox.navigation.ui.app.internal.navigation.NavigationState
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -37,9 +39,13 @@ class CameraLayoutObserverTest {
     @get:Rule
     val coroutineRule = MainCoroutineRule()
 
+    @get:Rule
+    val loggerRule = LoggingFrontendTestRule()
+
     private lateinit var store: TestStore
     private lateinit var binding: MapboxNavigationViewLayoutBinding
     private lateinit var mapView: View
+    private lateinit var infoPanelBehavior: InfoPanelBehavior
     private lateinit var sut: CameraLayoutObserver
 
     @Before
@@ -51,103 +57,66 @@ class CameraLayoutObserverTest {
         ).apply {
             // slightly modifying default layout to simulate layout changes
             guidanceLayout.bottom = 100
-            roadNameLayout.top = 100
-            actionListLayout.left = 100
-            infoPanelLayout.right = 100
+            roadNameLayout.top = 900
+            infoPanelLayout.right = 500
         }
-        mapView = View(context)
+        mapView = View(context).apply { bottom = 1000 }
         store = TestStore()
-        sut = CameraLayoutObserver(store, mapView, binding)
+        val navContext = NavigationViewContext(
+            context,
+            TestLifecycleOwner(),
+            NavigationViewModel(),
+        ) { store }
+        infoPanelBehavior = navContext.behavior.infoPanelBehavior
+        sut = CameraLayoutObserver(navContext, mapView, binding)
     }
 
     @Test
     @Config(qualifiers = "port")
-    fun `portrait - should update bottom padding for DestinationPreview, FreeDrive and RoutePreview state`() =
+    fun `portrait - should update camera paddings`() =
         coroutineRule.runBlockingTest {
             sut.onAttached(mockk())
 
-            triggerLayoutChangesAndVerifyDispatchedActions(
-                givenNavigationStates = listOf(
-                    NavigationState.DestinationPreview,
-                    NavigationState.FreeDrive,
-                    NavigationState.RoutePreview,
-                )
-            ) { state, action ->
-                assertEquals("$state|top", action.padding.top, PADDING_V_PORT, 0.001)
-                assertNotEquals("$state|bottom", action.padding.bottom, PADDING_V_PORT, 0.001)
-                assertEquals("$state|left", action.padding.left, PADDING_H_PORT, 0.001)
-                assertEquals("$state|right", action.padding.right, PADDING_H_PORT, 0.001)
-            }
-        }
-
-    @Test
-    @Config(qualifiers = "port")
-    fun `portrait - should update top and bottom padding for ActiveNavigation and Arrival state`() =
-        coroutineRule.runBlockingTest {
-            sut.onAttached(mockk())
-
-            triggerLayoutChangesAndVerifyDispatchedActions(
-                givenNavigationStates = listOf(
-                    NavigationState.ActiveNavigation,
-                    NavigationState.Arrival,
-                )
-            ) { s, action ->
-                assertNotEquals("$s|top", action.padding.top, PADDING_V_PORT, 0.001)
-                assertNotEquals("$s|bottom", action.padding.bottom, PADDING_V_PORT, 0.001)
-                assertEquals("$s|left", action.padding.left, PADDING_H_PORT, 0.001)
-                assertEquals("$s|right", action.padding.right, PADDING_H_PORT, 0.001)
-            }
-        }
-
-    @Test
-    @Config(qualifiers = "land")
-    fun `landscape - should update bottom padding for FreeDrive state`() =
-        coroutineRule.runBlockingTest {
-            sut.onAttached(mockk())
-
-            triggerLayoutChangesAndVerifyDispatchedActions(
-                givenNavigationStates = listOf(
-                    NavigationState.FreeDrive
-                )
-            ) { s, action ->
-                assertEquals("$s|top", action.padding.top, PADDING_V_LAND, 0.001)
-                assertNotEquals("$s|bottom", action.padding.bottom, PADDING_V_LAND, 0.001)
-                assertEquals("$s|left", action.padding.left, PADDING_H_LAND, 0.001)
-                assertEquals("$s|right", action.padding.right, PADDING_H_LAND, 0.001)
-            }
-        }
-
-    @Test
-    @Config(qualifiers = "land")
-    fun `landscape - should update left and bottom padding for all states except FreeDrive`() =
-        coroutineRule.runBlockingTest {
-            sut.onAttached(mockk())
-
-            triggerLayoutChangesAndVerifyDispatchedActions(
-                givenNavigationStates = listOf(
-                    NavigationState.DestinationPreview,
-                    NavigationState.RoutePreview,
-                    NavigationState.ActiveNavigation,
-                    NavigationState.Arrival,
-                )
-            ) { s, action ->
-                assertEquals("$s|top", action.padding.top, PADDING_V_LAND, 0.001)
-                assertNotEquals("$s|bottom", action.padding.bottom, PADDING_V_LAND, 0.001)
-                assertNotEquals("$s|left", action.padding.left, PADDING_H_LAND, 0.001)
-                assertEquals("$s|right", action.padding.right, PADDING_H_LAND, 0.001)
-            }
-        }
-
-    private suspend fun triggerLayoutChangesAndVerifyDispatchedActions(
-        givenNavigationStates: List<NavigationState>,
-        assertAction: (state: NavigationState, action: CameraAction.UpdatePadding) -> Unit
-    ) {
-        givenNavigationStates.forEachIndexed { index, navState ->
-            store.updateState { it.copy(navigation = navState) }
             binding.coordinatorLayout.triggerLayoutChange()
-            assertAction(navState, store.actions[index] as CameraAction.UpdatePadding)
+
+            val action = store.actions.last() as CameraAction.UpdatePadding
+            assertEquals("left", paddingH, action.padding.left, 0.001)
+            assertEquals("top", 100 + paddingV, action.padding.top, 0.001)
+            assertEquals("right", paddingH, action.padding.right, 0.001)
+            assertEquals("bottom", 100 + paddingV, action.padding.bottom, 0.001)
         }
-    }
+
+    @Test
+    @Config(qualifiers = "land")
+    fun `landscape - should update camera paddings when bottom sheet is collapsed`() =
+        coroutineRule.runBlockingTest {
+            sut.onAttached(mockk())
+
+            infoPanelBehavior.updateBottomSheetState(BottomSheetBehavior.STATE_COLLAPSED)
+            binding.coordinatorLayout.triggerLayoutChange()
+
+            val action = store.actions.last() as CameraAction.UpdatePadding
+            assertEquals("left", 500 + paddingH, action.padding.left, 0.001)
+            assertEquals("top", paddingV, action.padding.top, 0.001)
+            assertEquals("right", paddingH, action.padding.right, 0.001)
+            assertEquals("bottom", 100 + paddingV, action.padding.bottom, 0.001)
+        }
+
+    @Test
+    @Config(qualifiers = "land")
+    fun `landscape - should update camera paddings when bottom sheet is hidden`() =
+        coroutineRule.runBlockingTest {
+            sut.onAttached(mockk())
+
+            infoPanelBehavior.updateBottomSheetState(BottomSheetBehavior.STATE_HIDDEN)
+            binding.coordinatorLayout.triggerLayoutChange()
+
+            val action = store.actions.last() as CameraAction.UpdatePadding
+            assertEquals("left", paddingH, action.padding.left, 0.001)
+            assertEquals("top", paddingV, action.padding.top, 0.001)
+            assertEquals("right", paddingH, action.padding.right, 0.001)
+            assertEquals("bottom", 100 + paddingV, action.padding.bottom, 0.001)
+        }
 
     private suspend fun View.triggerLayoutChange() = coroutineScope {
         launch {
@@ -158,34 +127,13 @@ class CameraLayoutObserverTest {
     }
 
     private suspend fun View.waitForLayoutChange() = suspendCancellableCoroutine<Unit> { cont ->
-        addOnLayoutChangeListener(object : OnLayoutChangeListener {
-            override fun onLayoutChange(
-                v: View?,
-                left: Int,
-                top: Int,
-                right: Int,
-                bottom: Int,
-                oldLeft: Int,
-                oldTop: Int,
-                oldRight: Int,
-                oldBottom: Int
-            ) {
-                cont.resume(Unit)
-                removeOnLayoutChangeListener(this)
-            }
-        })
+        doOnNextLayout { cont.resume(Unit) }
     }
 
-    private val PADDING_V_PORT: Double
+    private val paddingV: Double
         get() = binding.root.resources
             .getDimensionPixelSize(R.dimen.mapbox_camera_overview_padding_v).toDouble()
-    private val PADDING_H_PORT: Double
+    private val paddingH: Double
         get() = binding.root.resources
             .getDimensionPixelSize(R.dimen.mapbox_camera_overview_padding_h).toDouble()
-    private val PADDING_V_LAND: Double
-        get() = binding.root.resources
-            .getDimensionPixelSize(R.dimen.mapbox_camera_overview_padding_landscape_v).toDouble()
-    private val PADDING_H_LAND: Double
-        get() = binding.root.resources
-            .getDimensionPixelSize(R.dimen.mapbox_camera_overview_padding_landscape_h).toDouble()
 }

--- a/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelCoordinatorTest.kt
+++ b/libnavui-dropin/src/test/java/com/mapbox/navigation/dropin/infopanel/InfoPanelCoordinatorTest.kt
@@ -62,11 +62,7 @@ class InfoPanelCoordinatorTest {
         )
         mapboxNavigation = mockk(relaxed = true)
 
-        sut = InfoPanelCoordinator(
-            viewContext,
-            binding.infoPanelLayout,
-            binding.guidelineBottom
-        )
+        sut = InfoPanelCoordinator(viewContext, binding)
     }
 
     @Test


### PR DESCRIPTION
### Description
Removed extra `CoordinatorLayout` with `fitsSystemWindows` and set paddings according to the current insets manually. The issue with `fitsSystemWindows` is that it also reacts to keyboard insets, while `NavigationViewContext.systemBarsInsets` only contains system bar insets. This leads to inconsistencies, e.g. when keyboard is shown the road name view will end up at the top of the screen despite the 50% guideline top position limitation we have. 

Before:

https://user-images.githubusercontent.com/2395284/213427515-0fd3fd08-5d09-49c6-8706-c2f64b965f55.mp4

After:

https://user-images.githubusercontent.com/2395284/213427491-9ecb3c56-53d6-4e98-8016-311f656a48bf.mp4

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
