### PR TITLE
Billing explanation logs

### DIFF
--- a/changelog/unreleased/features/7710.md
+++ b/changelog/unreleased/features/7710.md
@@ -1,0 +1,1 @@
+- Added billing explanation logs. Now Navigation SDK explains in the logs why certain Active Guidance or Free Drive Trip session started/stopped/paused/resumed. Billing explanations have `[BillingExplanation]` prefix in the logcat.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/accounts/BillingController.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/accounts/BillingController.kt
@@ -24,6 +24,7 @@ import com.mapbox.navigation.core.trip.session.NavigationSession
 import com.mapbox.navigation.core.trip.session.NavigationSessionState
 import com.mapbox.navigation.core.trip.session.NavigationSessionStateObserver
 import com.mapbox.navigation.core.trip.session.TripSession
+import com.mapbox.navigation.utils.internal.logI
 import com.mapbox.navigation.utils.internal.logW
 import com.mapbox.turf.TurfConstants.UNIT_METRES
 import com.mapbox.turf.TurfMeasurement
@@ -193,6 +194,7 @@ internal class BillingController(
 
     private companion object {
         private const val logCategory = "BillingController"
+        private const val BILLING_EXPLANATION_CATEGORY = "BillingExplanation"
         private const val MAX_WAYPOINTS_DISTANCE_DIFF_METERS = 100.0
     }
 
@@ -215,18 +217,23 @@ internal class BillingController(
                 is NavigationSessionState.Idle -> {
                     getRunningOrPausedSessionSkuId()?.let {
                         billingService.pauseBillingSession(it)
+                        logI(BILLING_EXPLANATION_CATEGORY) {
+                            "${it.publicName} has been paused because Nav SDK is in Idle state"
+                        }
                     }
                 }
                 is NavigationSessionState.FreeDrive -> {
                     resumeOrBeginBillingSession(
                         SessionSKUIdentifier.NAV2_SES_FDTRIP,
-                        validity = TimeUnit.HOURS.toMillis(1) // validity of 1hr
+                        validity = TimeUnit.HOURS.toMillis(1), // validity of 1hr
+                        "Nav SDK is in free drive state"
                     )
                 }
                 is NavigationSessionState.ActiveGuidance -> {
                     resumeOrBeginBillingSession(
                         SessionSKUIdentifier.NAV2_SES_TRIP,
-                        validity = 0 // default validity, 12hrs
+                        validity = 0, // default validity, 12hrs
+                        "Nav SDK is in Active Guidance state"
                     )
                 }
             }
@@ -247,7 +254,8 @@ internal class BillingController(
             }
             beginBillingSession(
                 SessionSKUIdentifier.NAV2_SES_TRIP,
-                validity = 0 // default validity, 12hrs
+                validity = 0, // default validity, 12hrs
+                "Nav SDK switched to the next route leg"
             )
         }
 
@@ -292,10 +300,17 @@ internal class BillingController(
                 ) == BillingSessionStatus.SESSION_PAUSED
                 beginBillingSession(
                     SessionSKUIdentifier.NAV2_SES_TRIP,
-                    validity = 0 // default validity, 12hrs
+                    validity = 0, // default validity, 12hrs
+                    "destination has been changed. " +
+                        "Old waypoints: $currentRemainingWaypoints," +
+                        "new waypoints: $newWaypoints"
                 )
                 if (wasSessionPaused) {
                     billingService.pauseBillingSession(SessionSKUIdentifier.NAV2_SES_TRIP)
+                    logI(BILLING_EXPLANATION_CATEGORY) {
+                        "${runningSessionSkuId.publicName} has been paused because " +
+                            "it used to be paused before destinations update"
+                    }
                 }
             }
         }
@@ -317,6 +332,9 @@ internal class BillingController(
         arrivalProgressObserver.unregisterObserver(arrivalObserver)
         getRunningOrPausedSessionSkuId()?.let {
             billingService.stopBillingSession(it)
+            logI(BILLING_EXPLANATION_CATEGORY) {
+                "${it.publicName} has been stopped because Nav SDK is destroyed"
+            }
         }
     }
 
@@ -325,7 +343,8 @@ internal class BillingController(
      */
     private fun resumeOrBeginBillingSession(
         skuId: SessionSKUIdentifier,
-        validity: Long
+        validity: Long,
+        reason: String
     ) {
         val runningSessionSkuId = getRunningOrPausedSessionSkuId()
         if (runningSessionSkuId == skuId) {
@@ -336,11 +355,18 @@ internal class BillingController(
                         "Session resumption failed, starting a new one instead.",
                         logCategory
                     )
-                    beginBillingSession(skuId, validity)
+                    logI(BILLING_EXPLANATION_CATEGORY) {
+                        "Failed to resume ${skuId.publicName}(${it.message})."
+                    }
+                    beginBillingSession(skuId, validity, reason)
+                } else {
+                    logI(BILLING_EXPLANATION_CATEGORY) {
+                        "${skuId.publicName} has ben resumed because $reason"
+                    }
                 }
             }
         } else {
-            beginBillingSession(skuId, validity)
+            beginBillingSession(skuId, validity, reason)
         }
     }
 
@@ -349,11 +375,15 @@ internal class BillingController(
      */
     private fun beginBillingSession(
         skuId: SessionSKUIdentifier,
-        validity: Long
+        validity: Long,
+        reason: String
     ) {
         val runningSessionSkuId = getRunningOrPausedSessionSkuId()
         if (runningSessionSkuId != null) {
             billingService.stopBillingSession(runningSessionSkuId)
+            logI(BILLING_EXPLANATION_CATEGORY) {
+                "${runningSessionSkuId.publicName} has been stopped because $reason"
+            }
         }
         billingService.beginBillingSession(
             accessToken,
@@ -364,6 +394,9 @@ internal class BillingController(
             },
             validity
         )
+        logI(BILLING_EXPLANATION_CATEGORY) {
+            "${skuId.publicName} has been started because $reason"
+        }
     }
 
     private fun getRunningOrPausedSessionSkuId(): SessionSKUIdentifier? {
@@ -453,4 +486,9 @@ internal class BillingController(
             }
         }
     }
+}
+
+private val SessionSKUIdentifier.publicName get() = when (this) {
+    SessionSKUIdentifier.NAV2_SES_TRIP -> "Active Guidance Trip Session"
+    SessionSKUIdentifier.NAV2_SES_FDTRIP -> "Free Drive Trip Session"
 }


### PR DESCRIPTION
### Description

From time to time customers asks us why they are billed for a certain amount of trip/freedrive sessions? This PR introduces answer to that question. A customer can filter logcat output using `BillingExplanation` and see why exactly certain billed session started/stopped/paused/resumed.

This is port of https://github.com/mapbox/mapbox-navigation-android/pull/7710 which has already helped to a customer. 

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
