### PR TITLE
[NAVAND-1144] Apply 'MapboxRouteLineOptions' changes without rebuilding geometries

### DIFF
--- a/changelog/unreleased/bugfixes/7043.md
+++ b/changelog/unreleased/bugfixes/7043.md
@@ -1,0 +1,1 @@
+- Improved `MapboxRouteLineView` to prevent a flash of rendered route geometries on the map when the view instance is recreated to apply new `MapboxRouteLineOptions`.

--- a/libnavui-maps/api/current.txt
+++ b/libnavui-maps/api/current.txt
@@ -1108,7 +1108,7 @@ package com.mapbox.navigation.ui.maps.route.line.model {
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder vanishingRouteLineUpdateInterval(long interval = 62500000L);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder waypointLayerIconAnchor(com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor iconAnchor = com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor.CENTER);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder waypointLayerIconOffset(java.util.List<java.lang.Double> iconOffset = listOf(0.0, 0.0));
-    method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineBelowLayerId(String layerId);
+    method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineBelowLayerId(String? layerId);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteLineResources(com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources resourceProvider);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withRouteStyleDescriptors(java.util.List<com.mapbox.navigation.ui.maps.route.line.model.RouteStyleDescriptor> routeStyleDescriptors);
     method public com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions.Builder withTolerance(double tolerance);

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineView.kt
@@ -1106,24 +1106,7 @@ class MapboxRouteLineView(options: MapboxRouteLineOptions) {
     }
 
     private fun resetLayers(style: Style) {
-        sourceToFeatureMap.clear()
-        sourceToFeatureMap[MapboxRouteLineUtils.layerGroup1SourceKey] = RouteLineFeatureId(null)
-        sourceToFeatureMap[MapboxRouteLineUtils.layerGroup2SourceKey] = RouteLineFeatureId(null)
-        sourceToFeatureMap[MapboxRouteLineUtils.layerGroup3SourceKey] = RouteLineFeatureId(null)
-        primaryRouteLineLayerGroup = setOf()
-        listOf(
-            RouteLayerConstants.LAYER_GROUP_1_SOURCE_ID,
-            RouteLayerConstants.LAYER_GROUP_2_SOURCE_ID,
-            RouteLayerConstants.LAYER_GROUP_3_SOURCE_ID,
-            RouteLayerConstants.WAYPOINT_SOURCE_ID
-        ).forEach {
-            updateSource(
-                style,
-                it,
-                FeatureCollection.fromFeatures(listOf())
-            )
-        }
-        MapboxRouteLineUtils.removeLayersAndSources(style)
+        MapboxRouteLineUtils.removeLayers(style)
         MapboxRouteLineUtils.initializeLayers(style, options)
     }
 }

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/route/line/model/MapboxRouteLineOptions.kt
@@ -264,7 +264,7 @@ class MapboxRouteLineOptions private constructor(
          *
          * @return the builder
          */
-        fun withRouteLineBelowLayerId(layerId: String): Builder =
+        fun withRouteLineBelowLayerId(layerId: String?): Builder =
             apply { this.routeLineBelowLayerId = layerId }
 
         /**


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
This PR fixes an issue where updating `MapboxRouteLineOptions` (for example to change the color or position of the route in the map layers stack) would fully recreate the backing GeoJSON source, leading to a brief "flash" of the route line on the map.

I found out that we can still freely remove and re-add the layers, as long as it happens synchronously in the same code block GL-Native optimizes the operation and layers persist. Same is not true for sources because async operations to rebuild the source prevent changes from being applied synchronously (and rightfully so), that's why the approach I took is to persist the `GeoJsonSource` instance if no of the options impacting the source have changed.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->

Here's a quick comparison, on each click I change the map style, route's position (either below or above the road labels / puck) and the route color (from blue to red).

_before_

https://user-images.githubusercontent.com/16925074/226363607-cb8584dc-148e-4e8d-b172-1b5ff72ef451.mp4

_after_

https://user-images.githubusercontent.com/16925074/226363645-a2e216c5-144e-46f3-88a4-9a100e582558.mp4


Example code of the transitions above:
```kotlin
binding.mapView.gestures.addOnMapClickListener {
    flag = !flag
    binding.mapView.getMapboxMap().loadStyleUri(
        if (flag) {
            NavigationStyles.NAVIGATION_NIGHT_STYLE
        } else {
            NavigationStyles.NAVIGATION_DAY_STYLE
        }
    ) { style ->
        val options = MapboxRouteLineOptions.Builder(this)
            .withRouteLineResources(
                RouteLineResources.Builder()
                    .routeLineColorResources(
                        RouteLineColorResources.Builder()
                            .routeLowCongestionColor(Color.TRANSPARENT)
                            .routeUnknownCongestionColor(Color.TRANSPARENT)
                            .routeDefaultColor(
                                if (flag)
                                    Color.RED
                                else
                                    RouteLineColorResources.Builder().build().routeDefaultColor
                            )
                            .build()
                    ).build()
            )
            .withRouteLineBelowLayerId(
                if (flag)
                    "road-label-navigation"
                else
                    null
            )
            .withVanishingRouteLineEnabled(true)
            .displayRestrictedRoadSections(true)
            .build()
        val offset = routeLineApi.getVanishPointOffset()
        routeLineApi = MapboxRouteLineApi(options)
        routeLineView = MapboxRouteLineView(options)
        CoroutineScope(Dispatchers.Main).launch {
            routeLineApi.setNavigationRoutes(
                mapboxNavigation.getNavigationRoutes(),
                mapboxNavigation.getAlternativeMetadataFor(mapboxNavigation.getNavigationRoutes())
            ).let {
                routeLineView.renderRouteDrawData(style, it)
            }
            routeLineApi.setVanishingOffset(offset).let {
                routeLineView.renderRouteLineUpdate(style, it)
            }
        }
    }
    true
}
```
<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
