### PR TITLE
Make ReplayRouteSession and TripSessionStarter handle route changes

### DIFF
--- a/android-auto-app/build.gradle
+++ b/android-auto-app/build.gradle
@@ -72,8 +72,8 @@ dependencies {
     // This example is used for development so it may depend on unstable versions.
     // Examples based on final versions can be found in the examples repository.
     //   https://github.com/mapbox/mapbox-navigation-android-examples
-    implementation("com.mapbox.navigation:ui-dropin:2.10.0-rc.1")
-    implementation("com.mapbox.search:mapbox-search-android:1.0.0-beta.42")
+    implementation("com.mapbox.navigation:ui-dropin:2.10.0")
+    implementation("com.mapbox.search:mapbox-search-android:1.0.0-beta.43")
 
     // Dependencies needed for this example.
     implementation dependenciesList.androidXCore

--- a/changelog/unreleased/bugfixes/6913.md
+++ b/changelog/unreleased/bugfixes/6913.md
@@ -1,0 +1,3 @@
+- Make `MapboxTripStarterType.ReplayRoute` and `ReplayRouteSession` automatically move to the origin of the route after `MapboxNavigation.setNavigationRoutes`.
+- Make `ReplayRouteSession` observe the `ReplayRouteSessionOptions` so changes can be made without creating a new instance of the session.
+- Change `ReplayRouteSession.getOptions()` to return a `StateFlow` so the options can be observed.

--- a/libnavigation-core/api/current.txt
+++ b/libnavigation-core/api/current.txt
@@ -703,7 +703,7 @@ package com.mapbox.navigation.core.replay.route {
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class ReplayRouteSession implements com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver {
     ctor public ReplayRouteSession();
-    method public com.mapbox.navigation.core.replay.route.ReplayRouteSessionOptions getOptions();
+    method public kotlinx.coroutines.flow.StateFlow<com.mapbox.navigation.core.replay.route.ReplayRouteSessionOptions> getOptions();
     method public void onAttached(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
     method public void onDetached(com.mapbox.navigation.core.MapboxNavigation mapboxNavigation);
     method public com.mapbox.navigation.core.replay.route.ReplayRouteSession setOptions(com.mapbox.navigation.core.replay.route.ReplayRouteSessionOptions options);

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/MapboxTripStarter.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/MapboxTripStarter.kt
@@ -37,7 +37,7 @@ import kotlinx.coroutines.flow.onEach
  */
 @ExperimentalPreviewMapboxNavigationAPI
 class MapboxTripStarter internal constructor(
-    private val services: MapboxTripStarterServices = MapboxTripStarterServices()
+    services: MapboxTripStarterServices = MapboxTripStarterServices()
 ) : MapboxNavigationObserver {
 
     private val tripType = MutableStateFlow<MapboxTripStarterType>(
@@ -152,14 +152,16 @@ class MapboxTripStarter internal constructor(
                     isLocationPermissionGranted.onEach { granted ->
                         onMapMatchingEnabled(mapboxNavigation, granted)
                     }
-                MapboxTripStarterType.ReplayRoute ->
-                    replayRouteSession.getOptions().onEach { options ->
-                        onReplayRouteEnabled(mapboxNavigation, options)
-                    }
-                MapboxTripStarterType.ReplayHistory ->
-                    replayHistorySession.getOptions().onEach { options ->
-                        onReplayHistoryEnabled(mapboxNavigation, options)
-                    }
+                MapboxTripStarterType.ReplayRoute -> {
+                    replayHistorySession.onDetached(mapboxNavigation)
+                    replayRouteSession.onAttached(mapboxNavigation)
+                    replayRouteSession.getOptions()
+                }
+                MapboxTripStarterType.ReplayHistory -> {
+                    replayRouteSession.onDetached(mapboxNavigation)
+                    replayHistorySession.onAttached(mapboxNavigation)
+                    replayHistorySession.getOptions()
+                }
             }
         }
     }
@@ -184,36 +186,6 @@ class MapboxTripStarter internal constructor(
             }
             onTripDisabled(mapboxNavigation)
         }
-    }
-
-    /**
-     * Internally called when the trip type has been set to replay route.
-     *
-     * @param mapboxNavigation
-     * @param options parameters for the [ReplayRouteSession]
-     */
-    private fun onReplayRouteEnabled(
-        mapboxNavigation: MapboxNavigation,
-        options: ReplayRouteSessionOptions
-    ) {
-        replayHistorySession.onDetached(mapboxNavigation)
-        replayRouteSession.setOptions(options)
-        replayRouteSession.onAttached(mapboxNavigation)
-    }
-
-    /**
-     * Internally called when the trip type has been set to replay history.
-     *
-     * @param mapboxNavigation
-     * @param options parameters for the [ReplayHistorySession]
-     */
-    private fun onReplayHistoryEnabled(
-        mapboxNavigation: MapboxNavigation,
-        options: ReplayHistorySessionOptions
-    ) {
-        replayRouteSession.onDetached(mapboxNavigation)
-        replayHistorySession.setOptions(options)
-        replayHistorySession.onAttached(mapboxNavigation)
     }
 
     /**

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/replay/route/ReplayRouteSessionTest.kt
@@ -145,7 +145,7 @@ class ReplayRouteSessionTest {
         sut.setOptions(firstOptions)
 
         assertNotEquals(firstOptions, initialOptions)
-        assertEquals(firstOptions, sut.getOptions())
+        assertEquals(firstOptions, sut.getOptions().value)
     }
 
     @Test
@@ -158,7 +158,7 @@ class ReplayRouteSessionTest {
         sut.setOptions(firstOptions)
 
         assertNotEquals(firstOptions, initialOptions)
-        assertEquals(firstOptions, sut.getOptions())
+        assertEquals(firstOptions, sut.getOptions().value)
     }
 
     @Test
@@ -355,7 +355,6 @@ class ReplayRouteSessionTest {
         progressObserver.captured.onRouteProgressChanged(secondRouteProgress)
 
         verify(exactly = 2) {
-            replayer.clearEvents()
             replayer.pushEvents(any())
         }
         verifyOrder {


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Status: opening as a draft cause i just made it work and need to update the tests

There are a couple experiences we have found that need improvement with the `ReplayRouteSession`.

1. Switching routes requires instantiating a new instance of `ReplayRouteSession` and calling `resetTripSession`
2. Selecting a route during route preview should move the location to the origin of that route to prepare for replay route

This pull request is addressing `1`. I haven't tested `2` much yet. But it works with Android Auto so I'm adding a video that demonstrates an improvement to the new junction view example. Now you can select routes and have the replayer reset to that location.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

https://user-images.githubusercontent.com/3021882/215225945-788645b0-19f9-4eff-9c2d-940556c4b825.mov

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
