### PR TITLE
Increase publish-documentation resource class to prevent internal memory failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -982,7 +982,7 @@ jobs:
 
   publish-documentation:
     executor: ndk-r22-latest-executor
-    resource_class: medium+
+    resource_class: xlarge
     steps:
       - checkout
       - prepare-mbx-ci


### PR DESCRIPTION
### Description
This PR is increasing the resource class of CircleCi job `publish-documentation` from `medium+` to `xlarge` to prevent internal memory failure. This is to address failures happening on our V2 release pipeline like [this one](https://app.circleci.com/pipelines/github/mapbox/mapbox-navigation-android/29220/workflows/b9acae44-a3bd-4521-b3c3-802aa2859caf/jobs/173332).


<!--
---------- CHECKLIST ----------
1. Add related labels (`bug`, `feature`, `new API(s)`, `SEMVER-MAJOR`, `needs-backporting`, etc.).
1. Adda a changelog entry under `Unreleased` tag or a `skip changelog` label if not applicable.
1. Update progress status on the project board.
1. Request a review from the team, if not a draft.
1. Add targeted milestone, when applicable.
1. Create ticket tracking addition of public documentation pages entry, when applicable.
-->
