### PR TITLE
Fixed double metrics triggering

### DIFF
--- a/scripts/trigger-mobile-metrics.py
+++ b/scripts/trigger-mobile-metrics.py
@@ -74,7 +74,6 @@ def Main():
   TriggerWorkflow(token, commit, publishResults)
 
   if publishResults:
-    TriggerJob(token, commit, "android-navigation-benchmark")
     TriggerJob(token, commit, "android-navigation-code-coverage")
     TriggerJob(token, commit, "android-navigation-binary-size")
   else:

--- a/scripts/trigger-mobile-metrics.py
+++ b/scripts/trigger-mobile-metrics.py
@@ -77,6 +77,7 @@ def Main():
     TriggerJob(token, commit, "android-navigation-code-coverage")
     TriggerJob(token, commit, "android-navigation-binary-size")
   else:
+    TriggerJob(token, commit, "android-navigation-benchmark")
     TriggerJob(token, commit, "android-navigation-code-coverage-ci")
     TriggerJob(token, commit, "android-navigation-binary-size-ci")
 


### PR DESCRIPTION
It makes sense to start the job `android-navigation-benchmark` only if we don't want to publish results, as the job doesn't publish results.

We already start workflow for results publishing with flag  `run_android_navigation_benchmark`, so the job, just waste device farm resources.