### PR TITLE
bump Navigation and Search versions in Android Auto

### DIFF
--- a/android-auto-app/build.gradle
+++ b/android-auto-app/build.gradle
@@ -72,8 +72,8 @@ dependencies {
     // This example is used for development so it may depend on unstable versions.
     // Examples based on final versions can be found in the examples repository.
     //   https://github.com/mapbox/mapbox-navigation-android-examples
-    implementation("com.mapbox.navigation:ui-dropin:2.10.0-rc.1")
-    implementation("com.mapbox.search:mapbox-search-android:1.0.0-beta.42")
+    implementation("com.mapbox.navigation:ui-dropin:2.10.3")
+    implementation("com.mapbox.search:mapbox-search-android:1.0.0-rc.1")
 
     // Dependencies needed for this example.
     implementation dependenciesList.androidXCore

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,7 +26,7 @@ ext {
       mapboxAnnotationPlugin    : '0.8.0',
       mapboxBaseAndroid         : '0.8.0',
       mapboxMapsAndroidAuto     : '0.5.0',
-      mapboxSearchAndroidAuto   : '1.0.0-beta.44',
+      mapboxSearchAndroidAuto   : '1.0.0-rc.1',
       androidXLifecycle         : '2.4.0',
       androidXCoreVersion       : '1.6.0',
       androidXArchCoreVersion   : '2.1.0',

--- a/libnavui-androidauto/build.gradle
+++ b/libnavui-androidauto/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     // This defines the minimum version of Navigation which is included in this SDK. To upgrade the
     // Navigation versions, you can specify a newer version in your downstream build.gradle.
-    api("com.mapbox.navigation:android:2.10.1")
+    api("com.mapbox.navigation:android:2.10.3")
 
     // Search is currently in beta so it is not included in this SDK. The functionality of search
     // is included behind this library's api.

--- a/libnavui-androidauto/changelog/unreleased/bugfixes/7000.md
+++ b/libnavui-androidauto/changelog/unreleased/bugfixes/7000.md
@@ -1,0 +1,1 @@
+- Bumped Navigation and Search versions to 2.10.3 and 1.0.0-rc.1 respectively.

--- a/libnavui-androidauto/src/main/java/com/mapbox/androidauto/internal/search/FavoritesApi.kt
+++ b/libnavui-androidauto/src/main/java/com/mapbox/androidauto/internal/search/FavoritesApi.kt
@@ -6,8 +6,8 @@ import com.mapbox.androidauto.search.PlaceRecord
 import com.mapbox.androidauto.search.PlaceRecordMapper
 import com.mapbox.bindgen.Expected
 import com.mapbox.bindgen.ExpectedFactory
-import com.mapbox.search.CompletionCallback
 import com.mapbox.search.common.AsyncOperationTask
+import com.mapbox.search.common.CompletionCallback
 import com.mapbox.search.record.FavoriteRecord
 import com.mapbox.search.record.FavoritesDataProvider
 import kotlin.coroutines.resume

--- a/libnavui-androidauto/src/test/java/com/mapbox/androidauto/search/FavoritesApiTest.kt
+++ b/libnavui-androidauto/src/test/java/com/mapbox/androidauto/search/FavoritesApiTest.kt
@@ -3,8 +3,8 @@ package com.mapbox.androidauto.search
 import com.mapbox.androidauto.internal.search.FavoritesApi
 import com.mapbox.geojson.Point
 import com.mapbox.navigation.testing.MainCoroutineRule
-import com.mapbox.search.CompletionCallback
 import com.mapbox.search.common.AsyncOperationTask
+import com.mapbox.search.common.CompletionCallback
 import com.mapbox.search.record.FavoriteRecord
 import com.mapbox.search.record.FavoritesDataProvider
 import com.mapbox.search.result.SearchResultType


### PR DESCRIPTION
We have to bump Search version in Android Auto because of the breaking changes which cause 1TAP to crash. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
