### PR TITLE
fixed upcoming route objects test

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/UpcomingRouteObjectsTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/UpcomingRouteObjectsTest.kt
@@ -21,7 +21,6 @@ import com.mapbox.navigation.testing.ui.utils.runOnMainSync
 import kotlinx.coroutines.flow.first
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.net.URI
@@ -76,8 +75,9 @@ class UpcomingRouteObjectsTest : BaseTest<EmptyTestActivity>(EmptyTestActivity::
             .first { it.roadObject.id == incidentId }
 
         assertEquals(
-            upcomingIncidentForOneLeg.distanceToStart,
-            upcomingIncidentForTwoLegsRoute.distanceToStart
+            upcomingIncidentForOneLeg.distanceToStart!!,
+            upcomingIncidentForTwoLegsRoute.distanceToStart!!,
+            0.1
         )
     }
 

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/UpcomingRouteObjectsTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/UpcomingRouteObjectsTest.kt
@@ -21,6 +21,7 @@ import com.mapbox.navigation.testing.ui.utils.runOnMainSync
 import kotlinx.coroutines.flow.first
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import java.net.URI


### PR DESCRIPTION
I tested NN fix [here](https://github.com/mapbox/mapbox-navigation-android/pull/6871), and found out that values aren't exact. 10 sm accuracy seems good. 