### PR TITLE
Got rid of internal third party API

### DIFF
--- a/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
+++ b/libnavigation-base/src/main/java/com/mapbox/navigation/base/route/NavigationRoute.kt
@@ -32,7 +32,6 @@ import com.mapbox.navigation.utils.internal.logI
 import com.mapbox.navigator.RouteInterface
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import okhttp3.internal.and
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.net.URL
@@ -714,7 +713,7 @@ private class ByteBufferBackedInputStream(
         return if (!buffer.hasRemaining()) {
             -1
         } else {
-            buffer.get() and 0xFF
+            buffer.get().toInt()
         }
     }
 


### PR DESCRIPTION
### Description

It appeared that we don't need `and` operator for that case, it was introduced during automatic java-kotlin migration. 

Thanks to @dzinad for noticing it.
