### PR TITLE
More logs in case of native status processing failure

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -345,12 +345,12 @@ internal class MapboxTripSession(
                 processNativeStatus(status)
             } catch (error: Throwable) {
                 logE(LOG_CATEGORY) {
-                    "Error processing onStatus: origin: $origin, status: $status. \n" +
-                        "$error" +
-                        "MapboxTripSession state:\n" +
-                        "isUpdatingRoute=$isUpdatingRoute, primaryRoute:${primaryRoute?.id}"
+                    "Error processing native status update: origin=$origin, status=$status.\n" +
+                        "Error: $error\n" +
+                        "MapboxTripSession state: " +
+                        "isUpdatingRoute=$isUpdatingRoute, primaryRoute=${primaryRoute?.id}"
                 }
-                throw error
+                throw NativeStatusProcessingError(error)
             }
         }
     }
@@ -780,3 +780,6 @@ internal class MapboxTripSession(
         }
     }
 }
+
+private class NativeStatusProcessingError(cause: Throwable) :
+    Throwable("Error processing native status update", cause)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -34,6 +34,8 @@ import com.mapbox.navigation.utils.internal.JobControl
 import com.mapbox.navigation.utils.internal.ThreadController
 import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.navigation.utils.internal.logD
+import com.mapbox.navigation.utils.internal.logE
+import com.mapbox.navigation.utils.internal.logI
 import com.mapbox.navigation.utils.internal.logW
 import com.mapbox.navigator.FallbackVersionsObserver
 import com.mapbox.navigator.NavigationStatus
@@ -83,7 +85,7 @@ internal class MapboxTripSession(
             "routes update (reason: ${setRoutes.mapToReason()}, " +
                 "route IDs: ${routes.map { it.id }}) $suffix"
         }
-        logD(LOG_CATEGORY, logMessage("- starting"))
+        logI(LOG_CATEGORY, logMessage("- starting"))
 
         val result = when (setRoutes) {
             is SetRoutes.CleanUp -> {
@@ -158,7 +160,7 @@ internal class MapboxTripSession(
                 }
             }
         }
-        logD(LOG_CATEGORY, logMessage("- finished"))
+        logI(LOG_CATEGORY, logMessage("- finished"))
         return result
     }
 
@@ -339,65 +341,17 @@ internal class MapboxTripSession(
     @OptIn(ExperimentalMapboxNavigationAPI::class)
     private val navigatorObserver = object : NavigatorObserver {
         override fun onStatus(origin: NavigationStatusOrigin, status: NavigationStatus) {
-            logD(
-                "navigatorObserver#onStatus; " +
-                    "fixLocation elapsed time: ${status.location.monotonicTimestampNanoseconds}, " +
-                    "state: ${status.routeState}",
-                LOG_CATEGORY
-            )
-            logD(LOG_CATEGORY) {
-                "navigatorObserver#onStatus; banner instruction: [${status.bannerInstruction}]," +
-                    " voice instruction: [${status.voiceInstruction}]"
-            }
-
-            val tripStatus = status.getTripStatusFrom(primaryRoute)
-            val enhancedLocation = tripStatus.navigationStatus.location.toLocation()
-            val keyPoints = tripStatus.navigationStatus.keyPoints.toLocations()
-            val road = RoadFactory.buildRoadObject(tripStatus.navigationStatus)
-            updateLocationMatcherResult(
-                tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
-            )
-            zLevel = status.layer
-
-            // we should skip RouteProgress, BannerInstructions, isOffRoute state updates while
-            // setting a new route
-            if (isUpdatingRoute) {
-                logD("route progress update dropped - updating routes", LOG_CATEGORY)
-                return
-            }
-
-            var triggerObserver = false
-            if (tripStatus.navigationStatus.routeState != RouteState.INVALID) {
-                val nativeBannerInstruction = tripStatus.navigationStatus.bannerInstruction
-                val bannerInstructions =
-                    tripStatus.navigationStatus.getCurrentBannerInstructions(primaryRoute)
-                triggerObserver = bannerInstructionEvent.isOccurring(
-                    bannerInstructions,
-                    nativeBannerInstruction?.index
-                )
-            }
-            val remainingWaypoints = tripStatus.calculateRemainingWaypoints()
-            val latestBannerInstructionsWrapper = bannerInstructionEvent.latestInstructionWrapper
-            val routeProgress = getRouteProgressFrom(
-                tripStatus.route,
-                tripStatus.navigationStatus,
-                remainingWaypoints,
-                latestBannerInstructionsWrapper?.latestBannerInstructions,
-                latestBannerInstructionsWrapper?.latestInstructionIndex,
-                lastVoiceInstruction
-            ).also {
-                if (it == null) {
-                    logD(
-                        "route progress update dropped - " +
-                            "currentPrimaryRoute ID: ${primaryRoute?.id}; " +
-                            "currentState: ${status.routeState}",
-                        LOG_CATEGORY
-                    )
+            try {
+                processNativeStatus(status)
+            } catch (error: Throwable) {
+                logE(LOG_CATEGORY) {
+                    "Error processing onStatus: origin: $origin, status: $status. \n" +
+                        "$error" +
+                        "MapboxTripSession state:\n" +
+                        "isUpdatingRoute=$isUpdatingRoute, primaryRoute:${primaryRoute?.id}"
                 }
+                throw error
             }
-            updateRouteProgress(routeProgress, triggerObserver)
-            triggerVoiceInstructionEvent(routeProgress, status)
-            isOffRoute = tripStatus.navigationStatus.routeState == RouteState.OFF_ROUTE
         }
     }
 
@@ -679,6 +633,69 @@ internal class MapboxTripSession(
     private fun updateLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
         this.locationMatcherResult = locationMatcherResult
         locationObservers.forEach { it.onNewLocationMatcherResult(locationMatcherResult) }
+    }
+
+    @OptIn(ExperimentalMapboxNavigationAPI::class)
+    private fun processNativeStatus(status: NavigationStatus) {
+        logD(
+            "navigatorObserver#onStatus; " +
+                "fixLocation elapsed time: ${status.location.monotonicTimestampNanoseconds}, " +
+                "state: ${status.routeState}",
+            LOG_CATEGORY
+        )
+        logD(LOG_CATEGORY) {
+            "navigatorObserver#onStatus; banner instruction: [${status.bannerInstruction}]," +
+                " voice instruction: [${status.voiceInstruction}]"
+        }
+
+        val tripStatus = status.getTripStatusFrom(primaryRoute)
+        val enhancedLocation = tripStatus.navigationStatus.location.toLocation()
+        val keyPoints = tripStatus.navigationStatus.keyPoints.toLocations()
+        val road = RoadFactory.buildRoadObject(tripStatus.navigationStatus)
+        updateLocationMatcherResult(
+            tripStatus.getLocationMatcherResult(enhancedLocation, keyPoints, road)
+        )
+        zLevel = status.layer
+
+        // we should skip RouteProgress, BannerInstructions, isOffRoute state updates while
+        // setting a new route
+        if (isUpdatingRoute) {
+            logD("route progress update dropped - updating routes", LOG_CATEGORY)
+            return
+        }
+
+        var triggerObserver = false
+        if (tripStatus.navigationStatus.routeState != RouteState.INVALID) {
+            val nativeBannerInstruction = tripStatus.navigationStatus.bannerInstruction
+            val bannerInstructions =
+                tripStatus.navigationStatus.getCurrentBannerInstructions(primaryRoute)
+            triggerObserver = bannerInstructionEvent.isOccurring(
+                bannerInstructions,
+                nativeBannerInstruction?.index
+            )
+        }
+        val remainingWaypoints = tripStatus.calculateRemainingWaypoints()
+        val latestBannerInstructionsWrapper = bannerInstructionEvent.latestInstructionWrapper
+        val routeProgress = getRouteProgressFrom(
+            tripStatus.route,
+            tripStatus.navigationStatus,
+            remainingWaypoints,
+            latestBannerInstructionsWrapper?.latestBannerInstructions,
+            latestBannerInstructionsWrapper?.latestInstructionIndex,
+            lastVoiceInstruction
+        ).also {
+            if (it == null) {
+                logD(
+                    "route progress update dropped - " +
+                        "currentPrimaryRoute ID: ${primaryRoute?.id}; " +
+                        "currentState: ${status.routeState}",
+                    LOG_CATEGORY
+                )
+            }
+        }
+        updateRouteProgress(routeProgress, triggerObserver)
+        triggerVoiceInstructionEvent(routeProgress, status)
+        isOffRoute = tripStatus.navigationStatus.routeState == RouteState.OFF_ROUTE
     }
 
     private fun updateRouteProgress(


### PR DESCRIPTION
### Description
Sometimes customers reports don't include debug logs. It's challenging to figure out what went with current level of info logging. 
Set route is complex and rather rare procedure, it seems okay to log it on info level. 
I also added more logs in case of exception during route status processing.