### PR TITLE
use proper type in drive ends event

### DIFF
--- a/changelog/unreleased/bugfixes/7236.md
+++ b/changelog/unreleased/bugfixes/7236.md
@@ -1,0 +1,1 @@
+- Improved Copilot to send a proper type with events of type `DriveEndsEvent`.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -137,7 +137,6 @@ ext {
       androidXLifecycleRuntime  : "androidx.lifecycle:lifecycle-runtime-ktx:${version.androidXLifecycle}",
       androidXLifecycleLivedata : "androidx.lifecycle:lifecycle-livedata-ktx:${version.androidXLifecycle}",
       androidXLifecycleViewmodel: "androidx.lifecycle:lifecycle-viewmodel-ktx:${version.androidXLifecycle}",
-      androidXLifecycleProcess  : "androidx.lifecycle:lifecycle-process:${version.androidXLifecycle}",
       androidXLifecycleTesting  : "androidx.lifecycle:lifecycle-runtime-testing:${version.androidXLifecycle}",
 
       // square crew

--- a/libnavigation-copilot/api/current.txt
+++ b/libnavigation-copilot/api/current.txt
@@ -55,9 +55,6 @@ package com.mapbox.navigation.copilot {
     field public static final com.mapbox.navigation.copilot.MapboxCopilot INSTANCE;
   }
 
-  public final class MapboxCopilotImplKt {
-  }
-
   @Keep @com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI public final class SearchResultUsed {
     ctor public SearchResultUsed(String provider, String id, String name, String address, com.mapbox.navigation.copilot.HistoryPoint coordinates, java.util.List<com.mapbox.navigation.copilot.HistoryRoutablePoint>? routablePoint);
     method public String component1();

--- a/libnavigation-copilot/build.gradle
+++ b/libnavigation-copilot/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation dependenciesList.coroutinesAndroid
 
     implementation dependenciesList.androidXWorkManager
-    implementation dependenciesList.androidXLifecycleProcess
 
     testImplementation project(':libtesting-navigation-util')
     testImplementation project(':libtesting-utils')

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/lifecycle/CarAppLifecycleOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/lifecycle/CarAppLifecycleOwner.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.lifecycle
+package com.mapbox.navigation.core.internal.lifecycle
 
 import android.app.Activity
 import android.app.Application
@@ -11,7 +11,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import com.mapbox.navigation.utils.internal.logI
 
-internal class CarAppLifecycleOwner : LifecycleOwner {
+class CarAppLifecycleOwner : LifecycleOwner {
 
     // Keeps track of the activities created and foregrounded
     private val activitiesCreated = hashSetOf<Activity>()
@@ -167,7 +167,7 @@ internal class CarAppLifecycleOwner : LifecycleOwner {
 
     override fun getLifecycle(): Lifecycle = lifecycleRegistry
 
-    internal fun attachAllActivities(application: Application) {
+    fun attachAllActivities(application: Application) {
         logI("attachAllActivities", LOG_CATEGORY)
         application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
         application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegate.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.core.lifecycle
 import android.app.Application
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.lifecycle.CarAppLifecycleOwner
 import kotlin.jvm.Throws
 import kotlin.reflect.KClass
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/lifecycle/CarAppLifecycleOwnerTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/internal/lifecycle/CarAppLifecycleOwnerTest.kt
@@ -1,4 +1,4 @@
-package com.mapbox.navigation.core.lifecycle
+package com.mapbox.navigation.core.internal.lifecycle
 
 import android.app.Activity
 import androidx.core.app.ComponentActivity

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/lifecycle/MapboxNavigationAppDelegateTest.kt
@@ -10,6 +10,7 @@ import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.internal.lifecycle.CarAppLifecycleOwnerTest
 import com.mapbox.navigation.testing.LoggingFrontendTestRule
 import io.mockk.every
 import io.mockk.just


### PR DESCRIPTION
### Description
This PR updates `DriveEndsEvent` to include a proper type based on some heuristics instead of hard-coding `CanceledManually`. Also removes `ProcessLifecycleOwner` dependency by using `CarAppLifecycleOwner` instead. 

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
