### PR TITLE
Fix Copilot ANR

### DIFF
--- a/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/HistoryAttachmentsUtils.kt
+++ b/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/HistoryAttachmentsUtils.kt
@@ -3,6 +3,8 @@ package com.mapbox.navigation.copilot
 import android.util.Base64
 import com.mapbox.navigation.copilot.internal.CopilotMetadata
 import com.mapbox.navigation.core.BuildConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.io.File
 import java.text.SimpleDateFormat
@@ -60,11 +62,10 @@ internal object HistoryAttachmentsUtils {
 
     fun delete(file: File): Boolean = file.delete()
 
-    fun copyToAndRemove(from: File, filename: String): File {
-        val to = from.copyTo(File(from.parent, filename))
-        from.delete()
-        return to
-    }
+    suspend fun copyToAndRemove(from: File, filename: String): File =
+        withContext(Dispatchers.IO) {
+            File(from.parent, filename).also { from.renameTo(it) }
+        }
 
     private fun decode(str: String): JSONObject {
         val requiredLength = (str.length - 1) / 4 * 4 + 4

--- a/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/HistoryUploadWorkerTest.kt
+++ b/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/HistoryUploadWorkerTest.kt
@@ -18,6 +18,7 @@ import com.mapbox.navigation.copilot.internal.PushStatus
 import com.mapbox.navigation.copilot.internal.PushStatusObserver
 import com.mapbox.navigation.utils.internal.logD
 import io.mockk.Runs
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -446,7 +447,7 @@ class HistoryUploadWorkerTest {
         mockkObject(HistoryAttachmentsUtils)
         val fileSlot = slot<File>()
         val mockedFile = mockk<File>(relaxed = true)
-        every { copyToAndRemove(capture(fileSlot), any()) } answers {
+        coEvery { copyToAndRemove(capture(fileSlot), any()) } coAnswers {
             every { mockedFile.absolutePath } returns fileSlot.captured.toString()
             mockedFile
         }

--- a/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/MapboxCopilotImplTest.kt
+++ b/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/MapboxCopilotImplTest.kt
@@ -30,8 +30,10 @@ import com.mapbox.navigation.core.internal.telemetry.UserFeedbackCallback
 import com.mapbox.navigation.core.internal.telemetry.registerUserFeedbackCallback
 import com.mapbox.navigation.core.internal.telemetry.unregisterUserFeedbackCallback
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.utils.internal.logD
 import io.mockk.Runs
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -44,6 +46,7 @@ import io.mockk.verifyOrder
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import java.io.File
 import java.util.Locale
@@ -57,6 +60,9 @@ import java.util.Locale
  */
 @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class MapboxCopilotImplTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
 
     @After
     fun teardown() {
@@ -2458,7 +2464,7 @@ class MapboxCopilotImplTest {
         mockkObject(HistoryAttachmentsUtils)
         val fileSlot = slot<File>()
         val mockedFile = mockk<File>(relaxed = true)
-        every { copyToAndRemove(capture(fileSlot), any()) } answers {
+        coEvery { copyToAndRemove(capture(fileSlot), any()) } coAnswers {
             every { mockedFile.absolutePath } returns fileSlot.captured.toString()
             mockedFile
         }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
- Fixes Copilot ANR executing `copyToAndRemove` in a separate IO thread