### PR TITLE
Release snapshot workflow refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,22 @@ workflows:
     when:
       not: << pipeline.parameters.mapbox_navigation_native_upstream >>
     jobs:
-      - release-snapshot
+      - release-snapshot-start:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - main
+                - /release-v.*/
+      - release-snapshot:
+          requires:
+            - release-snapshot-start
+      - release-snapshot:
+          filters:
+            branches:
+              only:
+                - main
+                - /release-v.*/
       - release:
           filters:
             tags:
@@ -96,20 +111,6 @@ workflows:
 #---------- COMMANDS ----------
 #------------------------------
 commands:
-  check-snapshot-label:
-    steps:
-      - run:
-          name: Check snapshot label
-          command: |
-            if [[ -n "$CIRCLE_PULL_REQUEST" ]]; then
-              PR=$(curl -s $CIRCLE_PULL_REQUEST)
-            fi
-            if [[ $CIRCLE_BRANCH == main || $CIRCLE_BRANCH =~ release-v.* || $PR == *"mapbox/mapbox-navigation-android/labels/publish-snapshot"* ]]; then
-              exit 0
-            else
-              exit 1
-            fi
-
   write-workspace:
     steps:
       - persist_to_workspace:
@@ -777,7 +778,6 @@ jobs:
     executor: ndk-r22-latest-executor
     resource_class: medium+
     steps:
-      - check-snapshot-label
       - checkout
       - assemble-core-release
       - assemble-ui-release

--- a/.github/workflows/run_release_snapshot.yml
+++ b/.github/workflows/run_release_snapshot.yml
@@ -1,0 +1,18 @@
+name: Run release-snapshot job
+on:
+  pull_request:
+    types: [ opened, synchronize, labeled ]
+jobs:
+  process:
+    if: contains(github.event.pull_request.labels.*.name, 'publish-snapshot')
+    permissions:
+      pull-requests: write
+      contents: write
+    runs-on: ubuntu-20.04
+    env:
+      BRANCH_NAME: ${{ github.head_ref }}
+      CIRCLE_CI_TOKEN: ${{ secrets.CIRCLE_CI_TOKEN }}
+    steps:
+      - name: Run release-snapshot job
+        run: |
+          curl -X POST -H "Circle-Token: ${CIRCLE_CI_TOKEN}" --header "Content-Type: application/json" --data "{\"build_parameters\":{\"CIRCLE_JOB\":\"release-snapshot\"}}" https://circleci.com/api/v1.1/project/github/mapbox/mapbox-navigation-android/tree/${BRANCH_NAME}


### PR DESCRIPTION
Failure release-snapshot job confuses the team when it runs on branches and PRs without the `publish-snapshot` label.

I propose a way like for the mobile-metrics-benchmarks job. If you want to publish a snapshot just approve the `release-snapshot-start` job, and it will start the `release-snapshot-1` job (with postfix 1 because we use this job for the main and release branches too). The `release-snapshot-2` job will be started without approvals for the main and release branches.

<img width="666" alt="image" src="https://user-images.githubusercontent.com/25399022/214868313-a3b7617a-3b55-4fde-954b-94784aa20734.png">

@RingerJK @Zayankovsky 