### PR TITLE
Fix for LRU cache inconsistency crash

### DIFF
--- a/app-mincompile/src/main/java/com/mapbox/navigation/examples/mincompile/DropInUIActivity.kt
+++ b/app-mincompile/src/main/java/com/mapbox/navigation/examples/mincompile/DropInUIActivity.kt
@@ -3,8 +3,6 @@ package com.mapbox.navigation.examples.mincompile
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.mapbox.navigation.examples.mincompile.databinding.LayoutActivityDropinBinding
-import com.mapbox.navigation.examples.mincompile.databinding.LayoutActivityMainBinding
-import com.mapbox.navigation.examples.mincompile.databinding.LayoutActivityNavigationBinding
 
 class DropInUIActivity : AppCompatActivity() {
     private lateinit var binding: LayoutActivityDropinBinding

--- a/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/route/RouteCompatibilityCacheTest.kt
+++ b/libnavigation-base/src/test/java/com/mapbox/navigation/base/internal/route/RouteCompatibilityCacheTest.kt
@@ -98,4 +98,27 @@ class RouteCompatibilityCacheTest {
         assertEquals(navigationRoute1, RouteCompatibilityCache.getFor(directionsRouteMock1))
         assertEquals(navigationRoute2, RouteCompatibilityCache.getFor(directionsRouteMock2))
     }
+
+    @Test
+    fun `cache size does not exceed maximum`() {
+        val route1 = mockk<NavigationRoute> {
+            every { directionsRoute } returns mockk()
+        }
+        val route2 = mockk<NavigationRoute> {
+            every { directionsRoute } returns mockk()
+        }
+        val route3 = mockk<NavigationRoute> {
+            every { directionsRoute } returns mockk()
+        }
+        val route4 = mockk<NavigationRoute> {
+            every { directionsRoute } returns mockk()
+        }
+
+        RouteCompatibilityCache.setDirectionsSessionResult(listOf(route1, route2, route3, route4))
+
+        assertNull(RouteCompatibilityCache.getFor(route1.directionsRoute))
+        assertEquals(route2, RouteCompatibilityCache.getFor(route2.directionsRoute))
+        assertEquals(route3, RouteCompatibilityCache.getFor(route3.directionsRoute))
+        assertEquals(route4, RouteCompatibilityCache.getFor(route4.directionsRoute))
+    }
 }


### PR DESCRIPTION
### Description

In response to: https://mapbox.atlassian.net/browse/NAVAND-3208

Put call to cache route data on it's own thread so the synchronize blocks in the caching class will be effective. The caching call is in a method that is being called from a coroutine.

### Screenshots or Gifs


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
