### PR TITLE
add option to split recorded history files

### DIFF
--- a/changelog/unreleased/bugfixes/7232.md
+++ b/changelog/unreleased/bugfixes/7232.md
@@ -1,0 +1,2 @@
+- Added Copilot option that allows to split history files by duration.
+- Added Copilot options that allow to limit the number and total size of history files to be sent per session.

--- a/libnavigation-base/api/current.txt
+++ b/libnavigation-base/api/current.txt
@@ -323,9 +323,15 @@ package com.mapbox.navigation.base.options {
   }
 
   @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class CopilotOptions {
+    method public long getMaxHistoryFileLengthMillis();
+    method public int getMaxHistoryFilesPerSession();
+    method public long getMaxTotalHistoryFilesSizePerSession();
     method public boolean getShouldRecordFreeDriveHistories();
     method public boolean getShouldSendHistoryOnlyWithFeedback();
     method public com.mapbox.navigation.base.options.CopilotOptions.Builder toBuilder();
+    property public final long maxHistoryFileLengthMillis;
+    property public final int maxHistoryFilesPerSession;
+    property public final long maxTotalHistoryFilesSizePerSession;
     property public final boolean shouldRecordFreeDriveHistories;
     property public final boolean shouldSendHistoryOnlyWithFeedback;
   }
@@ -333,6 +339,9 @@ package com.mapbox.navigation.base.options {
   public static final class CopilotOptions.Builder {
     ctor public CopilotOptions.Builder();
     method public com.mapbox.navigation.base.options.CopilotOptions build();
+    method public com.mapbox.navigation.base.options.CopilotOptions.Builder maxHistoryFileLengthMillis(long millis);
+    method public com.mapbox.navigation.base.options.CopilotOptions.Builder maxHistoryFilesPerSession(int count);
+    method public com.mapbox.navigation.base.options.CopilotOptions.Builder maxTotalHistoryFilesSizePerSession(long bytes);
     method public com.mapbox.navigation.base.options.CopilotOptions.Builder shouldRecordFreeDriveHistories(boolean flag);
     method public com.mapbox.navigation.base.options.CopilotOptions.Builder shouldSendHistoryOnlyWithFeedback(boolean flag);
   }

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/CopilotOptionsTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/CopilotOptionsTest.kt
@@ -11,6 +11,9 @@ class CopilotOptionsTest : BuilderTest<CopilotOptions, CopilotOptions.Builder>()
 
     override fun getFilledUpBuilder() = CopilotOptions.Builder()
         .shouldSendHistoryOnlyWithFeedback(true)
+        .maxHistoryFileLengthMillis(180000)
+        .maxHistoryFilesPerSession(2)
+        .maxTotalHistoryFilesSizePerSession(250000)
         .shouldRecordFreeDriveHistories(false)
 
     @Test

--- a/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/HistoryAttachmentsUtils.kt
+++ b/libnavigation-copilot/src/main/java/com/mapbox/navigation/copilot/HistoryAttachmentsUtils.kt
@@ -62,6 +62,8 @@ internal object HistoryAttachmentsUtils {
 
     fun delete(file: File): Boolean = file.delete()
 
+    fun size(file: File): Long = file.length()
+
     suspend fun copyToAndRemove(from: File, filename: String): File =
         withContext(Dispatchers.IO) {
             File(from.parent, filename).also { from.renameTo(it) }


### PR DESCRIPTION
### Description
This PR introduces several new Copilot options:
1. Split history files by duration. 
2. Limit number of history files to be uploaded per session. 
3. Limit total size of history files to be uploaded per session. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
