### PR TITLE
[NAVAND-5692] ManeuverViewBinder: get rid of `TransitionManager#go`

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@ Mapbox Navigation for Android version 2.0
 
 Mapbox Navigation Android SDK
 
-Copyright ©2022 - 2024 Mapbox, Inc. All rights reserved.
+Copyright ©2022 - 2025 Mapbox, Inc. All rights reserved.
 
 The software and files in this repository (collectively, "Software") are licensed under the Mapbox TOS for use only with the relevant Mapbox product(s) listed at www.mapbox.com/pricing. This license allows developers with a current active Mapbox account to use and modify the authorized portions of the Software as needed for use only with the relevant Mapbox product(s) through their Mapbox account in accordance with the Mapbox TOS.  This license terminates automatically if a developer no longer has a Mapbox account in good standing or breaches the Mapbox TOS. For the license terms, please see the Mapbox TOS at https://www.mapbox.com/legal/tos/ which incorporates the Mapbox Product Terms at www.mapbox.com/legal/service-terms.  If this Software is a SDK, modifications that change or interfere with marked portions of the code related to billing, accounting, or data collection are not authorized and the SDK sends limited de-identified location and usage data which is used in accordance with the Mapbox TOS. [Updated 2023-04]
 

--- a/changelog/unreleased/bugfixes/7908.md
+++ b/changelog/unreleased/bugfixes/7908.md
@@ -1,0 +1,1 @@
+- Fixed crash on `ManeuverViewBinder` with TransitionManager#go(Scene).

--- a/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/maneuver/ManeuverViewBinder.kt
+++ b/libnavui-dropin/src/main/java/com/mapbox/navigation/dropin/maneuver/ManeuverViewBinder.kt
@@ -1,10 +1,8 @@
 package com.mapbox.navigation.dropin.maneuver
 
-import android.transition.Scene
-import android.transition.TransitionManager
+import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
-import com.mapbox.navigation.dropin.R
 import com.mapbox.navigation.dropin.databinding.MapboxManeuverGuidanceLayoutBinding
 import com.mapbox.navigation.dropin.internal.extensions.reloadOnChange
 import com.mapbox.navigation.dropin.navigationview.NavigationViewContext
@@ -18,13 +16,11 @@ internal class ManeuverViewBinder(
 ) : UIBinder {
 
     override fun bind(viewGroup: ViewGroup): MapboxNavigationObserver {
-        val scene = Scene.getSceneForLayout(
-            viewGroup,
-            R.layout.mapbox_maneuver_guidance_layout,
-            viewGroup.context
+        viewGroup.removeAllViews()
+        val binding = MapboxManeuverGuidanceLayoutBinding.inflate(
+            LayoutInflater.from(viewGroup.context),
+            viewGroup
         )
-        TransitionManager.go(scene)
-        val binding = MapboxManeuverGuidanceLayoutBinding.bind(viewGroup)
 
         return reloadOnChange(
             context.mapStyleLoader.loadedMapStyle,


### PR DESCRIPTION
### Description

https://mapbox.atlassian.net/browse/NAVAND-5692

<!--
Include issue references (e.g., fixes [#issue](link))
Include necessary implementation details (e.g. I opted to use this algorithm because ... and test it in this way ...).
-->

### Screenshots or Gifs
<!-- Include media files to provide additional context. It's REALLY useful for UI related PRs (e.g. ![screenshot gif](link)) -->


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
