### PR TITLE
Simplified metics triggering + let easily rerun failed metrics 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,7 +502,7 @@ commands:
           name: Track metrics of the Navigation SDK
           command: |
             pip3 install requests
-            python3 scripts/trigger-mobile-metrics.py
+            python3 scripts/trigger-mobile-metrics.py --token $MOBILE_METRICS_TOKEN --commits $CIRCLE_SHA1
 
   prepare-mbx-ci:
     steps:

--- a/scripts/trigger-mobile-metrics.py
+++ b/scripts/trigger-mobile-metrics.py
@@ -8,36 +8,8 @@ import json
 import requests
 import sys
 
-def TriggerWorkflow(token, commit, publish):
-    url = "https://circleci.com/api/v2/project/github/mapbox/mobile-metrics/pipeline"
-
-    headers = {
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-    }
-
-    data = {
-        "parameters": {
-          "run_android_navigation_benchmark": publish,
-          "mapbox_slug": "mapbox/mapbox-navigation-android",
-          "mapbox_hash": commit
-        }
-    }
-
-    # Use this to test your mobile-metrics branches.
-    # data["branch"]: "mobile-metrics-branch-name"
-
-    response = requests.post(url, auth=(token, ""), headers=headers, json=data)
-
-    if response.status_code != 201 and response.status_code != 200:
-      print("Error triggering the CircleCI: %s." % response.json()["message"])
-      sys.exit(1)
-    else:
-      response_dict = json.loads(response.text)
-      print("Started run_android_navigation_benchmark: %s" % response_dict)
-
 def TriggerJob(token, commit, job, publish):
-    url = "https://circleci.com/api/v1.1/project/github/mapbox/mobile-metrics/tree/vv-publish-benchmark-results-from-job"
+    url = "https://circleci.com/api/v1.1/project/github/mapbox/mobile-metrics/tree/main" 
 
     headers = {
         "Content-Type": "application/json",
@@ -47,7 +19,8 @@ def TriggerJob(token, commit, job, publish):
     data = {
         "build_parameters": {
           "CIRCLE_JOB": job,
-          "BENCHMARK_COMMIT": commit
+          "BENCHMARK_COMMIT": commit,
+          "PUBLISH_RESULTS": publish,
         }
     }
 
@@ -65,32 +38,27 @@ def Main():
   PARSER = argparse.ArgumentParser(description='Script to run mobile-metrics')
   PARSER.add_argument('--commits', help='Comma separated SHAs of the commits of the Navigation SDK against which mobile-metrics will be run', required=True)
   PARSER.add_argument('-t', '--token', help='CircleCI token which is used to start metrics', required=True)
-  PARSER.add_argument('--publish', help="A flag indicating that metrics result should be published", action="store_true",)
-  PARSER.set_defaults(publish=False)
-
+  PARSER.add_argument('--publish', help="A flag indicating that metrics result should be published. By default published for main branch.", action="store_true")
+  PARSER.add_argument('--no-publish', help="A flag indicating that metrics result should NOT be published. By default published for main branch.", action="store_false")
+  PARSER.set_defaults(publish=os.getenv("CIRCLE_BRANCH") == "main")
+  PARSER.add_argument('--performance-only', help="A flag indicating that metrics only performance metrics need to be run", action="store_true")
+  PARSER.set_defaults(performance_only=False)
   ARGS = PARSER.parse_args()
   
   token = ARGS.token
   commits = ARGS.commits
+  publishResults = ARGS.publish
+  performanceOnly = ARGS.performance_only
 
-
-  # Publish results that have been committed to the main branch.
-  # Development runs can be found in CircleCI after manually triggered.
-  #publishResults = os.getenv("CIRCLE_BRANCH") == "main"
-  #TriggerWorkflow(token, commit, True)
   for commit in commits.split(','):
-    #print(f'{token} {commit} {ARGS.publish}')
-    TriggerJob(token, commit, "android-navigation-benchmark", ARGS.publish)
-    #TriggerWorkflow(token, commit, ARGS.publish)
-#
-#
-#   if publishResults:
-#     TriggerJob(token, commit, "android-navigation-benchmark")
-#     TriggerJob(token, commit, "android-navigation-code-coverage")
-#     TriggerJob(token, commit, "android-navigation-binary-size")
-#   else:
-#     TriggerJob(token, commit, "android-navigation-code-coverage-ci")
-#     TriggerJob(token, commit, "android-navigation-binary-size-ci")
+    TriggerJob(token, commit, "android-navigation-benchmark", publishResults)
+    if not performanceOnly:
+      if publishResults:
+        TriggerJob(token, commit, "android-navigation-code-coverage", publishResults)
+        TriggerJob(token, commit, "android-navigation-binary-size", publishResults)
+      else:
+        TriggerJob(token, commit, "android-navigation-code-coverage-ci", publishResults)
+        TriggerJob(token, commit, "android-navigation-binary-size-ci", publishResults)
 
   return 0
 


### PR DESCRIPTION
### Description

I need to rerun a bunch of failed metrics after those tests were fixed. I modified script that triggers and decided to contribute it back.

The scrip used to trigger worflow(which reports results) and job (which didn't). We used to run metrics 2 times on each commit. I replaced this flow by triggering job only with passing parameters.

See linked PR in metrics repo 