### PR TITLE
Improve stability of long routes tests

### DIFF
--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/LongRoutesSanityTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/LongRoutesSanityTest.kt
@@ -26,7 +26,7 @@ class LongRoutesSanityTest : BaseCoreNoCleanUpTest() {
     }
 
     @Test
-    fun requestAndSetLongRouteWithoutOnboardTiles() = sdkTest(timeout = 60_000) {
+    fun requestAndSetLongRouteWithoutOnboardTiles() = sdkTest(timeout = 120_000) {
         val routeOptions = RouteOptions.builder()
             .baseUrl(mockWebServerRule.baseUrl) // comment to use real Directions API
             .applyDefaultNavigationOptions()

--- a/instrumentation-tests/src/main/AndroidManifest.xml
+++ b/instrumentation-tests/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:largeHeap="true"
         android:requestLegacyExternalStorage="true"
         android:usesCleartextTraffic="true">
         <activity android:name=".activity.EmptyTestActivity" />

--- a/instrumentation-tests/src/main/AndroidManifest.xml
+++ b/instrumentation-tests/src/main/AndroidManifest.xml
@@ -19,7 +19,6 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:largeHeap="true"
         android:requestLegacyExternalStorage="true"
         android:usesCleartextTraffic="true">
         <activity android:name=".activity.EmptyTestActivity" />


### PR DESCRIPTION
It takes 48 seconds to serialise a long route on `Nexus 5, API Level 23` from firebase device lab.
```
04-19 09:39:30.908: I/Mapbox(12617): [nav-sdk]: [NavigationRoute] NavigationRoute.createAsync is called
04-19 09:40:18.730: D/Mapbox(12617): [nav-sdk]: [NavigationRoute] NavigationRoute.createAsync finished for Hx9dSjQIDnHkThyjoziZBodVBvaSGynKcAZEd2Ha5O05s3pKsvYkAQ==
```
Duration of the whole `requestAndSetLongRouteWithoutOnboardTiles` is **1m 15s**. The same test takes 14 seconds on modern devices, where 10 seconds is server delay.

Increasing timeout maybe not be the best option, but I think it's acceptable for the time being while we're looking for the better way to do sanity tests on weak devices. Maybe it's worth taking it away to a different test suite. 