### PR TITLE
Share common CacheHandle (backport for 2.14)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@ Mapbox Navigation for Android version 2.0
 
 Mapbox Navigation Android SDK
 
-Copyright ©2022 - 2023 Mapbox, Inc. All rights reserved.
+Copyright ©2022 - 2024 Mapbox, Inc. All rights reserved.
 
 The software and files in this repository (collectively, "Software") are licensed under the Mapbox TOS for use only with the relevant Mapbox product(s) listed at www.mapbox.com/pricing. This license allows developers with a current active Mapbox account to use and modify the authorized portions of the Software as needed for use only with the relevant Mapbox product(s) through their Mapbox account in accordance with the Mapbox TOS.  This license terminates automatically if a developer no longer has a Mapbox account in good standing or breaches the Mapbox TOS. For the license terms, please see the Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a SDK, modifications that change or interfere with marked portions of the code related to billing, accounting, or data collection are not authorized and the SDK sends limited de-identified location and usage data which is used in accordance with the Mapbox TOS. [Updated 2023-04]
 

--- a/changelog/unreleased/bugfixes/7693.md
+++ b/changelog/unreleased/bugfixes/7693.md
@@ -1,0 +1,1 @@
+- Fixed a bug with multiple instances of cache which resulted in excessive memory consumption.

--- a/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/EvOfflineTest.kt
+++ b/instrumentation-tests/src/androidTest/java/com/mapbox/navigation/instrumentation_tests/core/EvOfflineTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.first
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -65,6 +66,7 @@ class EvOfflineTest : BaseCoreNoCleanUpTest() {
         }
     }
 
+    @Ignore("Fix mocked response https://mapbox.atlassian.net/browse/NAVAND-1730")
     @Test
     fun startNavigationOfflineThenSwitchToOnlineRouteWhenInternetAppears() = sdkTest(
         timeout = INCREASED_TIMEOUT_BECAUSE_OF_REAL_ROUTING_TILES_USAGE

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/NavigationComponentProvider.kt
@@ -25,10 +25,10 @@ import com.mapbox.navigation.core.trip.session.eh.EHorizonSubscriptionManagerImp
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigator
 import com.mapbox.navigation.navigator.internal.MapboxNativeNavigatorImpl
 import com.mapbox.navigation.utils.internal.ThreadController
+import com.mapbox.navigator.CacheHandle
 import com.mapbox.navigator.ConfigHandle
 import com.mapbox.navigator.HistoryRecorderHandle
 import com.mapbox.navigator.RouterInterface
-import com.mapbox.navigator.TilesConfig
 import kotlinx.coroutines.CoroutineScope
 
 internal object NavigationComponentProvider {
@@ -38,15 +38,15 @@ internal object NavigationComponentProvider {
     ): DirectionsSession = MapboxDirectionsSession(router)
 
     fun createNativeNavigator(
+        cacheHandle: CacheHandle,
         config: ConfigHandle,
         historyRecorderComposite: HistoryRecorderHandle?,
-        tilesConfig: TilesConfig,
         accessToken: String,
         router: RouterInterface,
     ): MapboxNativeNavigator = MapboxNativeNavigatorImpl.create(
+        cacheHandle,
         config,
         historyRecorderComposite,
-        tilesConfig,
         accessToken,
         router,
     )

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationBaseTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationBaseTest.kt
@@ -148,6 +148,9 @@ internal open class MapboxNavigationBaseTest {
                 any(),
             )
         } returns mockk(relaxed = true)
+        every {
+            NavigatorLoader.createCacheHandle(any(), any(), any())
+        } returns mockk()
 
         mockkObject(MapboxSDKCommon)
         every {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -906,15 +906,9 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     fun `verify tile config path`() {
         threadController.cancelAllUICoroutines()
         val slot = slot<TilesConfig>()
-        every {
-            NavigationComponentProvider.createNativeNavigator(
-                any(),
-                any(),
-                capture(slot),
-                any(),
-                any(),
-            )
-        } returns navigator
+
+        every { NavigatorLoader.createCacheHandle(any(), capture(slot), any()) } returns mockk()
+
         val options = navigationOptions.toBuilder()
             .routingTilesOptions(RoutingTilesOptions.Builder().build())
             .build()
@@ -928,15 +922,9 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     fun `verify tile config dataset`() {
         threadController.cancelAllUICoroutines()
         val slot = slot<TilesConfig>()
-        every {
-            NavigationComponentProvider.createNativeNavigator(
-                any(),
-                any(),
-                capture(slot),
-                any(),
-                any(),
-            )
-        } returns navigator
+
+        every { NavigatorLoader.createCacheHandle(any(), capture(slot), any()) } returns mockk()
+
         val options = navigationOptions.toBuilder()
             .routingTilesOptions(
                 RoutingTilesOptions.Builder()
@@ -1220,15 +1208,9 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     fun `verify tile config tilesVersion and isFallback on init`() {
         threadController.cancelAllUICoroutines()
         val slot = slot<TilesConfig>()
-        every {
-            NavigationComponentProvider.createNativeNavigator(
-                any(),
-                any(),
-                capture(slot),
-                any(),
-                any(),
-            )
-        } returns navigator
+
+        every { NavigatorLoader.createCacheHandle(any(), capture(slot), any()) } returns mockk()
+
         val tilesVersion = "tilesVersion"
         val options = navigationOptions.toBuilder()
             .routingTilesOptions(
@@ -1261,15 +1243,10 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
 
         val tileConfigSlot = slot<TilesConfig>()
+
         every {
-            navigator.recreate(
-                any(),
-                any(),
-                capture(tileConfigSlot),
-                any(),
-                any(),
-            )
-        } just Runs
+            NavigatorLoader.createCacheHandle(any(), capture(tileConfigSlot), any())
+        } returns mockk()
 
         val tilesVersion = "tilesVersion"
         val latestTilesVersion = "latestTilesVersion"
@@ -1301,15 +1278,10 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
 
             val tileConfigSlot = slot<TilesConfig>()
+
             every {
-                navigator.recreate(
-                    any(),
-                    any(),
-                    capture(tileConfigSlot),
-                    any(),
-                    any(),
-                )
-            } just Runs
+                NavigatorLoader.createCacheHandle(any(), capture(tileConfigSlot), any())
+            } returns mockk()
 
             fallbackObserverSlot.captured.onCanReturnToLatest("")
 

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigator.kt
@@ -27,7 +27,6 @@ import com.mapbox.navigator.RouteAlternativesControllerInterface
 import com.mapbox.navigator.RouterInterface
 import com.mapbox.navigator.SetRoutesReason
 import com.mapbox.navigator.SetRoutesResult
-import com.mapbox.navigator.TilesConfig
 
 /**
  * Provides API to work with native Navigator class. Exposed for internal usage only.
@@ -38,9 +37,9 @@ interface MapboxNativeNavigator {
      * Initialize the navigator with a device profile
      */
     fun create(
+        cacheHandle: CacheHandle,
         config: ConfigHandle,
         historyRecorderComposite: HistoryRecorderHandle?,
-        tilesConfig: TilesConfig,
         accessToken: String,
         router: RouterInterface,
     ): MapboxNativeNavigator
@@ -49,9 +48,9 @@ interface MapboxNativeNavigator {
      * Reinitialize the navigator with a device profile
      */
     fun recreate(
+        cacheHandle: CacheHandle,
         config: ConfigHandle,
         historyRecorderComposite: HistoryRecorderHandle?,
-        tilesConfig: TilesConfig,
         accessToken: String,
         router: RouterInterface,
     )

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/MapboxNativeNavigatorImpl.kt
@@ -43,7 +43,6 @@ import com.mapbox.navigator.RouterInterface
 import com.mapbox.navigator.SetRoutesParams
 import com.mapbox.navigator.SetRoutesReason
 import com.mapbox.navigator.SetRoutesResult
-import com.mapbox.navigator.TilesConfig
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import java.util.concurrent.CopyOnWriteArraySet
@@ -79,18 +78,18 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
      * functions within [MapboxNativeNavigatorImpl]
      */
     override fun create(
+        cacheHandle: CacheHandle,
         config: ConfigHandle,
         historyRecorderComposite: HistoryRecorderHandle?,
-        tilesConfig: TilesConfig,
         accessToken: String,
         router: RouterInterface,
     ): MapboxNativeNavigator {
         navigator?.shutdown()
 
         val nativeComponents = NavigatorLoader.createNavigator(
+            cacheHandle,
             config,
             historyRecorderComposite,
-            tilesConfig,
             router,
         )
         navigator = nativeComponents.navigator
@@ -109,14 +108,14 @@ object MapboxNativeNavigatorImpl : MapboxNativeNavigator {
      * Recreate native objects and notify listeners.
      */
     override fun recreate(
+        cacheHandle: CacheHandle,
         config: ConfigHandle,
         historyRecorderComposite: HistoryRecorderHandle?,
-        tilesConfig: TilesConfig,
         accessToken: String,
         router: RouterInterface
     ) {
         val storeNavSessionState = navigator!!.storeNavigationSession()
-        create(config, historyRecorderComposite, tilesConfig, accessToken, router)
+        create(cacheHandle, config, historyRecorderComposite, accessToken, router)
         navigator!!.restoreNavigationSession(storeNavSessionState)
         nativeNavigatorRecreationObservers.forEach {
             it.onNativeNavigatorRecreated()

--- a/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
+++ b/libnavigator/src/main/java/com/mapbox/navigation/navigator/internal/NavigatorLoader.kt
@@ -49,40 +49,46 @@ object NavigatorLoader {
     }
 
     internal fun createNavigator(
+        cacheHandle: CacheHandle,
         config: ConfigHandle,
         historyRecorderComposite: HistoryRecorderHandle?,
-        tilesConfig: TilesConfig,
         router: RouterInterface,
     ): NativeComponents {
-        val cache = CacheFactory.build(tilesConfig, config, historyRecorderComposite)
         val navigator = Navigator(
             config,
-            cache,
+            cacheHandle,
             historyRecorderComposite,
             router,
         )
-        val graphAccessor = GraphAccessor(cache)
-        val roadObjectMatcher = RoadObjectMatcher(cache)
+        val graphAccessor = GraphAccessor(cacheHandle)
+        val roadObjectMatcher = RoadObjectMatcher(cacheHandle)
 
         return NativeComponents(
             navigator,
             graphAccessor,
-            cache,
+            cacheHandle,
             roadObjectMatcher,
             router,
             navigator.routeAlternativesController,
         )
     }
 
-    fun createNativeRouterInterface(
+    fun createCacheHandle(
         config: ConfigHandle,
         tilesConfig: TilesConfig,
         historyRecorder: HistoryRecorderHandle?,
+    ): CacheHandle {
+        return CacheFactory.build(tilesConfig, config, historyRecorder)
+    }
+
+    fun createNativeRouterInterface(
+        cacheHandle: CacheHandle,
+        config: ConfigHandle,
+        historyRecorder: HistoryRecorderHandle?,
     ): RouterInterface {
-        val cache = CacheFactory.build(tilesConfig, config, historyRecorder)
         return RouterFactory.build(
             RouterType.HYBRID,
-            cache,
+            cacheHandle,
             config,
             historyRecorder,
         )


### PR DESCRIPTION
### Description
Backports https://github.com/mapbox/mapbox-navigation-android/pull/7688 to 2.14

> This PR makes `CacheHandle` be shared between `Navigator` and `Router` during `MapboxNavigation` initialization https://mapbox.atlassian.net/browse/NAVAND-1679

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
