### PR TITLE
Change pipeline parameters for trigger metrics script

### DIFF
--- a/scripts/trigger-mobile-metrics.py
+++ b/scripts/trigger-mobile-metrics.py
@@ -17,7 +17,8 @@ def TriggerWorkflow(token, commit, publish):
 
     data = {
         "parameters": {
-          "run_android_navigation_benchmark": publish,
+          "run_android_navigation_benchmark": True,
+          "publish_android_navigation_benchmark": publish,
           "mapbox_slug": "mapbox/mapbox-navigation-android",
           "mapbox_hash": commit
         }
@@ -77,7 +78,6 @@ def Main():
     TriggerJob(token, commit, "android-navigation-code-coverage")
     TriggerJob(token, commit, "android-navigation-binary-size")
   else:
-    TriggerJob(token, commit, "android-navigation-benchmark")
     TriggerJob(token, commit, "android-navigation-code-coverage-ci")
     TriggerJob(token, commit, "android-navigation-binary-size-ci")
 

--- a/scripts/trigger-mobile-metrics.py
+++ b/scripts/trigger-mobile-metrics.py
@@ -20,7 +20,7 @@ def TriggerWorkflow(token, commit, publish):
           "run_android_navigation_benchmark": True,
           "publish_android_navigation_benchmark": publish,
           "mapbox_slug": "mapbox/mapbox-navigation-android",
-          "mapbox_hash": commit
+          "navigation_sdk_commit_hash": commit
         }
     }
 


### PR DESCRIPTION
## Trigger mobile metrics script runs:

- in **default** workflow by **mobile-metrics-dry-run** approval
- in **release-workflow** in **release-snapshot** job (by **release-snapshot-start** approval or automatically on main and release branches)

## How trigger mobile metrics script worked before these changes:

### On main branch:
- trigger workflow with parameter **run_android_navigation_benchmark** which runs **android_navigation_benchmark-workflow** with executing **publish-android-navigation-results** command

### On other branches:
- trigger workflow without parameter **run_android_navigation_benchmark** which runs **default** workflow (like we do any changes in mobile-metrics project)
- trigger **android-navigation-benchmark** job without executing **publish-android-navigation-results** command

## How trigger mobile metrics script will work after these changes:

### On main branch:
- trigger workflow with parameters **run_android_navigation_benchmark** and **publish_android_navigation_benchmark** which runs **android_navigation_benchmark-workflow** with executing **publish-android-navigation-results** command (same as previous variant)

### On other branches:
- trigger workflow with parameter **run_android_navigation_benchmark** which runs **android_navigation_benchmark-workflow** without executing **publish-android-navigation-results** command