### PR TITLE
add camera owner for fly to camera transitions

### DIFF
--- a/changelog/unreleased/bugfixes/7143.md
+++ b/changelog/unreleased/bugfixes/7143.md
@@ -1,0 +1,1 @@
+- Fixed an issue where `NavigationCamera` animations would stop executing if experimental `AnimationThreadController.useBackgroundThread()` option was enabled.

--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/transition/MapboxNavigationCameraTransition.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/camera/transition/MapboxNavigationCameraTransition.kt
@@ -304,7 +304,10 @@ class MapboxNavigationCameraTransition(
         val currentZL = currentMapCameraState.zoom
         val targetCenter = cameraOptions.center
         val targetZoom = cameraOptions.zoom
-        val animators = pluginImpl.cameraAnimationsFactory.getFlyTo(cameraOptions)
+        val animators = pluginImpl.cameraAnimationsFactory.getFlyTo(
+            cameraOptions = cameraOptions,
+            owner = NAVIGATION_CAMERA_OWNER
+        )
         ifNonNull(targetCenter, targetZoom) { targetPoint, targetZL ->
             val projection = projectedDistance(
                 mapboxMap = mapboxMap,

--- a/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/transition/MapboxNavigationCameraTransitionTest.kt
+++ b/libnavui-maps/src/test/java/com/mapbox/navigation/ui/maps/camera/transition/MapboxNavigationCameraTransitionTest.kt
@@ -10,6 +10,7 @@ import com.mapbox.maps.plugin.animation.CameraAnimatorOptions
 import com.mapbox.maps.plugin.animation.animator.CameraAnimator
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera.Companion.DEFAULT_FRAME_TRANSITION_OPT
 import com.mapbox.navigation.ui.maps.camera.NavigationCamera.Companion.DEFAULT_STATE_TRANSITION_OPT
+import com.mapbox.navigation.ui.maps.camera.NavigationCamera.Companion.NAVIGATION_CAMERA_OWNER
 import com.mapbox.navigation.ui.maps.camera.utils.constraintDurationTo
 import com.mapbox.navigation.ui.maps.camera.utils.createAnimatorSet
 import com.mapbox.navigation.ui.maps.camera.utils.createAnimatorSetWith
@@ -64,7 +65,7 @@ class MapboxNavigationCameraTransitionTest {
         val mockAnimators: Array<CameraAnimator<*>> = arrayOf()
         val cameraPluginImpl = mockk<CameraAnimationsPluginImpl> {
             every { cameraAnimationsFactory } returns mockk {
-                every { getFlyTo(cameraOptions) } returns mockAnimators
+                every { getFlyTo(cameraOptions, NAVIGATION_CAMERA_OWNER) } returns mockAnimators
             }
         }
         every { constrainedSet.duration } returns min(0.0, 1300.0).toLong()


### PR DESCRIPTION
### Description
<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

This ensures that the correct owner is set for fly-to transitions. It specifically helps when animations are attempted to be moved to a worker thread with `AnimationThreadController.useBackgroundThread()` which uncovered the incorrect setup this commit fixes.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
