### PR TITLE
[NN-383] - Update only distance value in existing upcoming road objects on each status

### DIFF
--- a/changelog/unreleased/bugfixes/6922.md
+++ b/changelog/unreleased/bugfixes/6922.md
@@ -1,0 +1,1 @@
+Fixed "global reference table overflow" in case an application accumulates and keeps links to `RouteProgress#upcomingRoadObjects`

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadObjectFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadObjectFactory.kt
@@ -37,6 +37,27 @@ object RoadObjectFactory {
             }
     }
 
+    fun List<UpcomingRoadObject>.getUpdatedObjectsAhead(
+        status: com.mapbox.navigator.NavigationStatus
+    ): List<UpcomingRoadObject> {
+        val idToDistanceRemaining = status.upcomingRouteAlerts.associate {
+            it.roadObject.id to it.distanceToStart
+        }
+        val updateObjects = mutableListOf<UpcomingRoadObject>()
+        forEach {
+            if (it.roadObject.id in idToDistanceRemaining.keys) {
+                updateObjects.add(
+                    buildUpcomingRoadObject(
+                        roadObject = it.roadObject, // reusing the old road object reference
+                        distanceToStart = idToDistanceRemaining[it.roadObject.id],
+                        distanceInfo = null
+                    )
+                )
+            }
+        }
+        return updateObjects
+    }
+
     /**
      * Build road object from native object
      */

--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadObjectFactory.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/factory/RoadObjectFactory.kt
@@ -6,6 +6,7 @@ import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
 import com.mapbox.navigation.base.trip.model.roadobject.distanceinfo.RoadObjectDistanceInfo
 import com.mapbox.navigation.base.trip.model.roadobject.mapToRoadObject
 import com.mapbox.navigator.RoadObjectType
+import com.mapbox.navigator.UpcomingRouteAlert
 
 /**
  * Internal factory to build road objects
@@ -38,9 +39,9 @@ object RoadObjectFactory {
     }
 
     fun List<UpcomingRoadObject>.getUpdatedObjectsAhead(
-        status: com.mapbox.navigator.NavigationStatus
+        upcomingRouteAlerts: List<UpcomingRouteAlert>
     ): List<UpcomingRoadObject> {
-        val idToDistanceRemaining = status.upcomingRouteAlerts.associate {
+        val idToDistanceRemaining = upcomingRouteAlerts.associate {
             it.roadObject.id to it.distanceToStart
         }
         val updateObjects = mutableListOf<UpcomingRoadObject>()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/navigator/NavigatorMapper.kt
@@ -9,7 +9,6 @@ import com.mapbox.api.directions.v5.models.RouteLeg
 import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
-import com.mapbox.navigation.base.internal.factory.RoadObjectFactory.toUpcomingRoadObjects
 import com.mapbox.navigation.base.internal.factory.RouteLegProgressFactory.buildRouteLegProgressObject
 import com.mapbox.navigation.base.internal.factory.RouteProgressFactory.buildRouteProgressObject
 import com.mapbox.navigation.base.internal.factory.RouteStepProgressFactory.buildRouteStepProgressObject
@@ -18,6 +17,7 @@ import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.speed.model.SpeedLimit
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.base.trip.model.RouteProgressState
+import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
 import com.mapbox.navigation.base.utils.DecodeUtils.stepGeometryToPoints
 import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import com.mapbox.navigation.navigator.internal.TripStatus
@@ -44,6 +44,7 @@ internal fun getRouteProgressFrom(
     bannerInstructions: BannerInstructions?,
     instructionIndex: Int?,
     lastVoiceInstruction: VoiceInstructions?,
+    upcomingRoadObjects: List<UpcomingRoadObject>,
 ): RouteProgress? {
     return status.getRouteProgress(
         route,
@@ -51,6 +52,7 @@ internal fun getRouteProgressFrom(
         bannerInstructions,
         instructionIndex,
         lastVoiceInstruction,
+        upcomingRoadObjects,
     )
 }
 
@@ -69,6 +71,7 @@ private fun NavigationStatus.getRouteProgress(
     bannerInstructions: BannerInstructions?,
     instructionIndex: Int?,
     lastVoiceInstruction: VoiceInstructions?,
+    upcomingRoadObjects: List<UpcomingRoadObject>,
 ): RouteProgress? {
     if (routeState == RouteState.INVALID) {
         return null
@@ -188,7 +191,7 @@ private fun NavigationStatus.getRouteProgress(
             routeProgressDurationRemaining,
             routeProgressFractionTraveled,
             remainingWaypoints,
-            upcomingRouteAlerts.toUpcomingRoadObjects(),
+            upcomingRoadObjects,
             stale,
             locatedAlternativeRouteId,
             geometryIndex,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -380,7 +380,7 @@ internal class MapboxTripSession(
             val remainingWaypoints = tripStatus.calculateRemainingWaypoints()
             val latestBannerInstructionsWrapper = bannerInstructionEvent.latestInstructionWrapper
             val upcomingRoadObjects = roadObjects.getUpdatedObjectsAhead(
-                tripStatus.navigationStatus
+                tripStatus.navigationStatus.upcomingRouteAlerts
             )
             val routeProgress = getRouteProgressFrom(
                 tripStatus.route,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -8,6 +8,7 @@ import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.bindgen.Expected
 import com.mapbox.navigation.base.ExperimentalMapboxNavigationAPI
 import com.mapbox.navigation.base.internal.factory.RoadFactory
+import com.mapbox.navigation.base.internal.factory.RoadObjectFactory.getUpdatedObjectsAhead
 import com.mapbox.navigation.base.internal.factory.TripNotificationStateFactory.buildTripNotificationState
 import com.mapbox.navigation.base.internal.route.refreshNativePeer
 import com.mapbox.navigation.base.route.NavigationRoute
@@ -378,13 +379,17 @@ internal class MapboxTripSession(
             }
             val remainingWaypoints = tripStatus.calculateRemainingWaypoints()
             val latestBannerInstructionsWrapper = bannerInstructionEvent.latestInstructionWrapper
+            val upcomingRoadObjects = roadObjects.getUpdatedObjectsAhead(
+                tripStatus.navigationStatus
+            )
             val routeProgress = getRouteProgressFrom(
                 tripStatus.route,
                 tripStatus.navigationStatus,
                 remainingWaypoints,
                 latestBannerInstructionsWrapper?.latestBannerInstructions,
                 latestBannerInstructionsWrapper?.latestInstructionIndex,
-                lastVoiceInstruction
+                lastVoiceInstruction,
+                upcomingRoadObjects,
             ).also {
                 if (it == null) {
                     logD(

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/navigator/NavigatorMapperTest.kt
@@ -11,6 +11,7 @@ import com.mapbox.navigation.base.internal.factory.RouteStepProgressFactory.buil
 import com.mapbox.navigation.base.road.model.Road
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.speed.model.SpeedLimit
+import com.mapbox.navigation.base.trip.model.roadobject.UpcomingRoadObject
 import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import com.mapbox.navigation.navigator.internal.TripStatus
 import com.mapbox.navigation.testing.FileUtils
@@ -54,6 +55,7 @@ class NavigatorMapperTest {
     @Test
     fun `route progress result sanity`() {
         val bannerInstructions = navigationStatus.getCurrentBannerInstructions(route)
+        val upcomingRoadObjects = listOf<UpcomingRoadObject>(mockk())
         val expected = RouteProgressFactory.buildRouteProgressObject(
             route = route,
             bannerInstructions = bannerInstructions,
@@ -94,7 +96,7 @@ class NavigatorMapperTest {
             inTunnel = true,
             stale = true,
             remainingWaypoints = 1,
-            upcomingRoadObjects = listOf(),
+            upcomingRoadObjects = upcomingRoadObjects,
             alternativeRouteId = "alternative_id",
             currentRouteGeometryIndex = routeGeometryIndex
         )
@@ -106,6 +108,7 @@ class NavigatorMapperTest {
             bannerInstructions,
             instructionIndex = 1,
             lastVoiceInstruction = null,
+            upcomingRoadObjects,
         )
 
         assertEquals(expected, result)
@@ -443,6 +446,7 @@ class NavigatorMapperTest {
             mockk(relaxed = true),
             0,
             mockk(relaxed = true),
+            emptyList(),
         )
 
         assertNull(routeProgress)
@@ -459,6 +463,7 @@ class NavigatorMapperTest {
             mockk(relaxed = true),
             0,
             mockk(relaxed = true),
+            emptyList(),
         )
 
         assertNull(routeProgress)
@@ -473,6 +478,7 @@ class NavigatorMapperTest {
             mockk(relaxed = true),
             0,
             mockk(relaxed = true),
+            emptyList(),
         )
 
         assertNotNull(routeProgress)
@@ -488,6 +494,7 @@ class NavigatorMapperTest {
             mockk(relaxed = true),
             0,
             lastVoiceInstruction = mockk(relaxed = true),
+            emptyList(),
         )
 
         assertTrue(routeProgress!!.stale)
@@ -503,6 +510,7 @@ class NavigatorMapperTest {
             mockk(relaxed = true),
             0,
             lastVoiceInstruction = mockk(relaxed = true),
+            emptyList(),
         )
 
         assertFalse(routeProgress!!.stale)
@@ -525,6 +533,7 @@ class NavigatorMapperTest {
             mockk(relaxed = true),
             0,
             mockk(relaxed = true),
+            emptyList(),
         )
         val upcomingRouteAlerts = routeProgress!!.upcomingRoadObjects
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -184,7 +184,7 @@ class MapboxTripSessionTest {
         every { routeProgress.voiceInstructions } returns null
         every { routeProgress.currentLegProgress } returns mockk(relaxed = true)
         every {
-            getRouteProgressFrom(any(), any(), any(), any(), any(), any())
+            getRouteProgressFrom(any(), any(), any(), any(), any(), any(), any())
         } returns routeProgress
         every { routeProgress.currentState } returns RouteProgressState.TRACKING
         every { routes[0].directionsResponse.uuid() } returns "uuid"
@@ -406,7 +406,7 @@ class MapboxTripSessionTest {
 
     @Test
     fun routeProgressObserverNotCalledWhenInFreeDrive() = coroutineRule.runBlockingTest {
-        every { getRouteProgressFrom(any(), any(), any(), any(), any(), any()) } returns null
+        every { getRouteProgressFrom(any(), any(), any(), any(), any(), any(), any()) } returns null
         tripSession = buildTripSession()
         tripSession.start(true)
         val observer: RouteProgressObserver = mockk(relaxUnitFun = true)

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/trip/session/MapboxTripSessionTest.kt
@@ -1745,7 +1745,7 @@ class MapboxTripSessionTest {
 }
 
 private fun mockNavigationRoute(
-    roadObjects: List<UpcomingRoadObject> = listOf(mockk())
+    roadObjects: List<UpcomingRoadObject> = listOf(mockk(relaxed = true))
 ): NavigationRoute = mockk(relaxed = true) {
     every { upcomingRoadObjects } returns roadObjects
 }


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
This PR optimizes the way we manage `UpcomingRoadObject`s by only updating `UpcomingRoadObject#distanceToStart` while keeping the existing reference to `RoadObject` (and with it to its native peer) instead of taking the new reference provided from Nav Native. This in some situations can help with accumulation of JNI weak global references.

There more improvements that should come from Nav Native (for example avoiding copying the reference in the first place or avoiding passing the whole objects which we'd be now ignoring) but this PR is a first step that we can do in parallel.

cc @mskurydin @VysotskiVadim 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->