### PR TITLE
Fixed leak of CarAppLifecycleOwner

### DIFF
--- a/changelog/unreleased/bugfixes/7669.md
+++ b/changelog/unreleased/bugfixes/7669.md
@@ -1,0 +1,1 @@
+- Fixed leak of CarAppLifecycleOwner on every copilot start.

--- a/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/MapboxCopilotImplTest.kt
+++ b/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/MapboxCopilotImplTest.kt
@@ -34,6 +34,7 @@ import com.mapbox.navigation.core.internal.telemetry.UserFeedbackCallback
 import com.mapbox.navigation.core.internal.telemetry.registerUserFeedbackCallback
 import com.mapbox.navigation.core.internal.telemetry.unregisterUserFeedbackCallback
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.testing.LoggingFrontendTestRule
 import com.mapbox.navigation.testing.MainCoroutineRule
 import com.mapbox.navigation.utils.internal.DefaultLifecycleObserver
 import com.mapbox.navigation.utils.internal.logD
@@ -72,6 +73,9 @@ class MapboxCopilotImplTest {
 
     @get:Rule
     val coroutineRule = MainCoroutineRule()
+
+    @get:Rule
+    val loggingFrontendTestRule = LoggingFrontendTestRule()
 
     @Before
     fun setUp() {

--- a/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/MapboxCopilotImplTest.kt
+++ b/libnavigation-copilot/src/test/java/com/mapbox/navigation/copilot/MapboxCopilotImplTest.kt
@@ -468,6 +468,30 @@ class MapboxCopilotImplTest {
     }
 
     @Test
+    fun `activity Lifecycle Callbacks is unregistered when stop if MapboxNavigationApp is not setup`() {
+        val mockedMapboxNavigation = prepareBasicMockks()
+        val mockedAppLifecycle = prepareCarAppLifecycleOwnerMockk()
+        val historyRecordingStateChangeObserver = slot<HistoryRecordingStateChangeObserver>()
+        every {
+            mockedMapboxNavigation.registerHistoryRecordingStateChangeObserver(
+                capture(historyRecordingStateChangeObserver)
+            )
+        } just Runs
+        val mapboxCopilot = createMapboxCopilotImplementation(mockedMapboxNavigation)
+        mapboxCopilot.start()
+        val activeGuidanceHistoryRecordingSessionState =
+            mockk<HistoryRecordingSessionState.ActiveGuidance>(relaxed = true)
+        historyRecordingStateChangeObserver.captured.onShouldStartRecording(
+            activeGuidanceHistoryRecordingSessionState
+        )
+
+        mapboxCopilot.stop()
+
+        verify(exactly = 1) { anyConstructed<CarAppLifecycleOwner>().attachAllActivities(any()) }
+        verify(exactly = 1) { anyConstructed<CarAppLifecycleOwner>().detachAllActivities(any()) }
+    }
+
+    @Test
     fun `unregisterHistoryRecordingStateChangeObserver is called when stop`() {
         val mockedMapboxNavigation = prepareBasicMockks()
         prepareLifecycleOwnerMockk()

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/lifecycle/CarAppLifecycleOwner.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/internal/lifecycle/CarAppLifecycleOwner.kt
@@ -173,6 +173,11 @@ class CarAppLifecycleOwner : LifecycleOwner {
         application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
     }
 
+    fun detachAllActivities(application: Application) {
+        logI("detachAllActivities", LOG_CATEGORY)
+        application.unregisterActivityLifecycleCallbacks(activityLifecycleCallbacks)
+    }
+
     fun attach(lifecycleOwner: LifecycleOwner) {
         logI("attach", LOG_CATEGORY)
         lifecycleOwner.lifecycle.addObserver(startedReferenceCounter)


### PR DESCRIPTION
### Description

A customer complained that they see 14 log entries like
```
[nav-sdk]: [CarAppLifecycleOwner] app onActivityPaused
```
every time activity is paused. The same for resume.

During investigation I found out that every time `MapboxCopilot` starts, it creates a new instance of `CarAppLifecycleOwner`, and subscribes for all activities changes without desubscribing from it. This PR added desubscription.