### PR TITLE
force route line layers to be initialized before route arrow layers are

### DIFF
--- a/libnavui-androidauto/changelog/unreleased/bugfixes/6921.md
+++ b/libnavui-androidauto/changelog/unreleased/bugfixes/6921.md
@@ -1,0 +1,1 @@
+- Fixed an issue with `CarRouteLineRenderer` that caused route arrows to be rendered above the location puck.

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/preview/CarRouteLineRenderer.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/preview/CarRouteLineRenderer.kt
@@ -85,6 +85,7 @@ class CarRouteLineRenderer(
                 val carContext = mapboxCarMapSurface.carContext
                 val routeLineOptions = getMapboxRouteLineOptions(carContext, style)
                 routeLineView = MapboxRouteLineView(routeLineOptions)
+                routeLineView.initializeLayers(style)
                 routeLineApi = MapboxRouteLineApi(routeLineOptions)
                 routeArrowApi = MapboxRouteArrowApi()
                 routeArrowView = MapboxRouteArrowView(


### PR DESCRIPTION
<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
