### PR TITLE
NAVAND-1469: UI thread annotation on for junction api

### DIFF
--- a/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxJunctionApi.kt
+++ b/libnavui-maps/src/main/java/com/mapbox/navigation/ui/maps/guidance/junction/api/MapboxJunctionApi.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.ui.maps.guidance.junction.api
 
 import android.net.Uri
+import androidx.annotation.UiThread
 import com.mapbox.api.directions.v5.models.BannerComponents
 import com.mapbox.api.directions.v5.models.BannerInstructions
 import com.mapbox.bindgen.Expected
@@ -23,6 +24,7 @@ import kotlinx.coroutines.launch
  * Mapbox Junction Api allows you to generate junction for select maneuvers.
  * @property accessToken String
  */
+@UiThread
 class MapboxJunctionApi(
     private val accessToken: String
 ) {


### PR DESCRIPTION
### Description

`MapboxJunctionAPI` seems to be implemented with an assumption to be called from a main thread:
* it calls callbacks on main thread in case of success
* it calls callbacks on current thread in case of failture

Given the fact that it's stateless the class could handle calls from worker threads, but the callbacks behavior seems inconsistent then. 
