### PR TITLE
NAVAND-1279: Got rid of com.mapbox.ManageSkuToken=false

### DIFF
--- a/libnavigation-core/src/main/AndroidManifest.xml
+++ b/libnavigation-core/src/main/AndroidManifest.xml
@@ -24,8 +24,5 @@
             android:name=".trip.service.NavigationNotificationService"
             android:foregroundServiceType="location" />
 
-        <meta-data
-            android:name="com.mapbox.ManageSkuToken"
-            android:value="false" />
     </application>
 </manifest>


### PR DESCRIPTION
See more details [here](https://mapbox.atlassian.net/browse/NAVAND-1279?focusedCommentId=110046)

I haven't found any usage of this value in [maps v10](https://github.com/mapbox/mapbox-maps-android/search?q=com.mapbox.ManageSkuToken), only [maps v9](https://github.com/mapbox/mapbox-gl-native-android/search?q=com.mapbox.ManageSkuToken) use it. [It also doesn't seem that other project use this value](https://github.com/search?q=org%3Amapbox+com.mapbox.ManageSkuToken&type=code).

`com.mapbox.ManageSkuToken` seems like something that we forgot to remove before releasing 2.0. 