### PR TITLE
show a spinner in route preview screen when there are no routes

### DIFF
--- a/libnavui-androidauto/changelog/unreleased/bugfixes/7014.md
+++ b/libnavui-androidauto/changelog/unreleased/bugfixes/7014.md
@@ -1,0 +1,1 @@
+- Fixed an issue with the experimental route preview screen that caused template restrictions violations.


### PR DESCRIPTION
### Description
Previous behavior was to show an empty list first and then show the routes when they are available. From Android Auto's point of view this is considered a full screen update, which in some cases violate template restrictions. If we show a spinner instead of an empty list, Android Auto will consider it a refresh, which does not violate said restrictions. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
