### PR TITLE
CI: enable snapshot repo for snapshot releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -776,6 +776,9 @@ jobs:
   release-snapshot:
     executor: ndk-r22-latest-executor
     resource_class: medium+
+    # Allow snapshot repository for snapshot releases
+    environment:
+      ALLOW_SNAPSHOT_REPOSITORY: true
     steps:
       - check-snapshot-label
       - checkout


### PR DESCRIPTION
### Description
CI: enable snapshot repo for snapshot releases

⚠️ other jobs are failing: the changes allow snapshot release only, but not build, tests, analytics, etc on top of a snapshot 

Ideally, the above jobs should be allowed but forbidden to merge.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
