### PR TITLE
Dynamic telemetry initialisation/deinitialisation based on user preferences

### DIFF
--- a/changelog/unreleased/bugfixes/7755.md
+++ b/changelog/unreleased/bugfixes/7755.md
@@ -1,0 +1,1 @@
+- Resolved an issue where a crash could occur if telemetry sending settings were changed after creating `MapboxNavigation`.

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigation.kt
@@ -253,9 +253,14 @@ private const val MAPBOX_NOTIFICATION_ACTION_CHANNEL = "notificationActionButton
 class MapboxNavigation @VisibleForTesting internal constructor(
     val navigationOptions: NavigationOptions,
     private val threadController: ThreadController,
+    private val telemetryWrapper: TelemetryWrapper = TelemetryWrapper(),
 ) {
 
-    constructor(navigationOptions: NavigationOptions) : this(navigationOptions, ThreadController())
+    constructor(navigationOptions: NavigationOptions) : this(
+        navigationOptions,
+        ThreadController(),
+        TelemetryWrapper(),
+    )
 
     private val mainJobController = threadController.getMainScopeAndRootJob()
     private val directionsSession: DirectionsSession
@@ -345,12 +350,6 @@ class MapboxNavigation @VisibleForTesting internal constructor(
      * [NavigationVersionSwitchObserver] is notified when navigation switches tiles version.
      */
     private val navigationVersionSwitchObservers = mutableSetOf<NavigationVersionSwitchObserver>()
-
-    private val telemetryWrapper = TelemetryWrapper(
-        mapboxNavigation = this,
-        navigationOptions = navigationOptions,
-        userAgent = obtainUserAgent(),
-    )
 
     /**
      * [MapboxNavigation.roadObjectsStore] provides methods to get road objects metadata,
@@ -571,7 +570,11 @@ class MapboxNavigation @VisibleForTesting internal constructor(
             arrivalProgressObserver
         )
 
-        telemetryWrapper.initialize()
+        telemetryWrapper.initialize(
+            mapboxNavigation = this,
+            navigationOptions = navigationOptions,
+            userAgent = obtainUserAgent(),
+        )
 
         val routeOptionsProvider = RouteOptionsUpdater()
 

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigationProvider.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/MapboxNavigationProvider.kt
@@ -1,7 +1,10 @@
 package com.mapbox.navigation.core
 
 import androidx.annotation.UiThread
+import androidx.annotation.VisibleForTesting
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.telemetry.TelemetryWrapper
+import com.mapbox.navigation.utils.internal.ThreadController
 
 /**
  * Singleton responsible for ensuring there is only one MapboxNavigation instance.
@@ -28,6 +31,22 @@ object MapboxNavigationProvider {
         mapboxNavigation?.onDestroy()
         mapboxNavigation = MapboxNavigation(
             navigationOptions
+        )
+
+        return mapboxNavigation!!
+    }
+
+    @VisibleForTesting
+    internal fun create(
+        navigationOptions: NavigationOptions,
+        threadController: ThreadController = ThreadController(),
+        telemetryWrapper: TelemetryWrapper = TelemetryWrapper()
+    ): MapboxNavigation {
+        mapboxNavigation?.onDestroy()
+        mapboxNavigation = MapboxNavigation(
+            navigationOptions,
+            threadController,
+            telemetryWrapper,
         )
 
         return mapboxNavigation!!

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -154,7 +154,7 @@ The class has two public methods, postUserFeedback() and initialize().
 
 TODO(NAVAND-1820) refactor this class. It's hard to test because of statics.
  */
-internal object MapboxNavigationTelemetry {
+internal object MapboxNavigationTelemetry : SdkTelemetry {
     internal const val LOG_CATEGORY = "MapboxNavigationTelemetry"
 
     private const val ONE_SECOND = 1000
@@ -356,7 +356,7 @@ internal object MapboxNavigationTelemetry {
         log("Valid initialization")
     }
 
-    fun destroy(mapboxNavigation: MapboxNavigation) {
+    override fun destroy(mapboxNavigation: MapboxNavigation) {
         telemetryStop()
 
         // TODO(NAVAND-1820) MapboxMetricsReporter is destroyed here,
@@ -427,7 +427,7 @@ internal object MapboxNavigationTelemetry {
         userFeedbackCallbacks.remove(userFeedbackCallback)
     }
 
-    fun postCustomEvent(
+    override fun postCustomEvent(
         payload: String,
         customEventType: String,
         customEventVersion: String
@@ -443,7 +443,7 @@ internal object MapboxNavigationTelemetry {
     }
 
     @ExperimentalPreviewMapboxNavigationAPI
-    fun provideFeedbackMetadataWrapper(): FeedbackMetadataWrapper {
+    override fun provideFeedbackMetadataWrapper(): FeedbackMetadataWrapper {
         (telemetryState as? NavTelemetryState.Running)?.sessionMetadata?.let { sessionMetadata ->
             return FeedbackMetadataWrapper(
                 sessionMetadata.navigatorSessionIdentifier,
@@ -468,7 +468,7 @@ internal object MapboxNavigationTelemetry {
     }
 
     @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
-    fun postUserFeedback(
+    override fun postUserFeedback(
         feedbackType: String,
         description: String,
         @FeedbackEvent.Source feedbackSource: String,

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/MapboxNavigationTelemetry.kt
@@ -151,6 +151,8 @@ The class must be initialized before any telemetry events are reported.
 Attempting to use telemetry before initialization is called will throw an exception.
 Initialization may be called multiple times, the call is idempotent.
 The class has two public methods, postUserFeedback() and initialize().
+
+TODO(NAVAND-1820) refactor this class. It's hard to test because of statics.
  */
 internal object MapboxNavigationTelemetry {
     internal const val LOG_CATEGORY = "MapboxNavigationTelemetry"
@@ -356,8 +358,12 @@ internal object MapboxNavigationTelemetry {
 
     fun destroy(mapboxNavigation: MapboxNavigation) {
         telemetryStop()
+
+        // TODO(NAVAND-1820) MapboxMetricsReporter is destroyed here,
+        // but initialized separately from MapboxNavigationTelemetry
         log("MapboxMetricsReporter disable")
         MapboxMetricsReporter.disable()
+
         mapboxNavigation.run {
             unregisterLocationObserver(locationsCollector)
             unregisterRouteProgressObserver(routeProgressObserver)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/SdkTelemetry.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/SdkTelemetry.kt
@@ -1,0 +1,67 @@
+package com.mapbox.navigation.core.telemetry
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.telemetry.CustomEvent
+import com.mapbox.navigation.core.internal.telemetry.UserFeedbackCallback
+import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
+import com.mapbox.navigation.core.telemetry.events.FeedbackMetadata
+import com.mapbox.navigation.core.telemetry.events.FeedbackMetadataWrapper
+
+internal interface SdkTelemetry {
+
+    fun postCustomEvent(
+        payload: String,
+        @CustomEvent.Type customEventType: String,
+        customEventVersion: String,
+    )
+
+    @ExperimentalPreviewMapboxNavigationAPI
+    fun provideFeedbackMetadataWrapper(): FeedbackMetadataWrapper?
+
+    @ExperimentalPreviewMapboxNavigationAPI
+    fun postUserFeedback(
+        feedbackType: String,
+        description: String,
+        @FeedbackEvent.Source feedbackSource: String,
+        screenshot: String?,
+        feedbackSubType: Array<String>?,
+        feedbackMetadata: FeedbackMetadata?,
+        userFeedbackCallback: UserFeedbackCallback?,
+    )
+
+    fun destroy(mapboxNavigation: MapboxNavigation)
+
+    companion object {
+
+        val EMPTY = object : SdkTelemetry {
+            override fun postCustomEvent(
+                payload: String,
+                customEventType: String,
+                customEventVersion: String,
+            ) {
+                // do nothing
+            }
+
+            @ExperimentalPreviewMapboxNavigationAPI
+            override fun provideFeedbackMetadataWrapper(): FeedbackMetadataWrapper? = null
+
+            @ExperimentalPreviewMapboxNavigationAPI
+            override fun postUserFeedback(
+                feedbackType: String,
+                description: String,
+                feedbackSource: String,
+                screenshot: String?,
+                feedbackSubType: Array<String>?,
+                feedbackMetadata: FeedbackMetadata?,
+                userFeedbackCallback: UserFeedbackCallback?,
+            ) {
+                // do nothing
+            }
+
+            override fun destroy(mapboxNavigation: MapboxNavigation) {
+                // do nothing
+            }
+        }
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
@@ -61,7 +61,7 @@ internal class TelemetryStateWatcher(
  * Class that manages [MapboxNavigationTelemetry] initialisation. Listens to telemetry state events
  * and can enable/disable telemetry in runtime.
  *
- * TODO ensure that we have 1-1 relationship between [TelemetryWrapper] and [MapboxNavigationTelemetry]
+ * TODO(NAVAND-1820) ensure that we have 1-1 relationship between [TelemetryWrapper] and [MapboxNavigationTelemetry]
  * [MapboxNavigationTelemetry] is very complex already and needs to be refactored.
  */
 @UiThread

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
@@ -29,7 +29,7 @@ internal class TelemetryWrapper {
     private lateinit var userAgent: String
 
     private var isWrapperInitialized = false
-    private var isTelemetryEnabled = false
+    private var sdkTelemetry: SdkTelemetry = SdkTelemetry.EMPTY
 
     fun initialize(
         mapboxNavigation: MapboxNavigation,
@@ -66,9 +66,8 @@ internal class TelemetryWrapper {
 
         isWrapperInitialized = false
 
-        if (isTelemetryEnabled) {
-            unInitializeSdkTelemetry()
-        }
+        sdkTelemetry.destroy(mapboxNavigation)
+        sdkTelemetry = SdkTelemetry.EMPTY
     }
 
     fun postCustomEvent(
@@ -76,11 +75,7 @@ internal class TelemetryWrapper {
         @CustomEvent.Type customEventType: String,
         customEventVersion: String,
     ) {
-        if (!isTelemetryEnabled) {
-            return
-        }
-
-        MapboxNavigationTelemetry.postCustomEvent(
+        sdkTelemetry.postCustomEvent(
             payload = payload,
             customEventType = customEventType,
             customEventVersion = customEventVersion
@@ -89,11 +84,7 @@ internal class TelemetryWrapper {
 
     @ExperimentalPreviewMapboxNavigationAPI
     fun provideFeedbackMetadataWrapper(): FeedbackMetadataWrapper? {
-        return if (isTelemetryEnabled) {
-            MapboxNavigationTelemetry.provideFeedbackMetadataWrapper()
-        } else {
-            null
-        }
+        return sdkTelemetry.provideFeedbackMetadataWrapper()
     }
 
     @ExperimentalPreviewMapboxNavigationAPI
@@ -106,11 +97,7 @@ internal class TelemetryWrapper {
         feedbackMetadata: FeedbackMetadata?,
         userFeedbackCallback: UserFeedbackCallback?,
     ) {
-        if (!isTelemetryEnabled) {
-            return
-        }
-
-        MapboxNavigationTelemetry.postUserFeedback(
+        sdkTelemetry.postUserFeedback(
             feedbackType,
             description,
             feedbackSource,
@@ -139,11 +126,6 @@ internal class TelemetryWrapper {
             MapboxMetricsReporter,
         )
 
-        isTelemetryEnabled = true
-    }
-
-    private fun unInitializeSdkTelemetry() {
-        MapboxNavigationTelemetry.destroy(mapboxNavigation)
-        isTelemetryEnabled = false
+        sdkTelemetry = MapboxNavigationTelemetry
     }
 }

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
@@ -1,0 +1,186 @@
+package com.mapbox.navigation.core.telemetry
+
+import androidx.annotation.UiThread
+import com.mapbox.common.TelemetryCollectionState
+import com.mapbox.common.TelemetryCollectionStateObserver
+import com.mapbox.common.TelemetryUtils
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.telemetry.CustomEvent
+import com.mapbox.navigation.core.internal.telemetry.UserFeedbackCallback
+import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
+import com.mapbox.navigation.core.telemetry.events.FeedbackMetadata
+import com.mapbox.navigation.core.telemetry.events.FeedbackMetadataWrapper
+import com.mapbox.navigation.metrics.MapboxMetricsReporter
+import com.mapbox.navigation.metrics.internal.TelemetryUtilsDelegate
+import com.mapbox.navigation.utils.internal.logD
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * This wrapper is needed just for unit tests in order not to deal with types from Common SDK
+ */
+@UiThread
+internal class TelemetryStateWatcher(
+    private val telemetryUtils: TelemetryUtils = TelemetryUtils()
+) {
+
+    private val observers = CopyOnWriteArrayList<Observer>()
+
+    private val telemetryStateObserver = TelemetryCollectionStateObserver { state ->
+        observers.forEach {
+            it.onStateChanged(state.isEnabled)
+        }
+    }
+
+    fun registerObserver(observer: Observer) {
+        observers.add(observer)
+        if (observers.size == 1) {
+            telemetryUtils.registerTelemetryCollectionStateObserver(telemetryStateObserver)
+        }
+    }
+
+    fun unregisterObserver(observer: Observer) {
+        observers.remove(observer)
+        if (observers.isEmpty()) {
+            telemetryUtils.unregisterTelemetryCollectionStateObserver(telemetryStateObserver)
+        }
+    }
+
+    fun interface Observer {
+        fun onStateChanged(telemetryEnable: Boolean)
+    }
+
+    private companion object {
+        val TelemetryCollectionState.isEnabled: Boolean
+            get() = this == TelemetryCollectionState.ENABLED
+    }
+}
+
+/**
+ * Class that manages [MapboxNavigationTelemetry] initialisation. Listens to telemetry state events
+ * and can enable/disable telemetry in runtime.
+ *
+ * TODO ensure that we have 1-1 relationship between [TelemetryWrapper] and [MapboxNavigationTelemetry]
+ * [MapboxNavigationTelemetry] is very complex already and needs to be refactored.
+ */
+@UiThread
+internal class TelemetryWrapper(
+    private val mapboxNavigation: MapboxNavigation,
+    private val navigationOptions: NavigationOptions,
+    private val userAgent: String,
+    private val telemetryStateWatcher: TelemetryStateWatcher = TelemetryStateWatcher()
+) {
+
+    private var isWrapperInitialized = false
+    private var isTelemetryEnabled = false
+
+    private val telemetryStateObserver = TelemetryStateWatcher.Observer { isEnabled ->
+        if (!isTelemetryEnabled && isEnabled) {
+            initializeSdkTelemetry()
+        } else if (isTelemetryEnabled && !isEnabled) {
+            unInitializeSdkTelemetry()
+        }
+    }
+
+    fun initialize() {
+        check(!isWrapperInitialized) {
+            "Already initialized"
+        }
+        isWrapperInitialized = true
+
+        if (TelemetryUtilsDelegate.getEventsCollectionState()) {
+            initializeSdkTelemetry()
+        }
+
+        telemetryStateWatcher.registerObserver(telemetryStateObserver)
+    }
+
+    fun destroy() {
+        check(isWrapperInitialized) {
+            "Initialize object first"
+        }
+        isWrapperInitialized = false
+
+        telemetryStateWatcher.unregisterObserver(telemetryStateObserver)
+        if (isTelemetryEnabled) {
+            unInitializeSdkTelemetry()
+        }
+    }
+
+    fun postCustomEvent(
+        payload: String,
+        @CustomEvent.Type customEventType: String,
+        customEventVersion: String,
+    ) {
+        if (!isTelemetryEnabled) {
+            return
+        }
+
+        MapboxNavigationTelemetry.postCustomEvent(
+            payload = payload,
+            customEventType = customEventType,
+            customEventVersion = customEventVersion
+        )
+    }
+
+    @ExperimentalPreviewMapboxNavigationAPI
+    fun provideFeedbackMetadataWrapper(): FeedbackMetadataWrapper? {
+        return if (isTelemetryEnabled) {
+            MapboxNavigationTelemetry.provideFeedbackMetadataWrapper()
+        } else {
+            null
+        }
+    }
+
+    @ExperimentalPreviewMapboxNavigationAPI
+    fun postUserFeedback(
+        feedbackType: String,
+        description: String,
+        @FeedbackEvent.Source feedbackSource: String,
+        screenshot: String,
+        feedbackSubType: Array<String>?,
+        feedbackMetadata: FeedbackMetadata?,
+        userFeedbackCallback: UserFeedbackCallback?,
+    ) {
+        if (!isTelemetryEnabled) {
+            return
+        }
+
+        MapboxNavigationTelemetry.postUserFeedback(
+            feedbackType,
+            description,
+            feedbackSource,
+            screenshot,
+            feedbackSubType,
+            feedbackMetadata,
+            userFeedbackCallback,
+        )
+    }
+
+    private fun initializeSdkTelemetry() {
+        val token = navigationOptions.accessToken ?: return
+
+        logD(
+            "MapboxMetricsReporter.init from MapboxNavigation main",
+            MapboxNavigationTelemetry.LOG_CATEGORY
+        )
+        MapboxMetricsReporter.init(
+            navigationOptions.applicationContext,
+            token,
+            userAgent
+        )
+        MapboxNavigationTelemetry.initialize(
+            mapboxNavigation,
+            navigationOptions,
+            MapboxMetricsReporter,
+        )
+
+        isTelemetryEnabled = true
+    }
+
+    private fun unInitializeSdkTelemetry() {
+        MapboxNavigationTelemetry.destroy(mapboxNavigation)
+        isTelemetryEnabled = false
+    }
+}

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
@@ -14,6 +14,7 @@ import com.mapbox.navigation.core.telemetry.events.FeedbackMetadata
 import com.mapbox.navigation.core.telemetry.events.FeedbackMetadataWrapper
 import com.mapbox.navigation.metrics.MapboxMetricsReporter
 import com.mapbox.navigation.metrics.internal.TelemetryUtilsDelegate
+import com.mapbox.navigation.utils.internal.assertDebug
 import com.mapbox.navigation.utils.internal.logD
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -89,9 +90,14 @@ internal class TelemetryWrapper(
         navigationOptions: NavigationOptions,
         userAgent: String
     ) {
-        check(!isWrapperInitialized) {
+        assertDebug(!isWrapperInitialized) {
             "Already initialized"
         }
+
+        if (isWrapperInitialized) {
+            return
+        }
+
         isWrapperInitialized = true
 
         this.mapboxNavigation = mapboxNavigation
@@ -106,9 +112,14 @@ internal class TelemetryWrapper(
     }
 
     fun destroy() {
-        check(isWrapperInitialized) {
+        assertDebug(isWrapperInitialized) {
             "Initialize object first"
         }
+
+        if (!isWrapperInitialized) {
+            return
+        }
+
         isWrapperInitialized = false
 
         telemetryStateWatcher.unregisterObserver(telemetryStateObserver)

--- a/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
+++ b/libnavigation-core/src/main/java/com/mapbox/navigation/core/telemetry/TelemetryWrapper.kt
@@ -66,11 +66,12 @@ internal class TelemetryStateWatcher(
  */
 @UiThread
 internal class TelemetryWrapper(
-    private val mapboxNavigation: MapboxNavigation,
-    private val navigationOptions: NavigationOptions,
-    private val userAgent: String,
     private val telemetryStateWatcher: TelemetryStateWatcher = TelemetryStateWatcher()
 ) {
+
+    private lateinit var mapboxNavigation: MapboxNavigation
+    private lateinit var navigationOptions: NavigationOptions
+    private lateinit var userAgent: String
 
     private var isWrapperInitialized = false
     private var isTelemetryEnabled = false
@@ -83,11 +84,19 @@ internal class TelemetryWrapper(
         }
     }
 
-    fun initialize() {
+    fun initialize(
+        mapboxNavigation: MapboxNavigation,
+        navigationOptions: NavigationOptions,
+        userAgent: String
+    ) {
         check(!isWrapperInitialized) {
             "Already initialized"
         }
         isWrapperInitialized = true
+
+        this.mapboxNavigation = mapboxNavigation
+        this.navigationOptions = navigationOptions
+        this.userAgent = userAgent
 
         if (TelemetryUtilsDelegate.getEventsCollectionState()) {
             initializeSdkTelemetry()

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationBaseTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationBaseTest.kt
@@ -31,6 +31,7 @@ import com.mapbox.navigation.core.routealternatives.RouteAlternativesControllerP
 import com.mapbox.navigation.core.routerefresh.RouteRefreshController
 import com.mapbox.navigation.core.routerefresh.RouteRefreshControllerProvider
 import com.mapbox.navigation.core.telemetry.MapboxNavigationTelemetry
+import com.mapbox.navigation.core.telemetry.TelemetryWrapper
 import com.mapbox.navigation.core.testutil.createRoutesUpdatedResult
 import com.mapbox.navigation.core.trip.service.TripService
 import com.mapbox.navigation.core.trip.session.NativeSetRouteValue
@@ -106,6 +107,7 @@ internal open class MapboxNavigationBaseTest {
     val historyRecordingStateHandler: HistoryRecordingStateHandler = mockk(relaxed = true)
     val developerMetadataAggregator: DeveloperMetadataAggregator = mockk(relaxUnitFun = true)
     val threadController = mockk<ThreadController>(relaxed = true)
+    val telemetryWrapper = mockk<TelemetryWrapper>(relaxed = true)
     val routeProgressDataProvider = mockk<RoutesProgressDataProvider>(relaxed = true)
     val routesPreviewController = mockk<RoutesPreviewController>(relaxed = true)
     val routesCacheClearer = mockk<RoutesCacheClearer>(relaxed = true)
@@ -262,7 +264,7 @@ internal open class MapboxNavigationBaseTest {
     }
 
     fun createMapboxNavigation() {
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
     }
 
     private fun mockNativeNavigator() {

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/MapboxNavigationTest.kt
@@ -42,7 +42,9 @@ import com.mapbox.navigation.core.routerefresh.RouteRefresherStatus
 import com.mapbox.navigation.core.routerefresh.RoutesRefresherResult
 import com.mapbox.navigation.core.sensor.SensorData
 import com.mapbox.navigation.core.sensor.UpdateExternalSensorDataCallback
-import com.mapbox.navigation.core.telemetry.MapboxNavigationTelemetry
+import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
+import com.mapbox.navigation.core.telemetry.events.FeedbackMetadata
+import com.mapbox.navigation.core.telemetry.events.FeedbackMetadataWrapper
 import com.mapbox.navigation.core.testutil.createRoutesUpdatedResult
 import com.mapbox.navigation.core.trip.session.LocationObserver
 import com.mapbox.navigation.core.trip.session.NativeSetRouteError
@@ -53,7 +55,6 @@ import com.mapbox.navigation.core.trip.session.RoadObjectsOnRouteObserver
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import com.mapbox.navigation.core.trip.session.createSetRouteResult
-import com.mapbox.navigation.metrics.internal.TelemetryUtilsDelegate
 import com.mapbox.navigation.navigator.internal.NavigatorLoader
 import com.mapbox.navigation.testing.factories.createDirectionsRoute
 import com.mapbox.navigation.testing.factories.createNavigationRoute
@@ -87,6 +88,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -236,7 +238,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         threadController.cancelAllUICoroutines()
         val navigationOptions = provideNavigationOptions().build()
 
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
 
         verify(exactly = 2) { tripSession.registerOffRouteObserver(any()) }
     }
@@ -247,7 +249,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         mapboxNavigation.onDestroy()
         threadController.cancelAllUICoroutines()
         val navigationOptions = provideNavigationOptions().build()
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
 
         mapboxNavigation.onDestroy()
 
@@ -416,46 +418,78 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     }
 
     @Test
-    fun telemetryIsDisabled() {
-        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
+    fun initializeTelemetryOnSdkInitialisation() {
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
+
+        verify(exactly = 1) {
+            telemetryWrapper.initialize(
+                mapboxNavigation,
+                navigationOptions,
+                "mapbox-navigation-android/${BuildConfig.MAPBOX_NAVIGATION_VERSION_NAME}",
+            )
+        }
+    }
+
+    @Test
+    fun telemetryIsEnabledTryToGetFeedbackMetadataWrapper() {
+        val feedbackMetadataWrapper = mockk<FeedbackMetadataWrapper>(relaxed = true)
+        every { telemetryWrapper.provideFeedbackMetadataWrapper() } returns feedbackMetadataWrapper
 
         createMapboxNavigation()
-        mapboxNavigation.onDestroy()
-
-        verify(exactly = 0) {
-            MapboxNavigationTelemetry.initialize(any(), any(), any(), any())
-        }
-        verify(exactly = 0) { MapboxNavigationTelemetry.destroy(any()) }
+        assertSame(feedbackMetadataWrapper, mapboxNavigation.provideFeedbackMetadataWrapper())
     }
 
     @ExperimentalPreviewMapboxNavigationAPI
     @Test(expected = IllegalStateException::class)
     fun telemetryIsDisabledTryToGetFeedbackMetadataWrapper() {
-        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
+        every { telemetryWrapper.provideFeedbackMetadataWrapper() } returns null
 
         createMapboxNavigation()
         mapboxNavigation.provideFeedbackMetadataWrapper()
     }
 
     @ExperimentalPreviewMapboxNavigationAPI
-    fun telemetryIsDisabledTryToPostFeedback() {
-        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
-
+    @Test
+    fun forwardPostUserFeedbackCallToTelemetry() {
         createMapboxNavigation()
 
-        mapboxNavigation.postUserFeedback(mockk(), mockk(), mockk(), mockk(), mockk())
-        mapboxNavigation.postUserFeedback(mockk(), mockk(), mockk(), mockk(), mockk(), mockk())
+        val feedbackSubType = emptyArray<String>()
+        val feedbackMetadata = mockk<FeedbackMetadata>()
+        val feedbackType = "test-type"
+        val description = "test-description"
+        val feedbackEvent = FeedbackEvent.REROUTE
+        val screenshot = "test-screenshot"
 
-        verify(exactly = 0) {
-            MapboxNavigationTelemetry.postUserFeedback(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
+        mapboxNavigation.postUserFeedback(
+            feedbackType,
+            description,
+            feedbackEvent,
+            screenshot,
+            feedbackSubType,
+            feedbackMetadata,
+        )
+
+        verify(exactly = 1) {
+            telemetryWrapper.postUserFeedback(
+                feedbackType,
+                description,
+                feedbackEvent,
+                screenshot,
+                feedbackSubType,
+                feedbackMetadata,
+                null,
             )
+        }
+    }
+
+    @Test
+    fun forwardPostCustomEventCallToTelemetry() {
+        createMapboxNavigation()
+
+        mapboxNavigation.postCustomEvent("", NavigationCustomEventType.ANALYTICS, "1.0")
+
+        verify(exactly = 1) {
+            telemetryWrapper.postCustomEvent("", NavigationCustomEventType.ANALYTICS, "1.0")
         }
     }
 
@@ -464,7 +498,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         createMapboxNavigation()
         mapboxNavigation.onDestroy()
 
-        verify(exactly = 1) { MapboxNavigationTelemetry.destroy(eq(mapboxNavigation)) }
+        verify(exactly = 1) { telemetryWrapper.destroy() }
     }
 
     @Test
@@ -474,7 +508,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
         verifyOrder {
             tripSession.stop()
-            MapboxNavigationTelemetry.destroy(mapboxNavigation)
+            telemetryWrapper.destroy()
         }
     }
 
@@ -952,7 +986,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             .routingTilesOptions(RoutingTilesOptions.Builder().build())
             .build()
 
-        mapboxNavigation = MapboxNavigation(options, threadController)
+        mapboxNavigation = MapboxNavigation(options, threadController, telemetryWrapper)
 
         assertTrue(slot.captured.tilesPath.endsWith(RoutingTilesFiles.TILES_PATH_SUB_DIR))
     }
@@ -973,7 +1007,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             )
             .build()
 
-        mapboxNavigation = MapboxNavigation(options, threadController)
+        mapboxNavigation = MapboxNavigation(options, threadController, telemetryWrapper)
 
         assertEquals(slot.captured.endpointConfig!!.dataset, "someUser.osm/truck")
     }
@@ -984,7 +1018,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         val slot = slot<NavigatorConfig>()
         every { NavigatorLoader.createConfig(any(), capture(slot)) } returns mockk()
 
-        mapboxNavigation = MapboxNavigation(navigationOptions)
+        createMapboxNavigation()
 
         assertNull(slot.captured.incidentsOptions)
     }
@@ -1002,7 +1036,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             )
             .build()
 
-        mapboxNavigation = MapboxNavigation(options, threadController)
+        mapboxNavigation = MapboxNavigation(options, threadController, telemetryWrapper)
 
         assertEquals(slot.captured.incidentsOptions!!.graph, "graph")
         assertEquals(slot.captured.incidentsOptions!!.apiUrl, "")
@@ -1021,7 +1055,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             )
             .build()
 
-        mapboxNavigation = MapboxNavigation(options, threadController)
+        mapboxNavigation = MapboxNavigation(options, threadController, telemetryWrapper)
 
         assertEquals(slot.captured.incidentsOptions!!.apiUrl, "apiUrl")
         assertEquals(slot.captured.incidentsOptions!!.graph, "")
@@ -1259,7 +1293,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             )
             .build()
 
-        mapboxNavigation = MapboxNavigation(options, threadController)
+        mapboxNavigation = MapboxNavigation(options, threadController, telemetryWrapper)
 
         assertEquals(tilesVersion, slot.captured.endpointConfig?.version)
         assertFalse(slot.captured.endpointConfig?.isFallback!!)
@@ -1279,7 +1313,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         )
         every { tripSession.getRouteProgress() } returns mockk()
 
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
 
         val tileConfigSlot = slot<TilesConfig>()
 
@@ -1314,7 +1348,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             } returns listOf(mockPrimaryNavigationRoute, mockAlternativeNavigationRoute)
             every { tripSession.getRouteProgress()?.currentLegProgress?.legIndex } returns index
 
-            mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+            createMapboxNavigation()
 
             val tileConfigSlot = slot<TilesConfig>()
 
@@ -1358,7 +1392,7 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             createSetRouteResult()
         }
 
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
 
         fallbackObserverSlot.captured.onFallbackVersionsFound(listOf("version"))
 
@@ -1375,7 +1409,8 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
     @Test
     fun `verify that session state callbacks are always delivered to NavigationSession`() =
         runBlocking {
-            mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+            createMapboxNavigation()
+
             every { directionsSession.initialLegIndex } returns 0
             mapboxNavigation.startTripSession()
             mapboxNavigation.onDestroy()
@@ -1393,15 +1428,15 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test(expected = IllegalStateException::class)
     fun `verify that only one instance of MapboxNavigation can be alive`() = runBlocking {
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
     }
 
     @Test
     fun `verify that MapboxNavigation instance can be recreated`() = runBlocking {
-        val firstInstance = MapboxNavigation(navigationOptions)
+        val firstInstance = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
         firstInstance.onDestroy()
-        val secondInstance = MapboxNavigation(navigationOptions)
+        val secondInstance = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
 
         assertNotNull(secondInstance)
         assertTrue(firstInstance.isDestroyed)
@@ -1411,9 +1446,9 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test(expected = IllegalStateException::class)
     fun `verify that the old instance is not accessible when a new one is created`() = runBlocking {
-        val firstInstance = MapboxNavigation(navigationOptions)
+        val firstInstance = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
         firstInstance.onDestroy()
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
         firstInstance.startTripSession()
     }
 
@@ -1424,14 +1459,14 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
             localNavigationSession
         }
 
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
         mapboxNavigation.onDestroy()
         mapboxNavigation.startTripSession()
     }
 
     @Test(expected = IllegalStateException::class)
     fun `verify that stopTripSession is not called when destroyed`() = runBlocking {
-        mapboxNavigation = MapboxNavigation(navigationOptions, threadController)
+        mapboxNavigation = MapboxNavigation(navigationOptions, threadController, telemetryWrapper)
         mapboxNavigation.onDestroy()
         mapboxNavigation.stopTripSession()
     }
@@ -1509,7 +1544,10 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
 
     @Test
     fun `provider - check if the instance was destroyed outside of the providers scope`() {
-        val instance = MapboxNavigationProvider.create(navigationOptions)
+        val instance = MapboxNavigationProvider.create(
+            navigationOptions = navigationOptions,
+            telemetryWrapper = telemetryWrapper,
+        )
 
         instance.onDestroy()
 
@@ -2111,30 +2149,6 @@ internal class MapboxNavigationTest : MapboxNavigationBaseTest() {
         val actual = mapboxNavigation.getRerouteController()
         assertTrue(actual is InternalRerouteControllerAdapter)
         assertEquals(actual, mapboxNavigation.getRerouteController())
-    }
-
-    @Test
-    fun `when telemetry is enabled custom event is posted`() = coroutineRule.runBlockingTest {
-        createMapboxNavigation()
-        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
-        every { MapboxNavigationTelemetry.postCustomEvent(any(), any(), any()) } just Runs
-        every { MapboxNavigationTelemetry.destroy(any()) } just Runs
-
-        mapboxNavigation.postCustomEvent("", NavigationCustomEventType.ANALYTICS, "1.0")
-
-        verify(exactly = 1) { MapboxNavigationTelemetry.postCustomEvent(any(), any(), any()) }
-    }
-
-    @Test
-    fun `when telemetry is disabled custom event is not posted`() = coroutineRule.runBlockingTest {
-        createMapboxNavigation()
-        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
-        every { MapboxNavigationTelemetry.postCustomEvent(any(), any(), any()) } just Runs
-        every { MapboxNavigationTelemetry.destroy(any()) } just Runs
-
-        mapboxNavigation.postCustomEvent("", NavigationCustomEventType.ANALYTICS, "1.0")
-
-        verify(exactly = 0) { MapboxNavigationTelemetry.postCustomEvent(any(), any(), any()) }
     }
 
     @Test

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryWrapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryWrapperTest.kt
@@ -78,12 +78,7 @@ class TelemetryWrapperTest {
             every { registerObserver(capture(telemetryStateObserver)) } returns Unit
         }
 
-        telemetryWrapper = TelemetryWrapper(
-            mapboxNavigation,
-            navigationOptions,
-            userAgent,
-            telemetryStateWatcher
-        )
+        telemetryWrapper = TelemetryWrapper(telemetryStateWatcher)
     }
 
     @After
@@ -312,5 +307,13 @@ class TelemetryWrapperTest {
                 any()
             )
         }
+    }
+
+    private fun TelemetryWrapper.initialize() {
+        telemetryWrapper.initialize(
+            mapboxNavigation,
+            navigationOptions,
+            userAgent,
+        )
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryWrapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryWrapperTest.kt
@@ -1,8 +1,15 @@
+@file:OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+
 package com.mapbox.navigation.core.telemetry
 
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.BuildConfig
 import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.internal.telemetry.NavigationCustomEventType
+import com.mapbox.navigation.core.internal.telemetry.UserFeedbackCallback
+import com.mapbox.navigation.core.telemetry.events.FeedbackEvent
+import com.mapbox.navigation.core.telemetry.events.FeedbackMetadata
 import com.mapbox.navigation.metrics.MapboxMetricsReporter
 import com.mapbox.navigation.metrics.internal.EventsServiceProvider
 import com.mapbox.navigation.metrics.internal.TelemetryServiceProvider
@@ -19,6 +26,8 @@ import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
@@ -45,6 +54,7 @@ class TelemetryWrapperTest {
         every {
             TelemetryServiceProvider.provideTelemetryService(any())
         } returns mockk(relaxUnitFun = true)
+
         mockkObject(MapboxNavigationTelemetry)
         every { MapboxNavigationTelemetry.initialize(any(), any(), any(), any()) } just runs
         every { MapboxNavigationTelemetry.destroy(any()) } just runs
@@ -59,6 +69,17 @@ class TelemetryWrapperTest {
                 any(),
             )
         } just runs
+        every {
+            MapboxNavigationTelemetry.postCustomEvent(
+                any(),
+                any(),
+                any(),
+            )
+        } just runs
+        every {
+            MapboxNavigationTelemetry.provideFeedbackMetadataWrapper()
+        } returns mockk(relaxed = true)
+
         mockkObject(TelemetryUtilsDelegate)
         every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
         mockkObject(MapboxMetricsReporter)
@@ -68,6 +89,7 @@ class TelemetryWrapperTest {
         mapboxNavigation = mockk(relaxed = true)
         navigationOptions = mockk<NavigationOptions>(relaxed = true).apply {
             every { accessToken } returns testAccessToken
+            every { applicationContext } returns mockk(relaxed = true)
         }
 
         telemetryWrapper = TelemetryWrapper()
@@ -82,7 +104,7 @@ class TelemetryWrapperTest {
     }
 
     @Test
-    fun `throws exception when initialize is called again`() {
+    fun `throws exception in debug when initialize is called again`() {
         if (BuildConfig.DEBUG) {
             assertThrows(
                 "Already initialized",
@@ -95,7 +117,7 @@ class TelemetryWrapperTest {
     }
 
     @Test
-    fun `throws exception when destroy is called again`() {
+    fun `throws exception in debug when destroy is called again`() {
         if (BuildConfig.DEBUG) {
             assertThrows(
                 "Initialize object first",
@@ -109,7 +131,7 @@ class TelemetryWrapperTest {
     }
 
     @Test
-    fun `throws exception when destroy is called without initialization`() {
+    fun `throws exception in debug when destroy is called without initialization`() {
         if (BuildConfig.DEBUG) {
             assertThrows(
                 "Initialize object first",
@@ -153,6 +175,115 @@ class TelemetryWrapperTest {
     }
 
     @Test
+    fun `posts custom event when telemetry is enabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
+        telemetryWrapper.initialize()
+        telemetryWrapper.postCustomEvent(PAYLOAD, CUSTOM_EVENT_TYPE, CUSTOM_EVENT_VERSION)
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.postCustomEvent(
+                PAYLOAD,
+                CUSTOM_EVENT_TYPE,
+                CUSTOM_EVENT_VERSION,
+            )
+        }
+    }
+
+    @Test
+    fun `doesn't post custom event when telemetry is disabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
+        telemetryWrapper.initialize()
+        telemetryWrapper.postCustomEvent(PAYLOAD, CUSTOM_EVENT_TYPE, CUSTOM_EVENT_VERSION)
+
+        verify(exactly = 0) {
+            MapboxNavigationTelemetry.postCustomEvent(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `provides feedback metadata when telemetry is enabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
+        telemetryWrapper.initialize()
+
+        assertNotNull(telemetryWrapper.provideFeedbackMetadataWrapper())
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.provideFeedbackMetadataWrapper()
+        }
+    }
+
+    @Test
+    fun `doesn't provide feedback metadata when telemetry is disabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
+        telemetryWrapper.initialize()
+
+        assertNull(telemetryWrapper.provideFeedbackMetadataWrapper())
+
+        verify(exactly = 0) {
+            MapboxNavigationTelemetry.provideFeedbackMetadataWrapper()
+        }
+    }
+
+    @Test
+    fun `posts user feedback when telemetry is enabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
+        telemetryWrapper.initialize()
+
+        val feedbackMetadata = mockk<FeedbackMetadata>(relaxed = true)
+        val userFeedbackCallback = mockk<UserFeedbackCallback>(relaxed = true)
+
+        telemetryWrapper.postUserFeedback(
+            FEEDBACK_TYPE,
+            DESCRIPTION,
+            FEEDBACK_SOURCE,
+            SCREENSHOT,
+            FEEDBACK_SUB_TYPE,
+            feedbackMetadata,
+            userFeedbackCallback
+        )
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.postUserFeedback(
+                FEEDBACK_TYPE,
+                DESCRIPTION,
+                FEEDBACK_SOURCE,
+                SCREENSHOT,
+                FEEDBACK_SUB_TYPE,
+                feedbackMetadata,
+                userFeedbackCallback
+            )
+        }
+    }
+
+    @Test
+    fun `doesn't post user feedback when telemetry is disabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
+        telemetryWrapper.initialize()
+
+        telemetryWrapper.postUserFeedback(
+            FEEDBACK_TYPE,
+            DESCRIPTION,
+            FEEDBACK_SOURCE,
+            SCREENSHOT,
+            FEEDBACK_SUB_TYPE,
+            mockk<FeedbackMetadata>(relaxed = true),
+            mockk<UserFeedbackCallback>(relaxed = true)
+        )
+
+        verify(exactly = 0) {
+            MapboxNavigationTelemetry.postUserFeedback(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        }
+    }
+
+    @Test
     fun `destroys MapboxNavigationTelemetry on destroy if MapboxNavigationTelemetry was initialized`() {
         every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
 
@@ -186,5 +317,16 @@ class TelemetryWrapperTest {
             navigationOptions,
             userAgent,
         )
+    }
+
+    private companion object {
+        const val PAYLOAD = "test-payload"
+        const val CUSTOM_EVENT_TYPE = NavigationCustomEventType.ANALYTICS
+        const val CUSTOM_EVENT_VERSION = "test-version"
+        const val FEEDBACK_TYPE = "test-feedback-type"
+        const val DESCRIPTION = "test-description"
+        const val FEEDBACK_SOURCE = FeedbackEvent.REROUTE
+        const val SCREENSHOT = "test-screenshot"
+        val FEEDBACK_SUB_TYPE = arrayOf("test-type")
     }
 }

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryWrapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryWrapperTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.navigation.core.telemetry
 
 import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.BuildConfig
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.metrics.MapboxMetricsReporter
 import com.mapbox.navigation.metrics.internal.EventsServiceProvider
@@ -91,24 +92,28 @@ class TelemetryWrapperTest {
 
     @Test
     fun `throws exception when initialize is called again`() {
-        assertThrows(
-            "Already initialized",
-            IllegalStateException::class.java
-        ) {
-            telemetryWrapper.initialize()
-            telemetryWrapper.initialize()
+        if (BuildConfig.DEBUG) {
+            assertThrows(
+                "Already initialized",
+                IllegalStateException::class.java
+            ) {
+                telemetryWrapper.initialize()
+                telemetryWrapper.initialize()
+            }
         }
     }
 
     @Test
     fun `throws exception when destroy is called again`() {
-        assertThrows(
-            "Initialize object first",
-            IllegalStateException::class.java
-        ) {
-            telemetryWrapper.initialize()
-            telemetryWrapper.destroy()
-            telemetryWrapper.destroy()
+        if (BuildConfig.DEBUG) {
+            assertThrows(
+                "Initialize object first",
+                IllegalStateException::class.java
+            ) {
+                telemetryWrapper.initialize()
+                telemetryWrapper.destroy()
+                telemetryWrapper.destroy()
+            }
         }
     }
 

--- a/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryWrapperTest.kt
+++ b/libnavigation-core/src/test/java/com/mapbox/navigation/core/telemetry/TelemetryWrapperTest.kt
@@ -1,0 +1,316 @@
+package com.mapbox.navigation.core.telemetry
+
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.metrics.MapboxMetricsReporter
+import com.mapbox.navigation.metrics.internal.EventsServiceProvider
+import com.mapbox.navigation.metrics.internal.TelemetryServiceProvider
+import com.mapbox.navigation.metrics.internal.TelemetryUtilsDelegate
+import com.mapbox.navigation.utils.internal.logD
+import io.mockk.CapturingSlot
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TelemetryWrapperTest {
+
+    private val testAccessToken = "test-access-token"
+    private val userAgent: String = "test-user-agent"
+    private lateinit var mapboxNavigation: MapboxNavigation
+    private lateinit var navigationOptions: NavigationOptions
+    private lateinit var telemetryStateWatcher: TelemetryStateWatcher
+    private lateinit var telemetryStateObserver: CapturingSlot<TelemetryStateWatcher.Observer>
+
+    private lateinit var telemetryWrapper: TelemetryWrapper
+
+    @Before
+    fun setUp() {
+        mockkObject(EventsServiceProvider)
+        every {
+            EventsServiceProvider.provideEventsService(any())
+        } returns mockk(relaxUnitFun = true)
+        mockkObject(TelemetryServiceProvider)
+        every {
+            TelemetryServiceProvider.provideTelemetryService(any())
+        } returns mockk(relaxUnitFun = true)
+        mockkObject(MapboxNavigationTelemetry)
+        every { MapboxNavigationTelemetry.initialize(any(), any(), any(), any()) } just runs
+        every { MapboxNavigationTelemetry.destroy(any()) } just runs
+        every {
+            MapboxNavigationTelemetry.postUserFeedback(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } just runs
+        mockkObject(TelemetryUtilsDelegate)
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
+        mockkObject(MapboxMetricsReporter)
+        mockkStatic("com.mapbox.navigation.utils.internal.LoggerProviderKt")
+        every { logD(msg = any(), category = any()) } just Runs
+
+        mapboxNavigation = mockk(relaxed = true)
+        navigationOptions = mockk<NavigationOptions>(relaxed = true).apply {
+            every { accessToken } returns testAccessToken
+        }
+
+        telemetryStateObserver = slot<TelemetryStateWatcher.Observer>()
+        telemetryStateWatcher = mockk<TelemetryStateWatcher>(relaxed = true).apply {
+            every { registerObserver(capture(telemetryStateObserver)) } returns Unit
+        }
+
+        telemetryWrapper = TelemetryWrapper(
+            mapboxNavigation,
+            navigationOptions,
+            userAgent,
+            telemetryStateWatcher
+        )
+    }
+
+    @After
+    fun tearDown() {
+        unmockkObject(MapboxNavigationTelemetry)
+        unmockkObject(TelemetryUtilsDelegate)
+        unmockkObject(MapboxMetricsReporter)
+        unmockkStatic("com.mapbox.navigation.utils.internal.LoggerProviderKt")
+    }
+
+    @Test
+    fun `throws exception when initialize is called again`() {
+        assertThrows(
+            "Already initialized",
+            IllegalStateException::class.java
+        ) {
+            telemetryWrapper.initialize()
+            telemetryWrapper.initialize()
+        }
+    }
+
+    @Test
+    fun `throws exception when destroy is called again`() {
+        assertThrows(
+            "Initialize object first",
+            IllegalStateException::class.java
+        ) {
+            telemetryWrapper.initialize()
+            telemetryWrapper.destroy()
+            telemetryWrapper.destroy()
+        }
+    }
+
+    @Test
+    fun `throws exception when destroy is called without initialization`() {
+        assertThrows(
+            "Initialize object first",
+            IllegalStateException::class.java
+        ) {
+            telemetryWrapper.destroy()
+        }
+    }
+
+    @Test
+    fun `initializes MapboxNavigationTelemetry on initialization when telemetry is enabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
+
+        telemetryWrapper.initialize()
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.initialize(
+                mapboxNavigation,
+                navigationOptions,
+                MapboxMetricsReporter,
+                any()
+            )
+        }
+
+        verify(exactly = 1) {
+            telemetryStateWatcher.registerObserver(any())
+        }
+    }
+
+    @Test
+    fun `doesn't initialize MapboxNavigationTelemetry on initialization when telemetry is disabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
+
+        telemetryWrapper.initialize()
+
+        verify(exactly = 0) {
+            MapboxNavigationTelemetry.initialize(
+                mapboxNavigation,
+                navigationOptions,
+                MapboxMetricsReporter,
+                any()
+            )
+        }
+
+        verify(exactly = 1) {
+            telemetryStateWatcher.registerObserver(any())
+        }
+    }
+
+    @Test
+    fun `destroys MapboxNavigationTelemetry on destroy if MapboxNavigationTelemetry was initialized`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
+
+        telemetryWrapper.initialize()
+        telemetryWrapper.destroy()
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.destroy(
+                mapboxNavigation
+            )
+        }
+
+        verify(exactly = 1) {
+            telemetryStateWatcher.unregisterObserver(any())
+        }
+    }
+
+    @Test
+    fun `doesn't destroy MapboxNavigationTelemetry on destroy if MapboxNavigationTelemetry was not initialized`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
+
+        telemetryWrapper.initialize()
+        telemetryWrapper.destroy()
+
+        verify(exactly = 0) {
+            MapboxNavigationTelemetry.destroy(
+                mapboxNavigation
+            )
+        }
+
+        verify(exactly = 1) {
+            telemetryStateWatcher.unregisterObserver(any())
+        }
+    }
+
+    @Test
+    fun `initializes MapboxNavigationTelemetry when telemetry becomes enabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
+
+        telemetryWrapper.initialize()
+        telemetryStateObserver.captured.onStateChanged(true)
+        telemetryWrapper.destroy()
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.initialize(
+                mapboxNavigation,
+                navigationOptions,
+                MapboxMetricsReporter,
+                any()
+            )
+        }
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.destroy(
+                mapboxNavigation
+            )
+        }
+    }
+
+    @Test
+    fun `destroys MapboxNavigationTelemetry when telemetry becomes disabled`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
+
+        telemetryWrapper.initialize()
+        telemetryStateObserver.captured.onStateChanged(false)
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.initialize(
+                mapboxNavigation,
+                navigationOptions,
+                MapboxMetricsReporter,
+                any()
+            )
+        }
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.destroy(
+                mapboxNavigation
+            )
+        }
+    }
+
+    @Test
+    fun `initializes and destroys MapboxNavigationTelemetry when telemetry changes its state twice`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
+
+        telemetryWrapper.initialize()
+
+        telemetryStateObserver.captured.onStateChanged(false)
+        telemetryStateObserver.captured.onStateChanged(true)
+        telemetryStateObserver.captured.onStateChanged(false)
+
+        verify(exactly = 2) {
+            MapboxNavigationTelemetry.initialize(
+                mapboxNavigation,
+                navigationOptions,
+                MapboxMetricsReporter,
+                any()
+            )
+        }
+
+        verify(exactly = 2) {
+            MapboxNavigationTelemetry.destroy(
+                mapboxNavigation
+            )
+        }
+    }
+
+    @Test
+    fun `does nothing when telemetry state is disabled and doesn't change`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns false
+
+        telemetryWrapper.initialize()
+        telemetryStateObserver.captured.onStateChanged(false)
+        telemetryStateObserver.captured.onStateChanged(false)
+        telemetryStateObserver.captured.onStateChanged(false)
+
+        verify(exactly = 0) {
+            MapboxNavigationTelemetry.initialize(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun `does nothing when telemetry state is enabled and doesn't change`() {
+        every { TelemetryUtilsDelegate.getEventsCollectionState() } returns true
+
+        telemetryWrapper.initialize()
+        telemetryStateObserver.captured.onStateChanged(true)
+        telemetryStateObserver.captured.onStateChanged(true)
+        telemetryStateObserver.captured.onStateChanged(true)
+
+        verify(exactly = 1) {
+            MapboxNavigationTelemetry.initialize(
+                mapboxNavigation,
+                navigationOptions,
+                MapboxMetricsReporter,
+                any()
+            )
+        }
+    }
+}

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/Assertions.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/Assertions.kt
@@ -1,0 +1,13 @@
+package com.mapbox.navigation.utils.internal
+
+import com.mapbox.navigation.utils.BuildConfig
+
+inline fun assertDebug(value: Boolean, message: () -> Any) {
+    if (BuildConfig.DEBUG) {
+        check(value, message)
+    }
+
+    if (!value) {
+        logD { message().toString() }
+    }
+}

--- a/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/Assertions.kt
+++ b/libnavigation-util/src/main/java/com/mapbox/navigation/utils/internal/Assertions.kt
@@ -8,6 +8,6 @@ inline fun assertDebug(value: Boolean, message: () -> Any) {
     }
 
     if (!value) {
-        logD { message().toString() }
+        logW { message().toString() }
     }
 }


### PR DESCRIPTION
### Description
https://mapbox.atlassian.net/browse/NAVAND-1795

Fixed a crash that can happen when user dynamically changes telemetry collection preferences.

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
