### PR TITLE
CI config, release-snapshot: remove `check-public-documentation`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -781,7 +781,6 @@ jobs:
       - checkout
       - assemble-core-release
       - assemble-ui-release
-      - check-public-documentation
       - prepare-mbx-ci
       - setup-aws-credentials
       - upload-artifacts-snapshot


### PR DESCRIPTION
### Description
Removing the `check public documentation` step from `release-snapshot` as not necessary: 
- every Pull request already has this check and changes merged to production `branches` pass that verification;
- the check is only wasting pull requests with `release-snapshot` labels and forces to add documentation to the API that might be temporary or will be added later (the previous step prohibits merging changes to a production `branch` before API stays documented).

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
