### PR TITLE
Revert "use static mocking" to improve tests speed

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/SDKRouteParser.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/internal/SDKRouteParser.kt
@@ -1,5 +1,6 @@
 package com.mapbox.navigation.base.internal
 
+import androidx.annotation.VisibleForTesting
 import com.mapbox.bindgen.DataRef
 import com.mapbox.bindgen.Expected
 import com.mapbox.navigation.base.internal.utils.mapToNativeRouteOrigin
@@ -21,7 +22,13 @@ interface SDKRouteParser {
     ): Expected<String, List<RouteInterface>>
 
     companion object {
-        val default: SDKRouteParser = NativeRouteParserWrapper()
+        var default: SDKRouteParser = NativeRouteParserWrapper()
+            @VisibleForTesting set
+
+        @VisibleForTesting
+        fun resetDefault() {
+            default = NativeRouteParserWrapper()
+        }
     }
 }
 

--- a/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/NativeRouteParserRule.kt
+++ b/libtesting-navigation-base/src/main/java/com/mapbox/navigation/testing/NativeRouteParserRule.kt
@@ -3,8 +3,6 @@ package com.mapbox.navigation.testing
 import android.annotation.SuppressLint
 import com.mapbox.navigation.base.internal.SDKRouteParser
 import com.mapbox.navigation.testing.factories.TestSDKRouteParser
-import io.mockk.every
-import io.mockk.mockkObject
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -14,9 +12,11 @@ class NativeRouteParserRule : TestRule {
         return object : Statement() {
             @SuppressLint("VisibleForTests")
             override fun evaluate() {
-                mockkObject(SDKRouteParser) {
-                    every { SDKRouteParser.default } returns TestSDKRouteParser()
+                SDKRouteParser.default = TestSDKRouteParser()
+                try {
                     base.evaluate()
+                } finally {
+                    SDKRouteParser.resetDefault()
                 }
             }
         }


### PR DESCRIPTION
Continuation of https://github.com/mapbox/mapbox-navigation-android/pull/7201#discussion_r1211374738

I will run unit tests a few times to see how much time can we save in average 
