### PR TITLE
use CarActiveGuidanceMarkers in route preview screen

### DIFF
--- a/libnavui-androidauto/api/current.txt
+++ b/libnavui-androidauto/api/current.txt
@@ -283,7 +283,7 @@ package com.mapbox.androidauto.map.logo {
 package com.mapbox.androidauto.navigation {
 
   public final class CarActiveGuidanceMarkers implements com.mapbox.maps.extension.androidauto.MapboxCarMapObserver {
-    ctor public CarActiveGuidanceMarkers();
+    ctor public CarActiveGuidanceMarkers(com.mapbox.androidauto.routes.CarRoutesProvider carRoutesProvider = com.mapbox.androidauto.routes.NavigationCarRoutesProvider());
   }
 
   public final class CarArrivalTrigger implements com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver {

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/CarActiveGuidanceMarkers.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/navigation/CarActiveGuidanceMarkers.kt
@@ -1,63 +1,54 @@
 package com.mapbox.androidauto.navigation
 
 import com.mapbox.androidauto.internal.extensions.getStyle
-import com.mapbox.androidauto.internal.extensions.handleStyleOnAttached
-import com.mapbox.androidauto.internal.extensions.handleStyleOnDetached
-import com.mapbox.androidauto.internal.extensions.mapboxNavigationForward
+import com.mapbox.androidauto.internal.extensions.styleFlow
 import com.mapbox.androidauto.internal.logAndroidAuto
 import com.mapbox.androidauto.placeslistonmap.PlacesListOnMapLayerUtil
+import com.mapbox.androidauto.routes.CarRoutesProvider
+import com.mapbox.androidauto.routes.NavigationCarRoutesProvider
 import com.mapbox.geojson.Feature
 import com.mapbox.geojson.FeatureCollection
+import com.mapbox.maps.Style
 import com.mapbox.maps.extension.androidauto.MapboxCarMapObserver
 import com.mapbox.maps.extension.androidauto.MapboxCarMapSurface
-import com.mapbox.maps.plugin.delegates.listeners.OnStyleLoadedListener
-import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.core.directions.session.RoutesObserver
-import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.base.route.NavigationRoute
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
-class CarActiveGuidanceMarkers : MapboxCarMapObserver {
-    private var styleLoadedListener: OnStyleLoadedListener? = null
-    private var mapboxCarMapSurface: MapboxCarMapSurface? = null
-    private val navigationObserver = mapboxNavigationForward(this::onAttached, this::onDetached)
-    private val routesObserver = RoutesObserver { updateMarkers() }
+class CarActiveGuidanceMarkers(
+    private val carRoutesProvider: CarRoutesProvider = NavigationCarRoutesProvider(),
+) : MapboxCarMapObserver {
+
     private val placesLayerUtil = PlacesListOnMapLayerUtil()
+    private lateinit var scope: CoroutineScope
 
-    private fun updateMarkers() {
-        val route = MapboxNavigationApp.current()?.getNavigationRoutes()?.firstOrNull()
-            ?: return
-        val coordinate = route.routeOptions.coordinatesList().lastOrNull()
-            ?: return
-        val featureCollection = FeatureCollection.fromFeature(Feature.fromGeometry(coordinate))
-        mapboxCarMapSurface?.getStyle()?.let {
-            placesLayerUtil.updatePlacesListOnMapLayer(it, featureCollection)
-        }
+    private fun updateMarkers(style: Style, routes: List<NavigationRoute>) {
+        val features = routes.take(1)
+            .mapNotNull { it.routeOptions.coordinatesList().lastOrNull() }
+            .map { Feature.fromGeometry(it) }
+        placesLayerUtil.updatePlacesListOnMapLayer(style, FeatureCollection.fromFeatures(features))
     }
 
     override fun onAttached(mapboxCarMapSurface: MapboxCarMapSurface) {
-        logAndroidAuto("ActiveGuidanceScreen loaded")
-        this.mapboxCarMapSurface = mapboxCarMapSurface
+        logAndroidAuto("CarActiveGuidanceMarkers attached")
         val carContext = mapboxCarMapSurface.carContext
-        styleLoadedListener = mapboxCarMapSurface.handleStyleOnAttached {
-            placesLayerUtil.initializePlacesListOnMapLayer(it, carContext.resources)
-            updateMarkers()
+        scope = MainScope()
+        scope.launch {
+            mapboxCarMapSurface.styleFlow().collectLatest { style ->
+                placesLayerUtil.initializePlacesListOnMapLayer(style, carContext.resources)
+                carRoutesProvider.navigationRoutes.collect { updateMarkers(style, it) }
+            }
         }
-        MapboxNavigationApp.registerObserver(navigationObserver)
     }
 
     override fun onDetached(mapboxCarMapSurface: MapboxCarMapSurface) {
         super.onDetached(mapboxCarMapSurface)
-        logAndroidAuto("ActiveGuidanceScreen detached")
-        MapboxNavigationApp.unregisterObserver(navigationObserver)
-        mapboxCarMapSurface.handleStyleOnDetached(styleLoadedListener)?.let {
-            placesLayerUtil.removePlacesListOnMapLayer(it)
-        }
-    }
-
-    private fun onAttached(mapboxNavigation: MapboxNavigation) {
-        mapboxNavigation.registerRoutesObserver(routesObserver)
-    }
-
-    private fun onDetached(mapboxNavigation: MapboxNavigation) {
-        mapboxNavigation.unregisterRoutesObserver(routesObserver)
+        logAndroidAuto("CarActiveGuidanceMarkers detached")
+        scope.cancel()
+        mapboxCarMapSurface.getStyle()?.let { placesLayerUtil.removePlacesListOnMapLayer(it) }
     }
 }


### PR DESCRIPTION
### Description
While integrating the experimental route preview feature in Android Auto, I noticed that `CarRoutePreviewScreen` duplicates most of the logic in `CarActiveGuidanceMarkers`. That was resolved by using `CarActiveGuidanceMarkers` (should we rename it now?) in `CarRoutePreviewScreen`. Also working with styles using `handleStyleOnAttached`/`handleStyleOnDetached` was rather inconvenient, replaced that with `styleFlow`. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
