### PR TITLE
fixed an issue where DirectionsRoute#duration ignored charge time after refresh operation

### DIFF
--- a/changelog/unreleased/bugfixes/7121.md
+++ b/changelog/unreleased/bugfixes/7121.md
@@ -1,0 +1,1 @@
+- Fixed an issue where `DirectionsRoute#duration` ignored charge time after refresh operation.

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/route/RouteProgressExTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/route/RouteProgressExTest.kt
@@ -650,6 +650,7 @@ class RouteProgressExTest {
             0,
             mockk {
                 every { geometries() } returns DirectionsCriteria.GEOMETRY_POLYLINE
+                every { waypointsPerRoute() } returns false
             },
             mockk {
                 every { routeInfo } returns mockk(relaxed = true)
@@ -883,7 +884,11 @@ class RouteProgressExTest {
 
         @Test
         fun refreshResponseWaypoints() {
-            val inputRoute = provideNavigationRoute(dirWaypoints = inputWaypoints, addLeg = true)
+            val inputRoute = provideNavigationRoute(
+                dirWaypoints = inputWaypoints,
+                addLeg = true,
+                waypointsPerRoute = false,
+            )
             val updatedRoute = inputRoute.refreshRoute(
                 0,
                 0,
@@ -897,7 +902,11 @@ class RouteProgressExTest {
 
         @Test
         fun routeWaypoints() {
-            val inputRoute = provideNavigationRoute(routeWaypoints = inputWaypoints, addLeg = true)
+            val inputRoute = provideNavigationRoute(
+                routeWaypoints = inputWaypoints,
+                addLeg = true,
+                waypointsPerRoute = true,
+            )
             val updatedRoute = inputRoute.refreshRoute(
                 0,
                 0,
@@ -919,6 +928,7 @@ class RouteProgressExTest {
             dirWaypoints: List<DirectionsWaypoint>? = null,
             addLeg: Boolean,
             distance: Double = 10.0,
+            waypointsPerRoute: Boolean = false,
         ): NavigationRoute {
             val twoPointGeometry = PolylineUtils.encode(
                 listOf(
@@ -982,6 +992,7 @@ class RouteProgressExTest {
                 0,
                 mockk {
                     every { geometries() } returns DirectionsCriteria.GEOMETRY_POLYLINE
+                    every { waypointsPerRoute() } returns waypointsPerRoute
                 },
                 mockk {
                     every { routeInfo } returns mockk(relaxed = true)

--- a/libnavigation-router/src/test/resources/multi_leg_route_refreshed.json
+++ b/libnavigation-router/src/test/resources/multi_leg_route_refreshed.json
@@ -4,7 +4,7 @@
       "weight_typical": 1511.56,
       "routeIndex": "0",
       "distance": 2839.016,
-      "duration": 615.8249999999998,
+      "duration": 726.8249999999998,
       "duration_typical": 654.54,
       "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvDdCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaAj@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GMKdE??CxA@x@Ar@]vCWtA{Mfv@uGd_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeEdCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArITjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD",
       "weight": 1500.996,

--- a/libnavigation-router/src/test/resources/multi_leg_route_refreshed_second_leg.json
+++ b/libnavigation-router/src/test/resources/multi_leg_route_refreshed_second_leg.json
@@ -38,7 +38,7 @@
       "weight_typical": 1511.56,
       "routeIndex": "0",
       "distance": 2839.016,
-      "duration": 623.8819999999998,
+      "duration": 845.8819999999998,
       "duration_typical": 654.54,
       "geometry": "gwho`Bwlxn_@jAO`AOh@KhEi@tEo@r@In@Kn@IzEo@b@EdTqClAQzAS|YyDdBUr@KvC_@|Es@d@Ef@Ilg@cHnAWJCzCc@xCWf@E^EhBSfBKh[iElC]nMgBlDa@`@Ef@Cz@?|@DrA`@xAbAnBrBTLtCvDdCaFj`@}x@j@kAl@oAbAyBjA{BlAqA`AeAzAoAbAq@d@QxDaAj@pGt@`IzDj_@xBrU\\xD^lEvJvfAJbAJbAt@vINdBLnANtAfAjJ|AxIbAbDhAdDVt@tCfG|BbDn@`Al@l@j@l@`WfW|A~Ad@b@f@f@NN`A~@|DrElBtBzBl@zId@|Bz@rEfBnEd@`GMKdE??CxA@x@Ar@]vCWtA{Mfv@uGd_@tGe_@zMgv@VuA\\wC@s@Ay@ByAJeEdCi@~D_Ab@Kvj@eNtHiB|Bi@nCq@HArCq@bWoGLGJC|@]b@Q~Ck@rCaAZM\\dCDT`AnFLl@Pz@Tz@jOhq@hDpMdB`HZtAH`@d@~BnDpPZnA|AfHBJrC~Lf@lBl@|BhBhHBJPr@`GlWdAtEdDhObBrJhArITjBb@xDRpBXlC`DtZlAjPd@rFJ`Ad@`F@Jr@|HRvBdAjLzCl\\z@pF~@jExCnL`BfE`AbCt@rAxCjFdG~GxH|FnNlGt@Zn@Xx@^tCjA~@`@jAf@`EpAhEvAv@Vf@NhR~FdMxDlAb@pBx@l@RnInCt@Tr@XfBj@bBf@|BEv@Ct@GlAMt@I|OcCd@IvPuCvCo@vG}AbCk@xKwEvB}@vKiGvBeBVUZYxAuAx@s@VY\\c@zDwE`E_FJMzCuHh@oA|AkF^kAh@yBbByGvAyGb@uBToA`BcLLeAr@mFXmBpFo^`@oCx@wFR}An@_Fn@eEZ}BnAcJl@kEfAsIVgB|BwOjBwOnCeT|Ei\\|@{D`EkSzBkKN{@Hk@Hi@d@oD",
       "weight": 1500.996,


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->
This PR fixes an issue where `DirectionsRoute#duration` ignored charge time after refresh operation. All initial EV route responses do include charge time and it was cleared when refreshing.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
