### PR TITLE
Remove unavailable device from tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,7 +551,6 @@ commands:
             gcloud firebase test android run --type instrumentation \
               --app << parameters.module_wrapper >>/build/outputs/apk/<< parameters.variant >>/<< parameters.module_wrapper >>-<< parameters.variant >>.apk \
               --test << parameters.module_target >>/build/outputs/apk/androidTest/<< parameters.variant >>/<< parameters.module_target >>-<< parameters.variant >>-androidTest.apk \
-              --device model=hammerhead,version=23,locale=fr,orientation=portrait \
               --device model=q2q,version=31,locale=de,orientation=landscape \
               --device model=panther,version=33,locale=it,orientation=landscape \
               --use-orchestrator \
@@ -574,7 +573,6 @@ commands:
               --app instrumentation-tests/build/outputs/apk/<< parameters.variant >>/instrumentation-tests-<< parameters.variant >>.apk \
               --test instrumentation-tests/build/outputs/apk/androidTest/<< parameters.variant >>/instrumentation-tests-<< parameters.variant >>-androidTest.apk \
               --test-targets "class com.mapbox.navigation.instrumentation_tests.<< parameters.suite >>" \
-              --device model=hammerhead,version=23,locale=fr,orientation=portrait \
               --device model=q2q,version=31,locale=de,orientation=landscape \
               --device model=panther,version=33,locale=it,orientation=landscape \
               --use-orchestrator \
@@ -597,7 +595,6 @@ commands:
             gcloud firebase test android run --type robo \
               --app << parameters.module_target >>/build/outputs/apk/<< parameters.variant >>/<< parameters.module_target >>-<< parameters.variant >>.apk \
               --device model=hwALE-H,version=21,locale=es,orientation=portrait  \
-              --device model=hammerhead,version=23,locale=fr,orientation=portrait \
               --device model=q2q,version=31,locale=de,orientation=landscape \
               --device model=panther,version=33,locale=it,orientation=landscape \
               --timeout 5m


### PR DESCRIPTION
### Description
`hammerhead`  has been deprecated and not available anymore https://firebase.google.com/docs/test-lab/android/available-testing-devices#deprecated_devices

<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
