### PR TITLE
Dependency bump

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ ext {
 
   version = [
       mapboxMapSdk              : '10.15.0-beta.1',
-      mapboxSdkServices         : '6.12.0',
+      mapboxSdkServices         : '6.13.0-beta.1',
       mapboxNavigator           : "${mapboxNavigatorVersion}",
       mapboxCommonNative        : '23.7.0-beta.1',
       mapboxCrashMonitor        : '2.0.0',


### PR DESCRIPTION
### Description
This PR bumps ma-box-java to `6.13.0-beta.1`
