### PR TITLE
ignore route progress updates when while routes are being set

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/CoalescingBlockingQueue.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/CoalescingBlockingQueue.kt
@@ -1,0 +1,45 @@
+package com.mapbox.navigation.base.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A queue that executes added jobs (see [addJob]) in the order they are added,
+ * within provided scope in a blocking way (under the lock of provided mutex).
+ * If a new job is added while the previous one is not yet started (it's still waiting to acquire the lock),
+ * the previous job ([Item.block]) will not be be executed
+ * and the corresponding cancellation (see [Item.cancellation]) will be invoked.
+ * This way in case there are multiple jobs in the queue, only the latest one will be executed.
+ * NOTE: the queue is not thread safe. Add jobs from a single thread or add synchronization
+ * on your side to avoid concurrency problems.
+ */
+class CoalescingBlockingQueue(
+    private val scope: CoroutineScope,
+    private val mutex: Mutex,
+) {
+
+    data class Item(
+        val block: () -> Unit,
+        val cancellation: () -> Unit,
+    )
+
+    private var currentItem: Item? = null
+
+    fun addJob(item: Item) {
+        currentItem?.cancellation?.invoke()
+        currentItem = item
+        startExecuting()
+    }
+
+    private fun startExecuting() {
+        scope.launch {
+            mutex.withLock {
+                val currentItemCopy = currentItem
+                currentItem = null
+                currentItemCopy?.block?.invoke()
+            }
+        }
+    }
+}

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/CoalescingBlockingQueueTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/CoalescingBlockingQueueTest.kt
@@ -1,0 +1,77 @@
+package com.mapbox.navigation.base.internal
+
+import com.mapbox.navigation.testing.MainCoroutineRule
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.sync.Mutex
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class CoalescingBlockingQueueTest {
+
+    @get:Rule
+    val coroutineRule = MainCoroutineRule()
+    private val mutex = Mutex()
+
+    private lateinit var queue: CoalescingBlockingQueue
+
+    @Before
+    fun setUp() {
+        queue = CoalescingBlockingQueue(coroutineRule.coroutineScope, mutex)
+    }
+
+    @Test
+    fun addAndExecuteSingleJob() = coroutineRule.runBlockingTest {
+        val block = mockk<() -> Unit>(relaxed = true)
+        val cancellation = mockk<() -> Unit>(relaxed = true)
+
+        queue.addJob(CoalescingBlockingQueue.Item(block, cancellation))
+
+        verify(exactly = 1) { block() }
+        verify(exactly = 0) { cancellation() }
+    }
+
+    @Test
+    fun addAndExecuteMultipleJobs() = coroutineRule.runBlockingTest {
+        val block1 = mockk<() -> Unit>(relaxed = true)
+        val cancellation1 = mockk<() -> Unit>(relaxed = true)
+        val block2 = mockk<() -> Unit>(relaxed = true)
+        val cancellation2 = mockk<() -> Unit>(relaxed = true)
+        val block3 = mockk<() -> Unit>(relaxed = true)
+        val cancellation3 = mockk<() -> Unit>(relaxed = true)
+        val block4 = mockk<() -> Unit>(relaxed = true)
+        val cancellation4 = mockk<() -> Unit>(relaxed = true)
+        val block5 = mockk<() -> Unit>(relaxed = true)
+        val cancellation5 = mockk<() -> Unit>(relaxed = true)
+        val block6 = mockk<() -> Unit>(relaxed = true)
+        val cancellation6 = mockk<() -> Unit>(relaxed = true)
+
+        queue.addJob(CoalescingBlockingQueue.Item(block1, cancellation1))
+        mutex.lock()
+        queue.addJob(CoalescingBlockingQueue.Item(block2, cancellation2))
+        queue.addJob(CoalescingBlockingQueue.Item(block3, cancellation3))
+        queue.addJob(CoalescingBlockingQueue.Item(block4, cancellation4))
+        mutex.unlock()
+        queue.addJob(CoalescingBlockingQueue.Item(block5, cancellation5))
+        queue.addJob(CoalescingBlockingQueue.Item(block6, cancellation6))
+
+        verify(exactly = 1) { block1() }
+        verify(exactly = 0) { cancellation1() }
+        verify(exactly = 0) { block2() }
+        verify(exactly = 1) { cancellation2() }
+        verify(exactly = 0) { block3() }
+        verify(exactly = 1) { cancellation3() }
+        verify(exactly = 1) { block4() }
+        verify(exactly = 0) { cancellation4() }
+        verify(exactly = 1) { block5() }
+        verify(exactly = 0) { cancellation5() }
+        verify(exactly = 1) { block6() }
+        verify(exactly = 0) { cancellation6() }
+    }
+}

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/InternalJobControlFactory.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/InternalJobControlFactory.kt
@@ -27,6 +27,16 @@ object InternalJobControlFactory {
     }
 
     /**
+     * Creates a [JobControl] using the immediate main dispatcher. This is similar to [ThreadController] but the
+     * resources created here aren't shared. It is your responsibility to cancel child jobs as
+     * necessary.
+     */
+    fun createImmediateMainScopeJobControl(): JobControl {
+        val parentJob = SupervisorJob()
+        return JobControl(parentJob, CoroutineScope(parentJob + Dispatchers.Main.immediate))
+    }
+
+    /**
      * Creates a [JobControl] using the IO dispatcher. This is similar to [ThreadController] but the
      * resources created here aren't shared. It is your responsibility to cancel child jobs as
      * necessary.

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiRoboTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiRoboTest.kt
@@ -28,7 +28,6 @@ import com.mapbox.navigation.ui.maps.route.line.model.MapboxRouteLineOptions
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLine
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineColorResources
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineDistancesIndex
-import com.mapbox.navigation.ui.maps.route.line.model.RouteLineDynamicData
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineError
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineGranularDistances
 import com.mapbox.navigation.ui.maps.route.line.model.RouteLineResources
@@ -51,7 +50,6 @@ import kotlinx.coroutines.job
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -1760,89 +1758,6 @@ class MapboxRouteLineApiRoboTest {
                     "'abc#0' to hide the portion that overlaps " +
                     "with the primary route.",
                 "MapboxRouteLineUtils"
-            )
-        }
-    }
-
-    // We had a bug that when styleInactiveRouteLegsIndependently was enabled but we first
-    // got route progress update and only then routes update,
-    // there was a race that the independent legs might not have been styled independently
-    // until we switch to the next leg.
-    // The race scheme:
-    // 1. Invoke setNavigationRouteLines;
-    // 2. Set new routes;
-    // 3. Suspend before calculation routeLineExpressionData;
-    // 4. Invoke updateWithRouteProgress;
-    // 5. Change leg, set activeLegIndex to 0;
-    // 6. Invoke provideLegUpdate that styles inactive leg independently based on routeLineExpressionData;
-    // 7. Only here actually initialize the routeLineExpressionData in setNavigationRouteLines;
-    // Result: we styles independently the inactive legs based on empty data.
-    // And the state doesn't restore itself, because on the next updateWithRouteProgress leg didn't change ->
-    // we don't invoke provideLegUpdate (that's an optimization we still need).
-    @Test
-    fun updateWithRouteProgressBeforeSetNavigationRouteLines() = coroutineRule.runBlockingTest {
-        mockkObject(MapboxRouteLineUtils) {
-            every { MapboxRouteLineUtils.getRouteLineFeatureDataProvider(any()) } answers {
-                {
-                    coroutineRule.testDispatcher.pauseDispatcher()
-                    callOriginal()()
-                }
-            }
-
-            val expectedBaseExpContents = listOf(
-                StringChecker("step"),
-                StringChecker("[line-progress]"),
-                StringChecker("[rgba, 0.0, 0.0, 0.0, 0.0]"),
-                DoubleChecker(0.0),
-                StringChecker("[rgba, 86.0, 168.0, 251.0, 1.0]"),
-                DoubleChecker(0.10373821458415478),
-                StringChecker("[rgba, 255.0, 149.0, 0.0, 1.0]"),
-                DoubleChecker(0.1240124365711821),
-                StringChecker("[rgba, 86.0, 168.0, 251.0, 1.0]"),
-                DoubleChecker(0.2718982903427929),
-                StringChecker("[rgba, 255.0, 149.0, 0.0, 1.0]"),
-                DoubleChecker(0.32264099467350016),
-                StringChecker("[rgba, 86.0, 168.0, 251.0, 1.0]"),
-                DoubleChecker(0.4897719974699625),
-                StringChecker("[rgba, 0.0, 0.0, 0.0, 0.0]"),
-            )
-
-            val realOptions = MapboxRouteLineOptions.Builder(ctx)
-                .styleInactiveRouteLegsIndependently(true)
-                .build()
-            val route = multiLegRouteTwoLegs.navigationRoute
-            val mockVanishingRouteLine = mockk<VanishingRouteLine>(relaxed = true) {
-                every { vanishPointOffset } returns 0.0
-            }
-            val options = mockk<MapboxRouteLineOptions>(relaxed = true) {
-                every { vanishingRouteLine } returns mockVanishingRouteLine
-                every { resourceProvider } returns realOptions.resourceProvider
-                every {
-                    styleInactiveRouteLegsIndependently
-                } returns true
-                every { displayRestrictedRoadSections } returns false
-                every { displaySoftGradientForTraffic } returns false
-                every { softGradientTransition } returns 30.0
-                every { routeStyleDescriptors } returns listOf()
-            }
-            val api = MapboxRouteLineApi(options)
-            val routeProgress = multiLegRouteTwoLegs.mockRouteProgress(0, 0)
-
-            api.setNavigationRoutes(listOf(route)) {}
-
-            api.updateWithRouteProgress(routeProgress) {}
-            coroutineRule.testDispatcher.resumeDispatcher()
-
-            var result: RouteLineDynamicData? = null
-            api.updateWithRouteProgress(routeProgress) {
-                result = it.value!!.primaryRouteLineDynamicData
-            }
-
-            // this check will fail if there's a race
-            assertNotNull(result)
-            checkExpression(
-                expectedBaseExpContents,
-                result!!.trafficExpressionProvider!!.generateExpression()
             )
         }
     }

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiRoboTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/route/line/api/MapboxRouteLineApiRoboTest.kt
@@ -97,6 +97,12 @@ class MapboxRouteLineApiRoboTest {
             val defaultScope = coroutineRule.createTestScope()
             JobControl(defaultScope.coroutineContext.job, defaultScope)
         }
+        every {
+            InternalJobControlFactory.createImmediateMainScopeJobControl()
+        } answers {
+            val defaultScope = coroutineRule.createTestScope()
+            JobControl(defaultScope.coroutineContext.job, defaultScope)
+        }
     }
 
     @After


### PR DESCRIPTION
Race description can be found in a comment to the new unit test.