### PR TITLE
immediately dispatch MapboxRouteLineView updates

### DIFF
--- a/changelog/unreleased/bugfixes/7140.md
+++ b/changelog/unreleased/bugfixes/7140.md
@@ -1,0 +1,1 @@
+- Fixed an issue where route lines could flicker when `MapboxRouteLineOptions` where changed and re-applied to rebuilt `MapboxRouteLineView` and `MapboxRouteLineApi` instances.


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

Unfortunately the rollback in https://github.com/mapbox/mapbox-navigation-android/pull/7043#discussion_r1147604913 was incorrect - we do need to set the new data immediately after rebuilding a layer, otherwise, the threads loops and the line or vanishing point are cleared before being re-applied which causes a flicker.

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->
_before_

https://user-images.githubusercontent.com/16925074/234858216-4bc3b741-d4e3-46ca-a8ad-e33308e5e27d.mp4

_after_

https://user-images.githubusercontent.com/16925074/234857812-5550ddf1-77b3-42f3-8a62-fa518239c7ef.mp4



<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
