### PR TITLE
snapshot build fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,12 @@ parameters:
   mapbox_navigation_native_snapshot:
     type: string
     default: ''
+  weekly_snapshot:
+    type: boolean
+    default: false
+  ignore_snapshot_dependencies:
+    type: boolean
+    default: false
 
 #-------------------------------
 #---------- EXECUTORS ----------
@@ -125,6 +131,10 @@ workflows:
             branches:
               only:
                 - main
+    jobs:
+      - release-weekly-snapshot
+  weekly-snapshot-manual-workflow:
+    when: << pipeline.parameters.weekly_snapshot >>
     jobs:
       - release-weekly-snapshot
   pre-snapshot-workflow:
@@ -596,7 +606,7 @@ commands:
           name: Prepare snapshot
           command: |
             export GITHUB_TOKEN=$(./mbx-ci github writer private token)
-            python3 scripts/snapshot/prepare-snapshot.py
+            python3 scripts/snapshot/prepare-snapshot.py << pipeline.parameters.ignore_snapshot_dependencies >>
 
 #--------------------------
 #---------- JOBS ----------

--- a/scripts/snapshot/prepare-snapshot.py
+++ b/scripts/snapshot/prepare-snapshot.py
@@ -45,6 +45,12 @@ for line in versions_lines:
         nav_native_version_line = line
 
 versions_file = open(versions_file_name, 'r').read()
+
+ignore_snapshot_dependencies = sys.argv[1]
+if (not maps_version or not nav_native_version) and ignore_snapshot_dependencies == 'false':
+    print('Cancel workflow. Not all dependencies are ready')
+    sys.exit(1)
+
 if maps_version:
     print('Bumping Maps to ' + maps_version)
     versions_file = versions_file.replace(


### PR DESCRIPTION
- do not build a snapshot if not all dependencies are ready
- manual snapshot workflow where you can ignore readiness of dependencies

To run manual snapshot use parameters:
- weekly_snapshot (boolean, set true)
- ignore_snapshot_dependencies (boolean, set true)