### PR TITLE
Fix changelog verification for changelog in ibnavui-androidauto

### DIFF
--- a/scripts/validate-changelog-tests.py
+++ b/scripts/validate-changelog-tests.py
@@ -100,6 +100,20 @@ class TestValidateChangelog(unittest.TestCase):
         '''
         validate_changelog_utils.check_has_changelog_diff(diff)
 
+    def test_check_has_changelog_diff_has_diff_auto_bugfixes(self):
+        diff = '''
+        diff --git a/libnavui-androidauto/changelog/unreleased/bugfixes/amazing-fix.md b/libnavui-androidauto/changelog/unreleased/bugfixes/amazing-fix.md
+        new file mode 100644
+        index 00000000000..c0505027151
+        --- /dev/null
+        +++ b/libnavui-androidauto/changelog/unreleased/features/amazing-fix.md
+        @@ -0,0 +1 @@
+        +- Definitely amazing fix
+        +- Nice changes 
+        \ No newline at end of file
+        '''
+        validate_changelog_utils.check_has_changelog_diff(diff)
+
     def test_parse_contents_url_empty_json(self):
         with self.assertRaises(Exception):
             validate_changelog_utils.parse_contents_url([])

--- a/scripts/validate_changelog_utils.py
+++ b/scripts/validate_changelog_utils.py
@@ -1,6 +1,6 @@
 import re
 
-changelog_diff_regex = "^([\s]*)diff --git a/changelog/unreleased/(features|bugfixes|issues|other)/(.*).md b/changelog/unreleased/(features|bugfixes|issues|other)/(.*).md"
+changelog_diff_regex = "^([\s]*)diff --git a/(libnavui-androidauto/)?changelog/unreleased/(features|bugfixes|issues|other)/(.*).md b/(libnavui-androidauto/)?changelog/unreleased/(features|bugfixes|issues|other)/(.*).md"
 changelog_diff_filename_regex = re.compile("([\s]*)diff --git a\/(.*) b\/(.*)")
 changelog_filename = "CHANGELOG.md"
 any_diff_substring = "diff --git"


### PR DESCRIPTION
The issue with the regular expression used for the changelog file path has been resolved.