### PR TITLE
NAVAND-7348: Fix ampersands not being encoded in API URL

### DIFF
--- a/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/UrlUtils.kt
+++ b/libnavui-voice/src/main/java/com/mapbox/navigation/ui/voice/api/UrlUtils.kt
@@ -18,7 +18,10 @@ internal object UrlUtils {
 
     private val HEX_DIGITS =
         charArrayOf('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
-    private const val PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#"
+    // '&' is technically valid in a path segment per RFC 3986, but leaving it unencoded risks
+    // misparse by servers or proxies that don't fully respect the path/query boundary, and breaks
+    // XML entities in SSML (e.g. &amp; must arrive at the server as %26amp; then decode to &amp;).
+    private const val PATH_SEGMENT_ENCODE_SET = " \"<>^`{}|/\\?#&"
     private const val FORM_ENCODE_SET = " !\"#$&'()+,/:;<=>?@[\\]^`{|}~"
 
     fun encodePathSegment(pathSegment: String): String =

--- a/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/UrlUtilsTest.kt
+++ b/libnavui-voice/src/test/java/com/mapbox/navigation/ui/voice/api/UrlUtilsTest.kt
@@ -1,0 +1,33 @@
+package com.mapbox.navigation.ui.voice.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UrlUtilsTest {
+
+    @Test
+    fun `ampersand in plain text is percent encoded`() {
+        val encoded = UrlUtils.encodePathSegment("Barnes & Noble")
+        assertTrue("& must be percent-encoded as %26", encoded.contains("%26"))
+        assertFalse("raw & must not appear in path segment", encoded.contains("&"))
+    }
+
+    @Test
+    fun `slash in text is percent encoded`() {
+        val encoded = UrlUtils.encodePathSegment("Take US-101/I-5")
+        assertTrue("/ must be percent-encoded as %2F", encoded.contains("%2F"))
+        assertFalse(encoded.contains("/"))
+    }
+
+    @Test
+    fun `space is percent encoded`() {
+        assertEquals("Turn%20left", UrlUtils.encodePathSegment("Turn left"))
+    }
+
+    @Test
+    fun `plain ascii without reserved characters is unchanged`() {
+        assertEquals("voice", UrlUtils.encodePathSegment("voice"))
+    }
+}


### PR DESCRIPTION
### Description
https://mapbox.atlassian.net/browse/NAVAND-7348

Speech API related requests were failing due to unexpected characters being sent by the client SDKs. In particular, the client sends “&” as a literal character in the URL path. This impacts turn-by-turn voice instructions.