### PR TITLE
Updated cache key for NavigationRoute in order to optimize key calculation

### DIFF
--- a/changelog/unreleased/bugfixes/6915.md
+++ b/changelog/unreleased/bugfixes/6915.md
@@ -1,0 +1,1 @@
+- Improved cache key performance for NavigationRoutes in order to address ANR experienced when setting long routes.

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/internal/route/line/MapboxRouteLineUtils.kt
@@ -57,6 +57,7 @@ import com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor
 import com.mapbox.navigation.ui.maps.util.CacheResultUtils
 import com.mapbox.navigation.ui.maps.util.CacheResultUtils.cacheResult
 import com.mapbox.navigation.ui.maps.util.CacheResultUtils.cacheRouteResult
+import com.mapbox.navigation.ui.maps.util.CacheResultUtils.cacheRouteTrafficResult
 import com.mapbox.navigation.ui.utils.internal.extensions.getBitmap
 import com.mapbox.navigation.ui.utils.internal.ifNonNull
 import com.mapbox.navigation.utils.internal.logE
@@ -76,11 +77,9 @@ internal object MapboxRouteLineUtils {
     private const val NUMBER_OF_SUPPORTED_ROUTES = 3
 
     internal val extractRouteDataCache: LruCache<
-        CacheResultUtils.CacheResultKey2<
-            NavigationRoute, (RouteLeg) -> List<String>?,
-            List<ExtractedRouteData>
-            >,
-        List<ExtractedRouteData>> by lazy { LruCache(NUMBER_OF_SUPPORTED_ROUTES) }
+        CacheResultUtils.CacheResultKeyRouteTraffic<
+            List<ExtractedRouteData>>, List<ExtractedRouteData>>
+        by lazy { LruCache(NUMBER_OF_SUPPORTED_ROUTES) }
 
     private val granularDistancesCache: LruCache<
         CacheResultUtils.CacheResultKeyRoute<
@@ -691,7 +690,7 @@ internal object MapboxRouteLineUtils {
                 }
             }
             itemsToReturn
-        }.cacheResult(extractRouteDataCache)
+        }.cacheRouteTrafficResult(extractRouteDataCache)
 
     internal val getRouteLegTrafficNumericCongestionProvider: (
         routeLineColorResources: RouteLineColorResources
@@ -741,7 +740,7 @@ internal object MapboxRouteLineUtils {
             } ?: listOf()
     }
 
-    private fun getRoadClassArray(
+    internal fun getRoadClassArray(
         steps: List<LegStep>?
     ): Array<String?> {
         val intersectionsWithGeometryIndex = steps

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/CacheResultUtils.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/util/CacheResultUtils.kt
@@ -1,8 +1,11 @@
 package com.mapbox.navigation.ui.maps.util
 
 import android.util.LruCache
+import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.DirectionsRoute
+import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.navigation.base.route.NavigationRoute
+import com.mapbox.navigation.ui.maps.internal.route.line.MapboxRouteLineUtils
 
 internal object CacheResultUtils {
     private interface CacheResultCall<in F, out R> {
@@ -53,6 +56,153 @@ internal object CacheResultUtils {
 
         override fun hashCode(): Int {
             return route.id.hashCode()
+        }
+    }
+
+    data class CacheResultKeyRouteTraffic<R>(
+        val route: NavigationRoute,
+        val trafficProvider: (RouteLeg) -> List<String>?
+    ) :
+        CacheResultCall<(NavigationRoute, (RouteLeg) -> List<String>?) -> R, R> {
+
+        override fun invoke(f: (NavigationRoute, (RouteLeg) -> List<String>?) -> R) = f(
+            route,
+            trafficProvider
+        )
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as CacheResultKeyRouteTraffic<*>
+
+            if (route.id != other.route.id) return false
+            if (trafficProvider != other.trafficProvider) return false
+            if (
+                route.directionsRoute.legs()?.size !=
+                other.route.directionsRoute.legs()?.size
+            ) {
+                return false
+            }
+            if (!trafficIsEqual(route, other.route)) return false
+            if (!closuresAreEqual(route, other.route)) return false
+            if (!roadClassesAreEqual(route, other.route)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = route.id.hashCode()
+            result = 31 * result + trafficProvider.hashCode()
+            route.directionsRoute.legs()?.forEach { routeLeg ->
+                result = 31 * result + routeLeg.annotation()?.congestion().hashCode()
+                result = 31 * result + routeLeg.annotation()?.congestionNumeric().hashCode()
+                result = 31 * result + routeLeg.closures().hashCode()
+                MapboxRouteLineUtils.getRoadClassArray(routeLeg.steps()).forEach {
+                    result = 31 * result + it.hashCode()
+                }
+            }
+            return result
+        }
+
+        private fun roadClassesAreEqual(route: NavigationRoute, other: NavigationRoute): Boolean {
+            val routeRoadClasses = route.directionsRoute.legs()?.map {
+                MapboxRouteLineUtils.getRoadClassArray(it.steps()).toList()
+            }?.flatten() ?: listOf()
+            val otherRoadClasses = other.directionsRoute.legs()?.map {
+                MapboxRouteLineUtils.getRoadClassArray(it.steps()).toList()
+            }?.flatten() ?: listOf()
+
+            return listElementsAreEqual(
+                routeRoadClasses,
+                otherRoadClasses
+            ) { roadClass1, roadClass2 ->
+                roadClass1 == roadClass2
+            }
+        }
+
+        private fun closuresAreEqual(route: NavigationRoute, other: NavigationRoute): Boolean {
+            if (route.directionsRoute.legs()?.size != other.directionsRoute.legs()?.size) {
+                return false
+            }
+            route.directionsRoute.legs()?.forEachIndexed { index, routeLeg ->
+                if (
+                    !listElementsAreEqual(
+                        routeLeg.closures() ?: listOf(),
+                        other.directionsRoute.legs()?.get(index)?.closures() ?: listOf()
+                    ) { closure1, closure2 ->
+                        closure1 == closure2
+                    }
+                ) {
+                    return false
+                }
+            }
+            return true
+        }
+
+        private fun trafficIsEqual(route: NavigationRoute, other: NavigationRoute): Boolean {
+            if (route.directionsRoute.legs()?.size != other.directionsRoute.legs()?.size) {
+                return false
+            }
+
+            val hasNumericTraffic: Boolean = route.directionsRoute.routeOptions()?.annotationsList()
+                ?.contains(DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC) ?: false
+            val sameTrafficType: Boolean = hasNumericTraffic ==
+                (
+                    other.directionsRoute.routeOptions()?.annotationsList()
+                        ?.contains(DirectionsCriteria.ANNOTATION_CONGESTION_NUMERIC) ?: false
+                    )
+            when (sameTrafficType) {
+                false -> return false
+                true -> {
+                    route.directionsRoute.legs()?.forEachIndexed { index, routeLeg ->
+                        val trafficCongestionIsEqual = when (hasNumericTraffic) {
+                            false -> {
+                                if (
+                                    routeLeg.annotation()?.congestion()?.size !=
+                                    other.directionsRoute
+                                        .legs()?.get(index)?.annotation()?.congestion()?.size
+                                ) {
+                                    false
+                                } else {
+                                    listElementsAreEqual(
+                                        routeLeg.annotation()?.congestion() ?: listOf(),
+                                        other.directionsRoute
+                                            .legs()
+                                            ?.get(index)
+                                            ?.annotation()
+                                            ?.congestion() ?: listOf()
+                                    ) { string1: String?, string2: String? -> string1 == string2 }
+                                }
+                            }
+                            true -> {
+                                if (
+                                    routeLeg.annotation()?.congestionNumeric()?.size !=
+                                    other.directionsRoute
+                                        .legs()
+                                        ?.get(index)
+                                        ?.annotation()
+                                        ?.congestionNumeric()
+                                        ?.size
+                                ) {
+                                    false
+                                } else {
+                                    listElementsAreEqual(
+                                        routeLeg.annotation()?.congestionNumeric() ?: listOf(),
+                                        other.directionsRoute.legs()?.get(index)?.annotation()
+                                            ?.congestionNumeric() ?: listOf()
+                                    ) { item1: Int?, item2: Int? ->
+                                        item1 == item2
+                                    }
+                                }
+                            }
+                        }
+                        if (!trafficCongestionIsEqual) {
+                            return false
+                        }
+                    }
+                }
+            }
+            return true
         }
     }
 
@@ -130,6 +280,22 @@ internal object CacheResultUtils {
         }
     }
 
+    fun <R> ((NavigationRoute, (RouteLeg) -> List<String>?) -> R).cacheRouteTrafficResult(
+        cache: LruCache<CacheResultKeyRouteTraffic<R>, R>
+    ): (NavigationRoute, (RouteLeg) -> List<String>?) -> R {
+        return object : (NavigationRoute, (RouteLeg) -> List<String>?) -> R {
+            private val handler =
+                CacheResultHandler(
+                    this@cacheRouteTrafficResult,
+                    cache
+                )
+            override fun invoke(
+                route: NavigationRoute,
+                trafficProvider: (RouteLeg) -> List<String>?
+            ) = handler(CacheResultKeyRouteTraffic(route, trafficProvider))
+        }
+    }
+
     private class CacheResultHandler<F, K : CacheResultCall<F, R>, R>(
         val f: F,
         val cache: LruCache<K, R>
@@ -142,6 +308,20 @@ internal object CacheResultUtils {
                     }
                 }
             }
+        }
+    }
+
+    private fun <T> listElementsAreEqual(
+        first: List<T>,
+        second: List<T>,
+        equalityFun: (T?, T?) -> Boolean
+    ): Boolean {
+        if (first.size != second.size) {
+            return false
+        }
+
+        return first.zip(second).all { (x, y) ->
+            equalityFun(x, y)
         }
     }
 }


### PR DESCRIPTION
### Description
Created cache key specifically to calculate hash code and equality based on traffic rather than the default `NavigationRoute` hash code which is quite expensive especially for long routes.

### Screenshots or Gifs

