### PR TITLE
Fixed 1tap weekly snapshots 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,10 +117,10 @@ workflows:
             - unit-tests-ui
             - unit-tests-core
   weekly-snapshot-workflow:
-    # Run workflow every Wednesday at 12pm UTC
+    # Run workflow every Friday at 23:59 UTC
     triggers:
       - schedule:
-          cron: "0 12 * * 3"
+          cron: "59 23 * * 5"
           filters:
             branches:
               only:

--- a/scripts/trigger-onetap.py
+++ b/scripts/trigger-onetap.py
@@ -13,7 +13,7 @@ last_release = str(subprocess.run("git describe --tag --match 'v*' --abbrev=0", 
                                   text=True).stdout).strip()
 print("Last release " + last_release)
 
-release_main_part = last_release.partition('-')[0]
+release_main_part = last_release.partition('-')[0].replace('v', '')
 snapshot_name = release_main_part + "-WEEKLY-SNAPSHOT"
 print("Snapshot name " + snapshot_name)
 


### PR DESCRIPTION
1. Don't send version that start with `v`
2. Run snapshot builds on Fridays 

Testing: wait for the 1Tap snapshot 