### PR TITLE
add a blurp about where to find the examples repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 Refer to the [full documentation pages](https://docs.mapbox.com/android/navigation/) for 
 [installation](https://docs.mapbox.com/android/navigation/guides/installation/) and usage instructions.
 
+Check out the example repo at https://github.com/mapbox/mapbox-navigation-android-examples for a collection of examples with complete source code.
+
 For the latest version and changelog visit [CHANGELOG](./CHANGELOG.md).
 
 Along with the full documentation, [this migration guide](https://docs.mapbox.com/android/navigation/guides/migration-from-v2/) can help you transition your project from version `v2` of the Navigation SDK to `v3` or higher.
+
+
 
 ## Getting Help
 


### PR DESCRIPTION
### Summary

Add a sentence in the README about where to find the examples repo. 

Context: there was some questions about where to find the example repo, and people often being redirected here. This addition will direct people to the right repo, our examples in documentation is also pointing to the same example repo. https://github.com/mapbox/mapbox-navigation-android-examples 


