### PR TITLE
remove RoadObjectType NOTIFICATION from IntDef

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/RoadObjectType.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/trip/model/roadobject/RoadObjectType.kt
@@ -96,7 +96,6 @@ object RoadObjectType {
         RAILWAY_CROSSING,
         IC,
         JCT,
-        NOTIFICATION
     )
     annotation class Type
 }


### PR DESCRIPTION
Otherwise it's reflected in the current.txt when you run core update-api. Let's remove this until we fully support it.