### PR TITLE
MapboxNavigationViewportDataSourceOptions: make constructors of inner classes public

### DIFF
--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -210,6 +210,7 @@ package com.mapbox.navigation.ui.maps.camera {
 package com.mapbox.navigation.ui.maps.camera.data {
 
   public final class FollowingFrameOptions {
+    ctor public FollowingFrameOptions();
     method public com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions.BearingSmoothing getBearingSmoothing();
     method public boolean getBearingUpdatesAllowed();
     method public boolean getCenterUpdatesAllowed();
@@ -251,6 +252,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
   }
 
   public static final class FollowingFrameOptions.BearingSmoothing {
+    ctor public FollowingFrameOptions.BearingSmoothing();
     method public boolean getEnabled();
     method public double getMaxBearingAngleDiff();
     method public void setEnabled(boolean);
@@ -271,6 +273,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
   }
 
   public static final class FollowingFrameOptions.FrameGeometryAfterManeuver {
+    ctor public FollowingFrameOptions.FrameGeometryAfterManeuver();
     method public double getDistanceToCoalesceCompoundManeuvers();
     method public double getDistanceToFrameAfterManeuver();
     method public boolean getEnabled();
@@ -283,6 +286,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
   }
 
   public static final class FollowingFrameOptions.IntersectionDensityCalculation {
+    ctor public FollowingFrameOptions.IntersectionDensityCalculation();
     method public double getAverageDistanceMultiplier();
     method public boolean getEnabled();
     method public double getMinimumDistanceBetweenIntersections();
@@ -295,6 +299,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
   }
 
   public static final class FollowingFrameOptions.PitchNearManeuvers {
+    ctor public FollowingFrameOptions.PitchNearManeuvers();
     method public boolean getEnabled();
     method public java.util.List<java.lang.String> getExcludedManeuvers();
     method public double getTriggerDistanceFromManeuver();
@@ -345,11 +350,14 @@ package com.mapbox.navigation.ui.maps.camera.data {
   public final class MapboxNavigationViewportDataSourceOptions {
     method public com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions getFollowingFrameOptions();
     method public com.mapbox.navigation.ui.maps.camera.data.OverviewFrameOptions getOverviewFrameOptions();
+    method public void setFollowingFrameOptions(com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions);
+    method public void setOverviewFrameOptions(com.mapbox.navigation.ui.maps.camera.data.OverviewFrameOptions);
     property public final com.mapbox.navigation.ui.maps.camera.data.FollowingFrameOptions followingFrameOptions;
     property public final com.mapbox.navigation.ui.maps.camera.data.OverviewFrameOptions overviewFrameOptions;
   }
 
   public final class OverviewFrameOptions {
+    ctor public OverviewFrameOptions();
     method public boolean getBearingUpdatesAllowed();
     method public boolean getCenterUpdatesAllowed();
     method public com.mapbox.navigation.ui.maps.camera.data.OverviewFrameOptions.GeometrySimplification getGeometrySimplification();
@@ -373,6 +381,7 @@ package com.mapbox.navigation.ui.maps.camera.data {
   }
 
   public static final class OverviewFrameOptions.GeometrySimplification {
+    ctor public OverviewFrameOptions.GeometrySimplification();
     method public boolean getEnabled();
     method public int getSimplificationFactor();
     method public void setEnabled(boolean);
@@ -1394,19 +1403,24 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   public final class RouteLineUpdateValue {
     method public java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData> getAlternativeRouteLinesDynamicData();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData getPrimaryRouteLineDynamicData();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData? getRouteLineMaskingLayerDynamicData();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue.MutableRouteLineUpdateValue toMutableValue();
     property public final java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData> alternativeRouteLinesDynamicData;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData primaryRouteLineDynamicData;
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData? routeLineMaskingLayerDynamicData;
   }
 
   public static final class RouteLineUpdateValue.MutableRouteLineUpdateValue {
     method public java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData> getAlternativeRouteLinesDynamicData();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData getPrimaryRouteLineDynamicData();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData? getRouteLineMaskingLayerDynamicData();
     method public void setAlternativeRouteLinesDynamicData(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData>);
     method public void setPrimaryRouteLineDynamicData(com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData);
+    method public void setRouteLineMaskingLayerDynamicData(com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData?);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineUpdateValue toImmutableValue();
     property public final java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData> alternativeRouteLinesDynamicData;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData primaryRouteLineDynamicData;
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData? routeLineMaskingLayerDynamicData;
   }
 
   public final class RouteNotFound {
@@ -1419,23 +1433,28 @@ package com.mapbox.navigation.ui.maps.route.line.model {
   public final class RouteSetValue {
     method public java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineData> getAlternativeRouteLinesData();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineData getPrimaryRouteLineData();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData? getRouteLineMaskingLayerDynamicData();
     method public com.mapbox.geojson.FeatureCollection getWaypointsSource();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue.MutableRouteSetValue toMutableValue();
     property public final java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineData> alternativeRouteLinesData;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineData primaryRouteLineData;
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData? routeLineMaskingLayerDynamicData;
     property public final com.mapbox.geojson.FeatureCollection waypointsSource;
   }
 
   public static final class RouteSetValue.MutableRouteSetValue {
     method public java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineData> getAlternativeRouteLinesData();
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineData getPrimaryRouteLineData();
+    method public com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData? getRouteLineMaskingLayerDynamicData();
     method public com.mapbox.geojson.FeatureCollection getWaypointsSource();
     method public void setAlternativeRouteLinesData(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineData>);
     method public void setPrimaryRouteLineData(com.mapbox.navigation.ui.maps.route.line.model.RouteLineData);
+    method public void setRouteLineMaskingLayerDynamicData(com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData?);
     method public void setWaypointsSource(com.mapbox.geojson.FeatureCollection);
     method public com.mapbox.navigation.ui.maps.route.line.model.RouteSetValue toImmutableValue();
     property public final java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteLineData> alternativeRouteLinesData;
     property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineData primaryRouteLineData;
+    property public final com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData? routeLineMaskingLayerDynamicData;
     property public final com.mapbox.geojson.FeatureCollection waypointsSource;
   }
 

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/data/MapboxNavigationViewportDataSourceOptions.kt
@@ -11,18 +11,18 @@ class MapboxNavigationViewportDataSourceOptions internal constructor() {
     /**
      * Options that impact generation of following frames.
      */
-    val followingFrameOptions = FollowingFrameOptions()
+    var followingFrameOptions = FollowingFrameOptions()
 
     /**
      * Options that impact generation of overview frames.
      */
-    val overviewFrameOptions = OverviewFrameOptions()
+    var overviewFrameOptions = OverviewFrameOptions()
 }
 
 /**
  * Options that impact the generation of the following frame.
  */
-class FollowingFrameOptions internal constructor() {
+class FollowingFrameOptions {
 
     /**
      * The default pitch that will be generated for following camera frames.
@@ -148,7 +148,7 @@ class FollowingFrameOptions internal constructor() {
      *
      * By default we frame the whole remainder of the step while the options here shrink that geometry to increase the zoom level.
      */
-    class IntersectionDensityCalculation internal constructor() {
+    class IntersectionDensityCalculation {
         /**
          * **Preconditions**:
          * - a route is provided via [MapboxNavigationViewportDataSource.onRouteChanged]
@@ -184,7 +184,7 @@ class FollowingFrameOptions internal constructor() {
     /**
      * Options that modify the framed route geometries when approaching a maneuver.
      */
-    class PitchNearManeuvers internal constructor() {
+    class PitchNearManeuvers {
         /**
          * **Preconditions**:
          * - a route is provided via [MapboxNavigationViewportDataSource.onRouteChanged]
@@ -223,7 +223,7 @@ class FollowingFrameOptions internal constructor() {
     /**
      * Options that modify the framed route geometries by appending additional points after maneuver to extend the view.
      */
-    class FrameGeometryAfterManeuver internal constructor() {
+    class FrameGeometryAfterManeuver {
         /**
          * **Preconditions**:
          * - a route is provided via [MapboxNavigationViewportDataSource.onRouteChanged]
@@ -258,7 +258,7 @@ class FollowingFrameOptions internal constructor() {
     /**
      * Options that impact bearing generation to not be fixed to location's bearing but also taking into the direction to the upcoming maneuver.
      */
-    class BearingSmoothing internal constructor() {
+    class BearingSmoothing {
         /**
          * If enabled, the **following frame**'s bearing won't exactly reflect the bearing returned by the [Location] from [MapboxNavigationViewportDataSource.onLocationChanged]
          * but will also be affected by the direction to the upcoming framed geometry, to maximize the viewable area.
@@ -296,7 +296,7 @@ class FollowingFrameOptions internal constructor() {
 /**
  * Options that impact the generation of the overview frame.
  */
-class OverviewFrameOptions internal constructor() {
+class OverviewFrameOptions {
 
     /**
      * The max zoom that will be generated for camera overview frames.
@@ -367,7 +367,7 @@ class OverviewFrameOptions internal constructor() {
      *
      * Simplifying geometries, especially for longer routes, can have a significant impact on the performance of generating frames and each [MapboxNavigationViewportDataSource.evaluate] calls.
      */
-    class GeometrySimplification internal constructor() {
+    class GeometrySimplification {
 
         /**
          * **Preconditions**:


### PR DESCRIPTION
### Description
MapboxNavigationViewportDataSourceOptions: make constructors of inner classes public. It allows easy-to-resolve and holds options at the app level 

ref https://github.com/mapbox/gm-navigation-app/pull/5974#discussion_r1132536476

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
