### PR TITLE
Weekly snapshot workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,14 @@ workflows:
             - unit-tests-ui
             - unit-tests-core
   weekly-snapshot-workflow:
+    # Run workflow every Wednesday at 12pm UTC
+    triggers:
+      - schedule:
+          cron: "0 12 * * 3"
+          filters:
+            branches:
+              only:
+                - develop
     jobs:
       - release-weekly-snapshot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,9 @@ workflows:
           requires:
             - unit-tests-ui
             - unit-tests-core
+  weekly-snapshot-workflow:
+    jobs:
+      - release-weekly-snapshot
 
 #------------------------------
 #---------- COMMANDS ----------
@@ -504,6 +507,12 @@ commands:
             pip3 install requests
             python3 scripts/trigger-mobile-metrics.py
 
+  trigger-onetap:
+    steps:
+      - run:
+          name: Trigger onetap
+          command: python3 scripts/trigger-onetap.py
+
   prepare-mbx-ci:
     steps:
       - run:
@@ -517,6 +526,12 @@ commands:
           name: Obtain AWS credentials
           command: |
             ./mbx-ci aws setup
+
+  checkout-branch:
+    steps:
+      - run:
+          name: Checkout branch
+          command: python3 scripts/checkout-branch.py
 
 #--------------------------
 #---------- JOBS ----------
@@ -629,7 +644,7 @@ jobs:
             - verify-codestyle
             - verify-license
             #disabled to bring common 23.3.1 on top of 23.3.1-rc.1
-#            - verify-common-sdk-version
+            #            - verify-common-sdk-version
             - check-api-core
             - check-api-ui
             - check-api-androidauto
@@ -789,6 +804,24 @@ jobs:
       - setup-aws-credentials
       - upload-artifacts-snapshot
       - trigger-mobile-metrics
+
+  release-weekly-snapshot:
+    executor: ndk-r22-latest-executor
+    resource_class: medium+
+    # Allow snapshot repository for snapshot releases
+    environment:
+      ALLOW_SNAPSHOT_REPOSITORY: true
+      WEEKLY_SNAPSHOT_WORKFLOW: true
+    steps:
+      - checkout
+      - checkout-branch
+      - assemble-core-release
+      - assemble-ui-release
+      - prepare-mbx-ci
+      - setup-aws-credentials
+      - upload-artifacts-snapshot
+      - trigger-mobile-metrics
+      - trigger-onetap
 
   release:
     executor: ndk-r22-latest-executor

--- a/gradle/artifact-settings.gradle
+++ b/gradle/artifact-settings.gradle
@@ -54,7 +54,10 @@ def getSnapshotVersion(String version) {
             minor += 1
         }
         def branch = System.getenv("CIRCLE_BRANCH")
-        if (!branch || branch == "main" || branch ==~ /release-v.*/) {
+        def weeklyWorkflow = System.getenv("WEEKLY_SNAPSHOT_WORKFLOW")?.toBoolean() ?: false
+        if (weeklyWorkflow) {
+            return "${major}.${minor}.${patch}-WEEKLY-SNAPSHOT"
+        } else if (!branch || branch == "main" || branch ==~ /release-v.*/) {
             return "${major}.${minor}.${patch}-SNAPSHOT"
         } else {
             return "${major}.${minor}.${patch}-${branch}-SNAPSHOT"

--- a/scripts/checkout-branch.py
+++ b/scripts/checkout-branch.py
@@ -1,0 +1,23 @@
+import subprocess
+
+import requests
+
+tags = requests.get('https://api.github.com/repos/mapbox/mapbox-navigation-android/git/refs/tags').json()
+
+for tag in reversed(tags):
+    tag_name = tag['ref'].replace('refs/tags/', '')
+    if tag_name.startswith('v') and tag_name.partition('-')[0].endswith('.0'):
+        latest_no_patch_tag = tag_name
+        break
+print('Latest no-patch release is ' + latest_no_patch_tag)
+
+branch_name = 'release-' + latest_no_patch_tag.partition('.0')[0]
+print('Checking if ' + branch_name + ' branch exists...')
+
+branch_response = requests.get('https://api.github.com/repos/mapbox/mapbox-navigation-android/branches/' + branch_name)
+
+if branch_response.ok:
+    print(branch_name + ' exists. Checking out...')
+    subprocess.run("git checkout $release_branch", shell=True, check=True)
+else:
+    print(branch_name + ' does not exist.')

--- a/scripts/trigger-onetap.py
+++ b/scripts/trigger-onetap.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import sys
+
+import requests
+
+token = os.getenv("CIRCLE_TOKEN")
+
+last_release = str(subprocess.run("git describe --tag --match 'v*' --abbrev=0", shell=True, capture_output=True,
+                                  text=True).stdout).strip()
+print("Last release " + last_release)
+
+release_main_part = last_release.partition('-')[0]
+snapshot_name = release_main_part + "-WEEKLY-SNAPSHOT"
+print("Snapshot name " + snapshot_name)
+
+if token is None:
+    print("Error triggering because CIRCLE_TOKEN is not set")
+    sys.exit(1)
+
+url = "https://circleci.com/api/v2/project/github/mapbox/1tap-android/pipeline"
+
+headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+}
+
+data = {
+    "parameters": {
+        "run_weekly_snapshot": True,
+        "navigation_sdk_snapshot_version": snapshot_name
+    }
+}
+
+response = requests.post(url, auth=(token, ""), headers=headers, json=data)
+
+if response.status_code != 201 and response.status_code != 200:
+    print("Error triggering the CircleCI: %s." % response.json()["message"])
+    sys.exit(1)
+else:
+    response_dict = json.loads(response.text)
+    print("Started run_weekly_snapshot: %s" % response_dict)


### PR DESCRIPTION
- runs every Wednesday
- executes on the release branch if it exists
- build a snapshot with name `${major}.${minor}.${patch}-WEEKLY-SNAPSHOT`
- upload the snapshot to s3
- trigger 1tap-android with the snapshot