### PR TITLE
test for NN-654

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/LongRoutesSanityTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/LongRoutesSanityTest.kt
@@ -1,0 +1,55 @@
+package com.mapbox.navigation.instrumentation_tests.core
+
+import android.location.Location
+import com.mapbox.api.directions.v5.DirectionsCriteria
+import com.mapbox.api.directions.v5.models.RouteOptions
+import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
+import com.mapbox.navigation.instrumentation_tests.R
+import com.mapbox.navigation.instrumentation_tests.utils.http.MockDirectionsRequestHandler
+import com.mapbox.navigation.instrumentation_tests.utils.readRawFileText
+import com.mapbox.navigation.instrumentation_tests.utils.withMapboxNavigation
+import com.mapbox.navigation.testing.ui.BaseCoreNoCleanUpTest
+import com.mapbox.navigation.testing.ui.utils.coroutines.getSuccessfulResultOrThrowException
+import com.mapbox.navigation.testing.ui.utils.coroutines.requestRoutes
+import com.mapbox.navigation.testing.ui.utils.coroutines.sdkTest
+import com.mapbox.navigation.testing.ui.utils.coroutines.setNavigationRoutesAsync
+import org.junit.Ignore
+import org.junit.Test
+
+class LongRoutesSanityTest : BaseCoreNoCleanUpTest() {
+
+    override fun setupMockLocation(): Location {
+        return mockLocationUpdatesRule.generateLocationUpdate { }
+    }
+
+    @Test
+    @Ignore("Waiting for NN-654 to be fixed")
+    fun requestAndSetLongRouteWithoutOnboardTiles() = sdkTest {
+        val routeOptions = RouteOptions.builder()
+            .baseUrl(mockWebServerRule.baseUrl) // comment to use real Directions API
+            .applyDefaultNavigationOptions()
+            .coordinates(
+                "4.898473756907066,52.37373595766587;5.359980783143584,43.280050656855906" +
+                    ";11.571179644010442,48.145540095763664" +
+                    ";13.394784408007155,52.51274942160785" +
+                    ";-9.143239539655042,38.70880224984026" +
+                    ";9.21595128801522,45.4694220491258"
+            )
+            .alternatives(true)
+            .enableRefresh(true)
+            .build()
+        val handler = MockDirectionsRequestHandler(
+            profile = DirectionsCriteria.PROFILE_DRIVING_TRAFFIC,
+            lazyJsonResponse = { readRawFileText(context, R.raw.long_route_7k) },
+            expectedCoordinates = routeOptions.coordinatesList(),
+            serverDelayMs = 12_000, // It takes time for Direction API to calculate a long route
+        )
+        mockWebServerRule.requestHandlers.add(handler)
+        withMapboxNavigation { navigation ->
+            val routes = navigation
+                .requestRoutes(routeOptions)
+                .getSuccessfulResultOrThrowException().routes
+            navigation.setNavigationRoutesAsync(routes)
+        }
+    }
+}

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/LongRoutesSanityTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/LongRoutesSanityTest.kt
@@ -5,6 +5,7 @@ import com.mapbox.api.directions.v5.DirectionsCriteria
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.instrumentation_tests.R
+import com.mapbox.navigation.instrumentation_tests.utils.DelayedResponseModifier
 import com.mapbox.navigation.instrumentation_tests.utils.http.MockDirectionsRequestHandler
 import com.mapbox.navigation.instrumentation_tests.utils.readRawFileText
 import com.mapbox.navigation.instrumentation_tests.utils.withMapboxNavigation
@@ -41,9 +42,11 @@ class LongRoutesSanityTest : BaseCoreNoCleanUpTest() {
         val handler = MockDirectionsRequestHandler(
             profile = DirectionsCriteria.PROFILE_DRIVING_TRAFFIC,
             lazyJsonResponse = { readRawFileText(context, R.raw.long_route_7k) },
-            expectedCoordinates = routeOptions.coordinatesList(),
-            serverDelayMs = 12_000, // It takes time for Direction API to calculate a long route
-        )
+            expectedCoordinates = routeOptions.coordinatesList()
+        ).apply {
+            // It takes time for Direction API to calculate a long route
+            jsonResponseModifier = DelayedResponseModifier(12_000)
+        }
         mockWebServerRule.requestHandlers.add(handler)
         withMapboxNavigation { navigation ->
             val routes = navigation

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/LongRoutesSanityTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/LongRoutesSanityTest.kt
@@ -20,7 +20,10 @@ import org.junit.Test
 class LongRoutesSanityTest : BaseCoreNoCleanUpTest() {
 
     override fun setupMockLocation(): Location {
-        return mockLocationUpdatesRule.generateLocationUpdate { }
+        return mockLocationUpdatesRule.generateLocationUpdate {
+            longitude = 4.898473756907066
+            latitude = 52.37373595766587
+        }
     }
 
     @Test
@@ -30,7 +33,8 @@ class LongRoutesSanityTest : BaseCoreNoCleanUpTest() {
             .baseUrl(mockWebServerRule.baseUrl) // comment to use real Directions API
             .applyDefaultNavigationOptions()
             .coordinates(
-                "4.898473756907066,52.37373595766587;5.359980783143584,43.280050656855906" +
+                "4.898473756907066,52.37373595766587" +
+                    ";5.359980783143584,43.280050656855906" +
                     ";11.571179644010442,48.145540095763664" +
                     ";13.394784408007155,52.51274942160785" +
                     ";-9.143239539655042,38.70880224984026" +

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/MapboxNavigationCreator.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/MapboxNavigationCreator.kt
@@ -4,7 +4,6 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.options.RoutingTilesOptions
 import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.core.MapboxNavigationProvider
 import com.mapbox.navigation.testing.ui.BaseCoreNoCleanUpTest
 import java.net.URI
 
@@ -13,7 +12,7 @@ inline fun BaseCoreNoCleanUpTest.withMapboxNavigation(
     block: (navigation: MapboxNavigation) -> Unit
 ) {
     val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
-    val navigation = MapboxNavigationProvider.create(
+    val navigation = MapboxNavigation(
         NavigationOptions.Builder(InstrumentationRegistry.getInstrumentation().targetContext)
             .accessToken(
                 getMapboxAccessTokenFromResources(

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/MapboxNavigationCreator.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/MapboxNavigationCreator.kt
@@ -1,0 +1,38 @@
+package com.mapbox.navigation.instrumentation_tests.utils
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.base.options.RoutingTilesOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.testing.ui.BaseCoreNoCleanUpTest
+import java.net.URI
+
+inline fun BaseCoreNoCleanUpTest.withMapboxNavigation(
+    useRealTiles: Boolean = false,
+    block: (navigation: MapboxNavigation) -> Unit
+) {
+    val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
+    val navigation = MapboxNavigationProvider.create(
+        NavigationOptions.Builder(InstrumentationRegistry.getInstrumentation().targetContext)
+            .accessToken(
+                getMapboxAccessTokenFromResources(
+                    targetContext
+                )
+            ).apply {
+                if (!useRealTiles) {
+                    routingTilesOptions(
+                        RoutingTilesOptions.Builder()
+                            .tilesBaseUri(URI(mockWebServerRule.baseUrl))
+                            .build()
+                    )
+                }
+            }
+            .build()
+    )
+    try {
+        block(navigation)
+    } finally {
+        navigation.onDestroy()
+    }
+}

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/http/MockDirectionsRequestHandler.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/http/MockDirectionsRequestHandler.kt
@@ -13,12 +13,20 @@ import okhttp3.mockwebserver.RecordedRequest
  * @param expectedCoordinates optionally the expected coordinates
  * that the handler should match when providing the response
  */
-data class MockDirectionsRequestHandler(
+data class MockDirectionsRequestHandler constructor(
     val profile: String,
-    val jsonResponse: String,
+    val lazyJsonResponse: () -> String,
     val expectedCoordinates: List<Point>?,
     val relaxedExpectedCoordinates: Boolean = false,
+    val serverDelayMs: Long = 0,
 ) : BaseMockRequestHandler() {
+
+    constructor(
+        profile: String,
+        jsonResponse: String,
+        expectedCoordinates: List<Point>?,
+        relaxedExpectedCoordinates: Boolean = false,
+    ) : this(profile, { jsonResponse }, expectedCoordinates, relaxedExpectedCoordinates)
 
     var jsonResponseModifier: ((String) -> String) = { it }
 
@@ -30,7 +38,8 @@ data class MockDirectionsRequestHandler(
         }
 
         return if (request.path!!.startsWith(prefix)) {
-            MockResponse().setBody(jsonResponseModifier(jsonResponse))
+            Thread.sleep(serverDelayMs)
+            MockResponse().setBody(jsonResponseModifier(lazyJsonResponse()))
         } else {
             null
         }
@@ -49,7 +58,8 @@ data class MockDirectionsRequestHandler(
             "profile='$profile', " +
             "expectedCoordinates=$expectedCoordinates, " +
             "relaxedExpectedCoordinates=$relaxedExpectedCoordinates, " +
-            "jsonResponse='$jsonResponse'" +
+            "lazyJsonResponse='$lazyJsonResponse', " +
+            "serverDelayMs='$serverDelayMs'" +
             ")"
     }
 }

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/http/MockDirectionsRequestHandler.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/utils/http/MockDirectionsRequestHandler.kt
@@ -18,7 +18,6 @@ data class MockDirectionsRequestHandler constructor(
     val lazyJsonResponse: () -> String,
     val expectedCoordinates: List<Point>?,
     val relaxedExpectedCoordinates: Boolean = false,
-    val serverDelayMs: Long = 0,
 ) : BaseMockRequestHandler() {
 
     constructor(
@@ -38,7 +37,6 @@ data class MockDirectionsRequestHandler constructor(
         }
 
         return if (request.path!!.startsWith(prefix)) {
-            Thread.sleep(serverDelayMs)
             MockResponse().setBody(jsonResponseModifier(lazyJsonResponse()))
         } else {
             null
@@ -58,8 +56,7 @@ data class MockDirectionsRequestHandler constructor(
             "profile='$profile', " +
             "expectedCoordinates=$expectedCoordinates, " +
             "relaxedExpectedCoordinates=$relaxedExpectedCoordinates, " +
-            "lazyJsonResponse='$lazyJsonResponse', " +
-            "serverDelayMs='$serverDelayMs'" +
+            "lazyJsonResponse='$lazyJsonResponse'" +
             ")"
     }
 }


### PR DESCRIPTION
NN changes algorithm of hybrid router from time to time. This test will ensure that they don't break long routes requests. Currently it always fail. We expect fix in the next NN release, see NN-654.
Test has passed locally with `av-NN-659-router-callback-1-SNAPSHOT`