### PR TITLE
NAVAND-1477: Nav SDK should not interact with map which is already destroyed 

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/PredictiveCacheController.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/PredictiveCacheController.kt
@@ -243,7 +243,9 @@ class PredictiveCacheController constructor(
      */
     fun removeMapControllers(map: MapboxMap) {
         mapListeners[map]?.let {
-            map.removeOnStyleLoadedListener(it)
+            if (map.isValid()) {
+                map.removeOnStyleLoadedListener(it)
+            }
             mapListeners.remove(map)
         }
         PredictiveCache.removeAllMapControllersFromTileVariants(map)


### PR DESCRIPTION
### Description

If Nav SDK user does `predictiveCacheController.removeMapControllers(mapboxMap)` in `Fragment#onDestroyView`, it causes following error message in the logs:

```
W  [maps-android\Mbgl-MapboxMap]: MapboxMap object (accessing removeOnStyleLoadedListener) should not be stored and used after MapView is destroyed.
``` 