### PR TITLE
Fix "SetRoutesReason" when alternative route is chosen as a primary.

### DIFF
--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -926,8 +926,12 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         // Telemetry uses this field to determine what type of event should be triggered.
         val setRoutesInfo = when {
             routes.isEmpty() -> SetRoutes.CleanUp
-            routes.first() == directionsSession.routes.firstOrNull() ->
+            routes.first() == directionsSession.routes.firstOrNull() -> {
                 SetRoutes.Alternatives(initialLegIndex)
+            }
+            directionsSession.routes.map { it.id }.contains(routes.first().id) -> {
+                SetRoutes.Reorder(initialLegIndex)
+            }
             else -> SetRoutes.NewRoutes(initialLegIndex)
         }
         internalSetNavigationRoutes(
@@ -1078,7 +1082,8 @@ class MapboxNavigation @VisibleForTesting internal constructor(
         when (setRoutesInfo) {
             SetRoutes.CleanUp,
             is SetRoutes.NewRoutes,
-            is SetRoutes.Reroute -> {
+            is SetRoutes.Reroute,
+            is SetRoutes.Reorder -> {
                 rerouteController?.interrupt()
             }
             is SetRoutes.RefreshRoutes,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/SetRoutes.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/SetRoutes.kt
@@ -38,6 +38,11 @@ internal sealed class SetRoutes {
     ) : SetRoutes()
 
     /**
+     * Triggered when primary route changed and previous primary became alternative.
+     */
+    internal data class Reorder(val legIndex: Int) : SetRoutes()
+
+    /**
      * Triggered when the **routes do not change but are refreshed**.
      *
      * Currently this can only be trigger internally by a response to [RouteRefreshController.refresh].

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesExtra.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/directions/session/RoutesExtra.kt
@@ -14,7 +14,7 @@ object RoutesExtra {
     const val ROUTES_UPDATE_REASON_CLEAN_UP = "ROUTES_UPDATE_REASON_CLEAN_UP"
 
     /**
-     * Routes update reason is *•new routes**.
+     * Routes update reason is **new routes**.
      * @see [RoutesObserver]
      */
     const val ROUTES_UPDATE_REASON_NEW = "ROUTES_UPDATE_REASON_NEW"

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/SetRoutesEx.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/utils/SetRoutesEx.kt
@@ -9,7 +9,8 @@ internal fun SetRoutes.mapToReason(): String =
     when (this) {
         is SetRoutes.Alternatives -> RoutesExtra.ROUTES_UPDATE_REASON_ALTERNATIVE
         SetRoutes.CleanUp -> RoutesExtra.ROUTES_UPDATE_REASON_CLEAN_UP
-        is SetRoutes.NewRoutes -> RoutesExtra.ROUTES_UPDATE_REASON_NEW
+        is SetRoutes.NewRoutes,
+        is SetRoutes.Reorder -> RoutesExtra.ROUTES_UPDATE_REASON_NEW
         is SetRoutes.RefreshRoutes -> RoutesExtra.ROUTES_UPDATE_REASON_REFRESH
         is SetRoutes.Reroute -> RoutesExtra.ROUTES_UPDATE_REASON_REROUTE
     }
@@ -17,6 +18,7 @@ internal fun SetRoutes.mapToReason(): String =
 internal fun SetRoutes.initialLegIndex(): Int =
     when (this) {
         is SetRoutes.Alternatives -> legIndex
+        is SetRoutes.Reorder -> legIndex
         SetRoutes.CleanUp -> MapboxDirectionsSession.DEFAULT_INITIAL_LEG_INDEX
         is SetRoutes.NewRoutes -> legIndex
         is SetRoutes.RefreshRoutes -> routeProgressData.legIndex

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/trip/session/MapboxTripSession.kt
@@ -117,6 +117,13 @@ internal class MapboxTripSession(
                     nativeAlternatives = navigator.setAlternativeRoutes(routes.drop(1))
                 )
             }
+            is SetRoutes.Reorder -> {
+                setRouteToNativeNavigator(
+                    routes,
+                    setRoutes.initialLegIndex(),
+                    SetRoutesReason.ALTERNATIVE
+                )
+            }
             is SetRoutes.RefreshRoutes -> {
                 if (routes.isNotEmpty()) {
                     val primaryRoute = routes.first()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -1858,6 +1858,30 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     }
 
     @Test
+    fun `setNavigationRoutes alternative for changed primary route`() = coroutineRule.runBlockingTest {
+        createMapboxNavigation()
+        val route1 = mockk<NavigationRoute>(relaxed = true) {
+            every { id } returns "id1"
+        }
+        val route2 = mockk<NavigationRoute>(relaxed = true) {
+            every { id } returns "id2"
+        }
+        val route3 = mockk<NavigationRoute>(relaxed = true) {
+            every { id } returns "id3"
+        }
+        every { directionsSession.routes } returns listOf(route1, route2, route3)
+
+        mapboxNavigation.setNavigationRoutes(listOf(route2, route1, route3))
+
+        coVerify(exactly = 1) {
+            tripSession.setRoutes(any(), eq(SetRoutes.Reorder(0)))
+        }
+        verify(exactly = 1) {
+            directionsSession.setNavigationRoutesFinished(any())
+        }
+    }
+
+    @Test
     fun `setNavigationRoutes new routes`() = coroutineRule.runBlockingTest {
         createMapboxNavigation()
         val route1 = mockk<NavigationRoute>(relaxed = true) {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/SetRoutesLegIndexTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/SetRoutesLegIndexTest.kt
@@ -23,6 +23,7 @@ internal class SetRoutesLegIndexTest(
             arrayOf(SetRoutes.RefreshRoutes(RouteProgressData(1, 2, 3)), 1),
             arrayOf(SetRoutes.Reroute(5), 5),
             arrayOf(SetRoutes.Alternatives(6), 6),
+            arrayOf(SetRoutes.Reorder(7), 7),
         ).also {
             assertEquals(SetRoutes::class.sealedSubclasses.size, it.size)
         }


### PR DESCRIPTION
### Description
This PR fixes `SetRoutesReason` when alternative route is chosen as a primary.


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
